### PR TITLE
[wip] keylines and shadows

### DIFF
--- a/src/base-core.css
+++ b/src/base-core.css
@@ -39,205 +39,214 @@
 .round-full-bottomright { border-bottom-right-radius: 50%; }
 .round-full-bottomleft  { border-bottom-left-radius: 50%; }
 
-.keyline-all,
-.keyline-all-dark     { border: 1px solid #404040; }
-.keyline-all-gray     { border: 1px solid #eee; }
-.keyline-all-light    { border: 1px solid #f8f8f8; }
-.keyline-all-white    { border: 1px solid #fff; }
-.keyline-all-cyan     { border: 1px solid #3bb2d0; }
-.keyline-all-blue     { border: 1px solid #3887be; }
-.keyline-all-darkblue { border: 1px solid #223b53; }
-.keyline-all-denim    { border: 1px solid #50667f; }
-.keyline-all-navy     { border: 1px solid #28353d; }
-.keyline-all-darknavy { border: 1px solid #222b30; }
-.keyline-all-purple   { border: 1px solid #8a8acb; }
-.keyline-all-teal     { border: 1px solid #41afa5; }
-.keyline-all-green    { border: 1px solid #56b881; }
-.keyline-all-yellow   { border: 1px solid #f1f075; }
-.keyline-all-mustard  { border: 1px solid #fbb03b; }
-.keyline-all-orange   { border: 1px solid #f9886c; }
-.keyline-all-red      { border: 1px solid #e55e5e; }
-.keyline-all-pink     { border: 1px solid #ed6498; }
+.bor-all,
+.bor-all-dark     { border: 1px solid #404040; }
+.bor-all-gray     { border: 1px solid #eee; }
+.bor-all-light    { border: 1px solid #f8f8f8; }
+.bor-all-white    { border: 1px solid #fff; }
+.bor-all-cyan     { border: 1px solid #3bb2d0; }
+.bor-all-blue     { border: 1px solid #3887be; }
+.bor-all-darkblue { border: 1px solid #223b53; }
+.bor-all-denim    { border: 1px solid #50667f; }
+.bor-all-navy     { border: 1px solid #28353d; }
+.bor-all-darknavy { border: 1px solid #222b30; }
+.bor-all-purple   { border: 1px solid #8a8acb; }
+.bor-all-teal     { border: 1px solid #41afa5; }
+.bor-all-green    { border: 1px solid #56b881; }
+.bor-all-yellow   { border: 1px solid #f1f075; }
+.bor-all-mustard  { border: 1px solid #fbb03b; }
+.bor-all-orange   { border: 1px solid #f9886c; }
+.bor-all-red      { border: 1px solid #e55e5e; }
+.bor-all-pink     { border: 1px solid #ed6498; }
 
-.keyline-top,
-.keyline-top-dark     { border-top: 1px solid #404040; }
-.keyline-top-gray     { border-top: 1px solid #eee; }
-.keyline-top-light    { border-top: 1px solid #f8f8f8; }
-.keyline-top-white    { border-top: 1px solid #fff; }
-.keyline-top-cyan     { border-top: 1px solid #3bb2d0; }
-.keyline-top-blue     { border-top: 1px solid #3887be; }
-.keyline-top-darkblue { border-top: 1px solid #223b53; }
-.keyline-top-denim    { border-top: 1px solid #50667f; }
-.keyline-top-navy     { border-top: 1px solid #28353d; }
-.keyline-top-darknavy { border-top: 1px solid #222b30; }
-.keyline-top-purple   { border-top: 1px solid #8a8acb; }
-.keyline-top-teal     { border-top: 1px solid #41afa5; }
-.keyline-top-green    { border-top: 1px solid #56b881; }
-.keyline-top-yellow   { border-top: 1px solid #f1f075; }
-.keyline-top-mustard  { border-top: 1px solid #fbb03b; }
-.keyline-top-orange   { border-top: 1px solid #f9886c; }
-.keyline-top-red      { border-top: 1px solid #e55e5e; }
-.keyline-top-pink     { border-top: 1px solid #ed6498; }
+.bor-top,
+.bor-top-dark     { border-top: 1px solid #404040; }
+.bor-top-gray     { border-top: 1px solid #eee; }
+.bor-top-light    { border-top: 1px solid #f8f8f8; }
+.bor-top-white    { border-top: 1px solid #fff; }
+.bor-top-cyan     { border-top: 1px solid #3bb2d0; }
+.bor-top-blue     { border-top: 1px solid #3887be; }
+.bor-top-darkblue { border-top: 1px solid #223b53; }
+.bor-top-denim    { border-top: 1px solid #50667f; }
+.bor-top-navy     { border-top: 1px solid #28353d; }
+.bor-top-darknavy { border-top: 1px solid #222b30; }
+.bor-top-purple   { border-top: 1px solid #8a8acb; }
+.bor-top-teal     { border-top: 1px solid #41afa5; }
+.bor-top-green    { border-top: 1px solid #56b881; }
+.bor-top-yellow   { border-top: 1px solid #f1f075; }
+.bor-top-mustard  { border-top: 1px solid #fbb03b; }
+.bor-top-orange   { border-top: 1px solid #f9886c; }
+.bor-top-red      { border-top: 1px solid #e55e5e; }
+.bor-top-pink     { border-top: 1px solid #ed6498; }
 
-.keyline-right,
-.keyline-right-dark     { border-right: 1px solid #404040; }
-.keyline-right-gray     { border-right: 1px solid #eee; }
-.keyline-right-light    { border-right: 1px solid #f8f8f8; }
-.keyline-right-white    { border-right: 1px solid #fff; }
-.keyline-right-cyan     { border-right: 1px solid #3bb2d0; }
-.keyline-right-blue     { border-right: 1px solid #3887be; }
-.keyline-right-darkblue { border-right: 1px solid #223b53; }
-.keyline-right-denim    { border-right: 1px solid #50667f; }
-.keyline-right-navy     { border-right: 1px solid #28353d; }
-.keyline-right-darknavy { border-right: 1px solid #222b30; }
-.keyline-right-purple   { border-right: 1px solid #8a8acb; }
-.keyline-right-teal     { border-right: 1px solid #41afa5; }
-.keyline-right-green    { border-right: 1px solid #56b881; }
-.keyline-right-yellow   { border-right: 1px solid #f1f075; }
-.keyline-right-mustard  { border-right: 1px solid #fbb03b; }
-.keyline-right-orange   { border-right: 1px solid #f9886c; }
-.keyline-right-red      { border-right: 1px solid #e55e5e; }
-.keyline-right-pink     { border-right: 1px solid #ed6498; }
+.bor-right,
+.bor-right-dark     { border-right: 1px solid #404040; }
+.bor-right-gray     { border-right: 1px solid #eee; }
+.bor-right-light    { border-right: 1px solid #f8f8f8; }
+.bor-right-white    { border-right: 1px solid #fff; }
+.bor-right-cyan     { border-right: 1px solid #3bb2d0; }
+.bor-right-blue     { border-right: 1px solid #3887be; }
+.bor-right-darkblue { border-right: 1px solid #223b53; }
+.bor-right-denim    { border-right: 1px solid #50667f; }
+.bor-right-navy     { border-right: 1px solid #28353d; }
+.bor-right-darknavy { border-right: 1px solid #222b30; }
+.bor-right-purple   { border-right: 1px solid #8a8acb; }
+.bor-right-teal     { border-right: 1px solid #41afa5; }
+.bor-right-green    { border-right: 1px solid #56b881; }
+.bor-right-yellow   { border-right: 1px solid #f1f075; }
+.bor-right-mustard  { border-right: 1px solid #fbb03b; }
+.bor-right-orange   { border-right: 1px solid #f9886c; }
+.bor-right-red      { border-right: 1px solid #e55e5e; }
+.bor-right-pink     { border-right: 1px solid #ed6498; }
 
-.keyline-bottom,
-.keyline-bottom-dark     { border-bottom: 1px solid #404040; }
-.keyline-bottom-gray     { border-bottom: 1px solid #eee; }
-.keyline-bottom-light    { border-bottom: 1px solid #f8f8f8; }
-.keyline-bottom-white    { border-bottom: 1px solid #fff; }
-.keyline-bottom-cyan     { border-bottom: 1px solid #3bb2d0; }
-.keyline-bottom-blue     { border-bottom: 1px solid #3887be; }
-.keyline-bottom-darkblue { border-bottom: 1px solid #223b53; }
-.keyline-bottom-denim    { border-bottom: 1px solid #50667f; }
-.keyline-bottom-navy     { border-bottom: 1px solid #28353d; }
-.keyline-bottom-darknavy { border-bottom: 1px solid #222b30; }
-.keyline-bottom-purple   { border-bottom: 1px solid #8a8acb; }
-.keyline-bottom-teal     { border-bottom: 1px solid #41afa5; }
-.keyline-bottom-green    { border-bottom: 1px solid #56b881; }
-.keyline-bottom-yellow   { border-bottom: 1px solid #f1f075; }
-.keyline-bottom-mustard  { border-bottom: 1px solid #fbb03b; }
-.keyline-bottom-orange   { border-bottom: 1px solid #f9886c; }
-.keyline-bottom-red      { border-bottom: 1px solid #e55e5e; }
-.keyline-bottom-pink     { border-bottom: 1px solid #ed6498; }
+.bor-bottom,
+.bor-bottom-dark     { border-bottom: 1px solid #404040; }
+.bor-bottom-gray     { border-bottom: 1px solid #eee; }
+.bor-bottom-light    { border-bottom: 1px solid #f8f8f8; }
+.bor-bottom-white    { border-bottom: 1px solid #fff; }
+.bor-bottom-cyan     { border-bottom: 1px solid #3bb2d0; }
+.bor-bottom-blue     { border-bottom: 1px solid #3887be; }
+.bor-bottom-darkblue { border-bottom: 1px solid #223b53; }
+.bor-bottom-denim    { border-bottom: 1px solid #50667f; }
+.bor-bottom-navy     { border-bottom: 1px solid #28353d; }
+.bor-bottom-darknavy { border-bottom: 1px solid #222b30; }
+.bor-bottom-purple   { border-bottom: 1px solid #8a8acb; }
+.bor-bottom-teal     { border-bottom: 1px solid #41afa5; }
+.bor-bottom-green    { border-bottom: 1px solid #56b881; }
+.bor-bottom-yellow   { border-bottom: 1px solid #f1f075; }
+.bor-bottom-mustard  { border-bottom: 1px solid #fbb03b; }
+.bor-bottom-orange   { border-bottom: 1px solid #f9886c; }
+.bor-bottom-red      { border-bottom: 1px solid #e55e5e; }
+.bor-bottom-pink     { border-bottom: 1px solid #ed6498; }
 
-.keyline-left,
-.keyline-left-dark     { border-left: 1px solid #404040; }
-.keyline-left-gray     { border-left: 1px solid #eee; }
-.keyline-left-light    { border-left: 1px solid #f8f8f8; }
-.keyline-left-white    { border-left: 1px solid #fff; }
-.keyline-left-cyan     { border-left: 1px solid #3bb2d0; }
-.keyline-left-blue     { border-left: 1px solid #3887be; }
-.keyline-left-darkblue { border-left: 1px solid #223b53; }
-.keyline-left-denim    { border-left: 1px solid #50667f; }
-.keyline-left-navy     { border-left: 1px solid #28353d; }
-.keyline-left-darknavy { border-left: 1px solid #222b30; }
-.keyline-left-purple   { border-left: 1px solid #8a8acb; }
-.keyline-left-teal     { border-left: 1px solid #41afa5; }
-.keyline-left-green    { border-left: 1px solid #56b881; }
-.keyline-left-yellow   { border-left: 1px solid #f1f075; }
-.keyline-left-mustard  { border-left: 1px solid #fbb03b; }
-.keyline-left-orange   { border-left: 1px solid #f9886c; }
-.keyline-left-red      { border-left: 1px solid #e55e5e; }
-.keyline-left-pink     { border-left: 1px solid #ed6498; }
+.bor-left,
+.bor-left-dark     { border-left: 1px solid #404040; }
+.bor-left-gray     { border-left: 1px solid #eee; }
+.bor-left-light    { border-left: 1px solid #f8f8f8; }
+.bor-left-white    { border-left: 1px solid #fff; }
+.bor-left-cyan     { border-left: 1px solid #3bb2d0; }
+.bor-left-blue     { border-left: 1px solid #3887be; }
+.bor-left-darkblue { border-left: 1px solid #223b53; }
+.bor-left-denim    { border-left: 1px solid #50667f; }
+.bor-left-navy     { border-left: 1px solid #28353d; }
+.bor-left-darknavy { border-left: 1px solid #222b30; }
+.bor-left-purple   { border-left: 1px solid #8a8acb; }
+.bor-left-teal     { border-left: 1px solid #41afa5; }
+.bor-left-green    { border-left: 1px solid #56b881; }
+.bor-left-yellow   { border-left: 1px solid #f1f075; }
+.bor-left-mustard  { border-left: 1px solid #fbb03b; }
+.bor-left-orange   { border-left: 1px solid #f9886c; }
+.bor-left-red      { border-left: 1px solid #e55e5e; }
+.bor-left-pink     { border-left: 1px solid #ed6498; }
 
-.keyline-all-2,
-.keyline-all-2-dark     { border: 2px solid #404040; }
-.keyline-all-2-gray     { border: 2px solid #eee; }
-.keyline-all-2-light    { border: 2px solid #f8f8f8; }
-.keyline-all-2-white    { border: 2px solid #fff; }
-.keyline-all-2-cyan     { border: 2px solid #3bb2d0; }
-.keyline-all-2-blue     { border: 2px solid #3887be; }
-.keyline-all-2-darkblue { border: 2px solid #223b53; }
-.keyline-all-2-denim    { border: 2px solid #50667f; }
-.keyline-all-2-navy     { border: 2px solid #28353d; }
-.keyline-all-2-darknavy { border: 2px solid #222b30; }
-.keyline-all-2-purple   { border: 2px solid #8a8acb; }
-.keyline-all-2-teal     { border: 2px solid #41afa5; }
-.keyline-all-2-green    { border: 2px solid #56b881; }
-.keyline-all-2-yellow   { border: 2px solid #f1f075; }
-.keyline-all-2-mustard  { border: 2px solid #fbb03b; }
-.keyline-all-2-orange   { border: 2px solid #f9886c; }
-.keyline-all-2-red      { border: 2px solid #e55e5e; }
-.keyline-all-2-pink     { border: 2px solid #ed6498; }
+.bor-all-2,
+.bor-all-2-dark     { border: 2px solid #404040; }
+.bor-all-2-gray     { border: 2px solid #eee; }
+.bor-all-2-light    { border: 2px solid #f8f8f8; }
+.bor-all-2-white    { border: 2px solid #fff; }
+.bor-all-2-cyan     { border: 2px solid #3bb2d0; }
+.bor-all-2-blue     { border: 2px solid #3887be; }
+.bor-all-2-darkblue { border: 2px solid #223b53; }
+.bor-all-2-denim    { border: 2px solid #50667f; }
+.bor-all-2-navy     { border: 2px solid #28353d; }
+.bor-all-2-darknavy { border: 2px solid #222b30; }
+.bor-all-2-purple   { border: 2px solid #8a8acb; }
+.bor-all-2-teal     { border: 2px solid #41afa5; }
+.bor-all-2-green    { border: 2px solid #56b881; }
+.bor-all-2-yellow   { border: 2px solid #f1f075; }
+.bor-all-2-mustard  { border: 2px solid #fbb03b; }
+.bor-all-2-orange   { border: 2px solid #f9886c; }
+.bor-all-2-red      { border: 2px solid #e55e5e; }
+.bor-all-2-pink     { border: 2px solid #ed6498; }
 
-.keyline-top-2,
-.keyline-top-2-dark     { border-top: 2px solid #404040; }
-.keyline-top-2-gray     { border-top: 2px solid #eee; }
-.keyline-top-2-light    { border-top: 2px solid #f8f8f8; }
-.keyline-top-2-white    { border-top: 2px solid #fff; }
-.keyline-top-2-cyan     { border-top: 2px solid #3bb2d0; }
-.keyline-top-2-blue     { border-top: 2px solid #3887be; }
-.keyline-top-2-darkblue { border-top: 2px solid #223b53; }
-.keyline-top-2-denim    { border-top: 2px solid #50667f; }
-.keyline-top-2-navy     { border-top: 2px solid #28353d; }
-.keyline-top-2-darknavy { border-top: 2px solid #222b30; }
-.keyline-top-2-purple   { border-top: 2px solid #8a8acb; }
-.keyline-top-2-teal     { border-top: 2px solid #41afa5; }
-.keyline-top-2-green    { border-top: 2px solid #56b881; }
-.keyline-top-2-yellow   { border-top: 2px solid #f1f075; }
-.keyline-top-2-mustard  { border-top: 2px solid #fbb03b; }
-.keyline-top-2-orange   { border-top: 2px solid #f9886c; }
-.keyline-top-2-red      { border-top: 2px solid #e55e5e; }
-.keyline-top-2-pink     { border-top: 2px solid #ed6498; }
+.bor-top-2,
+.bor-top-2-dark     { border-top: 2px solid #404040; }
+.bor-top-2-gray     { border-top: 2px solid #eee; }
+.bor-top-2-light    { border-top: 2px solid #f8f8f8; }
+.bor-top-2-white    { border-top: 2px solid #fff; }
+.bor-top-2-cyan     { border-top: 2px solid #3bb2d0; }
+.bor-top-2-blue     { border-top: 2px solid #3887be; }
+.bor-top-2-darkblue { border-top: 2px solid #223b53; }
+.bor-top-2-denim    { border-top: 2px solid #50667f; }
+.bor-top-2-navy     { border-top: 2px solid #28353d; }
+.bor-top-2-darknavy { border-top: 2px solid #222b30; }
+.bor-top-2-purple   { border-top: 2px solid #8a8acb; }
+.bor-top-2-teal     { border-top: 2px solid #41afa5; }
+.bor-top-2-green    { border-top: 2px solid #56b881; }
+.bor-top-2-yellow   { border-top: 2px solid #f1f075; }
+.bor-top-2-mustard  { border-top: 2px solid #fbb03b; }
+.bor-top-2-orange   { border-top: 2px solid #f9886c; }
+.bor-top-2-red      { border-top: 2px solid #e55e5e; }
+.bor-top-2-pink     { border-top: 2px solid #ed6498; }
 
-.keyline-right-2,
-.keyline-right-2-dark     { border-right: 2px solid #404040; }
-.keyline-right-2-gray     { border-right: 2px solid #eee; }
-.keyline-right-2-light    { border-right: 2px solid #f8f8f8; }
-.keyline-right-2-white    { border-right: 2px solid #fff; }
-.keyline-right-2-cyan     { border-right: 2px solid #3bb2d0; }
-.keyline-right-2-blue     { border-right: 2px solid #3887be; }
-.keyline-right-2-darkblue { border-right: 2px solid #223b53; }
-.keyline-right-2-denim    { border-right: 2px solid #50667f; }
-.keyline-right-2-navy     { border-right: 2px solid #28353d; }
-.keyline-right-2-darknavy { border-right: 2px solid #222b30; }
-.keyline-right-2-purple   { border-right: 2px solid #8a8acb; }
-.keyline-right-2-teal     { border-right: 2px solid #41afa5; }
-.keyline-right-2-green    { border-right: 2px solid #56b881; }
-.keyline-right-2-yellow   { border-right: 2px solid #f1f075; }
-.keyline-right-2-mustard  { border-right: 2px solid #fbb03b; }
-.keyline-right-2-orange   { border-right: 2px solid #f9886c; }
-.keyline-right-2-red      { border-right: 2px solid #e55e5e; }
-.keyline-right-2-pink     { border-right: 2px solid #ed6498; }
+.bor-right-2,
+.bor-right-2-dark     { border-right: 2px solid #404040; }
+.bor-right-2-gray     { border-right: 2px solid #eee; }
+.bor-right-2-light    { border-right: 2px solid #f8f8f8; }
+.bor-right-2-white    { border-right: 2px solid #fff; }
+.bor-right-2-cyan     { border-right: 2px solid #3bb2d0; }
+.bor-right-2-blue     { border-right: 2px solid #3887be; }
+.bor-right-2-darkblue { border-right: 2px solid #223b53; }
+.bor-right-2-denim    { border-right: 2px solid #50667f; }
+.bor-right-2-navy     { border-right: 2px solid #28353d; }
+.bor-right-2-darknavy { border-right: 2px solid #222b30; }
+.bor-right-2-purple   { border-right: 2px solid #8a8acb; }
+.bor-right-2-teal     { border-right: 2px solid #41afa5; }
+.bor-right-2-green    { border-right: 2px solid #56b881; }
+.bor-right-2-yellow   { border-right: 2px solid #f1f075; }
+.bor-right-2-mustard  { border-right: 2px solid #fbb03b; }
+.bor-right-2-orange   { border-right: 2px solid #f9886c; }
+.bor-right-2-red      { border-right: 2px solid #e55e5e; }
+.bor-right-2-pink     { border-right: 2px solid #ed6498; }
 
-.keyline-bottom-2,
-.keyline-bottom-2-dark     { border-bottom: 2px solid #404040; }
-.keyline-bottom-2-gray     { border-bottom: 2px solid #eee; }
-.keyline-bottom-2-light    { border-bottom: 2px solid #f8f8f8; }
-.keyline-bottom-2-white    { border-bottom: 2px solid #fff; }
-.keyline-bottom-2-cyan     { border-bottom: 2px solid #3bb2d0; }
-.keyline-bottom-2-blue     { border-bottom: 2px solid #3887be; }
-.keyline-bottom-2-darkblue { border-bottom: 2px solid #223b53; }
-.keyline-bottom-2-denim    { border-bottom: 2px solid #50667f; }
-.keyline-bottom-2-navy     { border-bottom: 2px solid #28353d; }
-.keyline-bottom-2-darknavy { border-bottom: 2px solid #222b30; }
-.keyline-bottom-2-purple   { border-bottom: 2px solid #8a8acb; }
-.keyline-bottom-2-teal     { border-bottom: 2px solid #41afa5; }
-.keyline-bottom-2-green    { border-bottom: 2px solid #56b881; }
-.keyline-bottom-2-yellow   { border-bottom: 2px solid #f1f075; }
-.keyline-bottom-2-mustard  { border-bottom: 2px solid #fbb03b; }
-.keyline-bottom-2-orange   { border-bottom: 2px solid #f9886c; }
-.keyline-bottom-2-red      { border-bottom: 2px solid #e55e5e; }
-.keyline-bottom-2-pink     { border-bottom: 2px solid #ed6498; }
+.bor-bottom-2,
+.bor-bottom-2-dark     { border-bottom: 2px solid #404040; }
+.bor-bottom-2-gray     { border-bottom: 2px solid #eee; }
+.bor-bottom-2-light    { border-bottom: 2px solid #f8f8f8; }
+.bor-bottom-2-white    { border-bottom: 2px solid #fff; }
+.bor-bottom-2-cyan     { border-bottom: 2px solid #3bb2d0; }
+.bor-bottom-2-blue     { border-bottom: 2px solid #3887be; }
+.bor-bottom-2-darkblue { border-bottom: 2px solid #223b53; }
+.bor-bottom-2-denim    { border-bottom: 2px solid #50667f; }
+.bor-bottom-2-navy     { border-bottom: 2px solid #28353d; }
+.bor-bottom-2-darknavy { border-bottom: 2px solid #222b30; }
+.bor-bottom-2-purple   { border-bottom: 2px solid #8a8acb; }
+.bor-bottom-2-teal     { border-bottom: 2px solid #41afa5; }
+.bor-bottom-2-green    { border-bottom: 2px solid #56b881; }
+.bor-bottom-2-yellow   { border-bottom: 2px solid #f1f075; }
+.bor-bottom-2-mustard  { border-bottom: 2px solid #fbb03b; }
+.bor-bottom-2-orange   { border-bottom: 2px solid #f9886c; }
+.bor-bottom-2-red      { border-bottom: 2px solid #e55e5e; }
+.bor-bottom-2-pink     { border-bottom: 2px solid #ed6498; }
 
-.keyline-left-2,
-.keyline-left-2-dark     { border-left: 2px solid #404040; }
-.keyline-left-2-gray     { border-left: 2px solid #eee; }
-.keyline-left-2-light    { border-left: 2px solid #f8f8f8; }
-.keyline-left-2-white    { border-left: 2px solid #fff; }
-.keyline-left-2-cyan     { border-left: 2px solid #3bb2d0; }
-.keyline-left-2-blue     { border-left: 2px solid #3887be; }
-.keyline-left-2-darkblue { border-left: 2px solid #223b53; }
-.keyline-left-2-denim    { border-left: 2px solid #50667f; }
-.keyline-left-2-navy     { border-left: 2px solid #28353d; }
-.keyline-left-2-darknavy { border-left: 2px solid #222b30; }
-.keyline-left-2-purple   { border-left: 2px solid #8a8acb; }
-.keyline-left-2-teal     { border-left: 2px solid #41afa5; }
-.keyline-left-2-green    { border-left: 2px solid #56b881; }
-.keyline-left-2-yellow   { border-left: 2px solid #f1f075; }
-.keyline-left-2-mustard  { border-left: 2px solid #fbb03b; }
-.keyline-left-2-orange   { border-left: 2px solid #f9886c; }
-.keyline-left-2-red      { border-left: 2px solid #e55e5e; }
-.keyline-left-2-pink     { border-left: 2px solid #ed6498; }
+.bor-left-2,
+.bor-left-2-dark     { border-left: 2px solid #404040; }
+.bor-left-2-gray     { border-left: 2px solid #eee; }
+.bor-left-2-light    { border-left: 2px solid #f8f8f8; }
+.bor-left-2-white    { border-left: 2px solid #fff; }
+.bor-left-2-cyan     { border-left: 2px solid #3bb2d0; }
+.bor-left-2-blue     { border-left: 2px solid #3887be; }
+.bor-left-2-darkblue { border-left: 2px solid #223b53; }
+.bor-left-2-denim    { border-left: 2px solid #50667f; }
+.bor-left-2-navy     { border-left: 2px solid #28353d; }
+.bor-left-2-darknavy { border-left: 2px solid #222b30; }
+.bor-left-2-purple   { border-left: 2px solid #8a8acb; }
+.bor-left-2-teal     { border-left: 2px solid #41afa5; }
+.bor-left-2-green    { border-left: 2px solid #56b881; }
+.bor-left-2-yellow   { border-left: 2px solid #f1f075; }
+.bor-left-2-mustard  { border-left: 2px solid #fbb03b; }
+.bor-left-2-orange   { border-left: 2px solid #f9886c; }
+.bor-left-2-red      { border-left: 2px solid #e55e5e; }
+.bor-left-2-pink     { border-left: 2px solid #ed6498; }
+
+.shd-5       { box-shadow: 0 0 5px 0 rgba(0,0,0,0.3); }
+.shd-10      { box-shadow: 0 0 10px 0 rgba(0,0,0,0.3); }
+.shd-20      { box-shadow: 0 0 20px 0 rgba(0,0,0,0.3); }
+.shd-30      { box-shadow: 0 0 30px 0 rgba(0,0,0,0.3); }
+.shd-bold-5  { box-shadow: 0 0 5px 0 rgba(0,0,0,0.9); }
+.shd-bold-10 { box-shadow: 0 0 10px 0 rgba(0,0,0,0.9); }
+.shd-bold-20 { box-shadow: 0 0 20px 0 rgba(0,0,0,0.9); }
+.shd-bold-30 { box-shadow: 0 0 30px 0 rgba(0,0,0,0.9); }
 
 /**
  * Limiter classes


### PR DESCRIPTION
Adding keylines and shadows.

Notes:
* `keyline-all` has a width of 1px; `keyline-all-2` has a width of 2px
* There's a `darkblue` and `navy-dark` in base colors at the moment— conflicting naming conventions? I favored `darknavy` here.
* When no color is specified, ex. `keyline-all` is used, `dark` is default.