### PR TITLE
Make linting pass

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -17,10 +17,6 @@
     "block-opening-brace-space-before": "always",
     "color-hex-case": "lower",
     "color-no-invalid-hex": true,
-    "comment-empty-line-before": ["always", {
-      "except": ["first-nested"],
-      "ignore": ["stylelint-commands"]
-    }],
     "comment-no-empty": true,
     "comment-whitespace-inside": "always",
     "declaration-bang-space-after": "never",
@@ -47,7 +43,7 @@
         "inside-single-line-block"
       ]
     }],
-    "font-family-name-quotes": "always-where-required",
+    "font-family-name-quotes": "always-unless-keyword",
     "font-family-no-duplicate-names": true,
     "function-calc-no-unspaced-operator": true,
     "function-comma-newline-after": "always-multi-line",

--- a/src/fonts.css
+++ b/src/fonts.css
@@ -1,12 +1,12 @@
 /**
  * FontFace
-*/
+ */
 @font-face {
   font-family: 'Open Sans';
   font-weight: 400;
   src: url('../fonts/opensans-regular.eot');
   src: url('../fonts/opensans-regular.eot#iefix') format('embedded-opentype'),
-  url('../fonts/opensans-regular.woff') format('woff');
+    url('../fonts/opensans-regular.woff') format('woff');
 }
 
 @font-face {
@@ -14,7 +14,7 @@
   font-weight: 300;
   src: url('../fonts/opensans-light.eot');
   src: url('../fonts/opensans-light.eot#iefix') format('embedded-opentype'),
-  url('../fonts/opensans-light.woff') format('woff');
+    url('../fonts/opensans-light.woff') format('woff');
 }
 
 @font-face {
@@ -22,7 +22,7 @@
   font-style: italic;
   src: url('../fonts/opensans-italic.eot');
   src: url('../fonts/opensans-italic.eot#iefix') format('embedded-opentype'),
-  url('../fonts/opensans-italic.woff') format('woff');
+    url('../fonts/opensans-italic.woff') format('woff');
 }
 
 @font-face {
@@ -30,7 +30,7 @@
   font-weight: bold;
   src: url('../fonts/opensans-bold.eot');
   src: url('../fonts/opensans-bold.eot#iefix') format('embedded-opentype'),
-  url('../fonts/opensans-bold.woff') format('woff');
+    url('../fonts/opensans-bold.woff') format('woff');
 }
 
 @font-face {
@@ -39,14 +39,14 @@
   font-style: italic;
   src: url('../fonts/opensans-bolditalic.eot');
   src: url('../fonts/opensans-bolditalic.eot#iefix') format('embedded-opentype'),
-  url('../fonts/opensans-bolditalic.woff') format('woff');
+    url('../fonts/opensans-bolditalic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Headline';
   src: url('../fonts/leaguespartan-bold-webfont.eot');
   src: url('../fonts/leaguespartan-bold-webfont.eot?#iefix') format('embedded-opentype'),
-       url('../fonts/leaguespartan-bold-webfont.woff') format('woff');
+    url('../fonts/leaguespartan-bold-webfont.woff') format('woff');
   font-weight: bold;
   font-style: normal;
 }

--- a/src/layout.css
+++ b/src/layout.css
@@ -32,7 +32,6 @@
  * Column classes
 */
 [class*='col'] { flex: 1; }
-.col {}
 .col1 { width: 08.3333%; }
 .col2 { width: 16.6666%; }
 .col3 { width: 25%; }
@@ -58,6 +57,7 @@
 .grd-gut40 { margin-left: -40px; }
 .grd-gut80 { margin-left: -80px; }
 
+/* stylelint-disable selector-no-combinator */
 /**
  * Column gutter classes
 */
@@ -66,6 +66,7 @@
 .grd-gut20 > [class*='col'] { margin-left: 20px; }
 .grd-gut40 > [class*='col'] { margin-left: 40px; }
 .grd-gut80 > [class*='col'] { margin-left: 80px; }
+/* stylelint-enable */
 
 /**
  * Column classes

--- a/src/theming.css
+++ b/src/theming.css
@@ -43,13 +43,15 @@
 [class^='bor'] { border: 0 solid currentColor; }
 [class^='bor'][class*='-dash'] { border-style: dashed; }
 
-.bor, .bor-dash { border-width: 1px; }
+.bor,
+.bor-dash { border-width: 1px; }
 [class^='bor'][class*='-top'] { border-top-width: 1px; }
 [class^='bor'][class*='-right'] { border-right-width: 1px; }
 [class^='bor'][class*='-bottom'] { border-bottom-width: 1px; }
 [class^='bor'][class*='-left'] { border-left-width: 1px; }
 
-.bor2, .bor2-dash { border-width: 2px; }
+.bor2,
+.bor2-dash { border-width: 2px; }
 [class^='bor2'][class*='-top'] { border-top-width: 2px; }
 [class^='bor2'][class*='-right'] { border-right-width: 2px; }
 [class^='bor2'][class*='-bottom'] { border-bottom-width: 2px; }
@@ -63,34 +65,33 @@
 [class^='bor'][class$='-orange'] { border-color: #cc5500; }
 [class^='bor'][class$='-mustard'] { border-color: #ffbf16; }
 [class^='bor'][class$='-yellow'] { border-color: #ffeb3b; }
-[class^='bor'][class$='-green'] { border-color:  #11cc00; }
+[class^='bor'][class$='-green'] { border-color: #11cc00; }
 [class^='bor'][class$='-teal'] { border-color: #3fbfbc; }
 [class^='bor'][class$='-cyan'] { border-color: #00ccbb; }
 [class^='bor'][class$='-denim'] { border-color: #34607f; }
 [class^='bor'][class$='-navy'] { border-color: #0a3a5c; }
 [class^='bor'][class$='-white'] { border-color: #fff; }
 [class^='bor'][class$='-light'] { border-color: #f2f2f2; }
-[class^='bor'][class$='-transparent'] { border-color: rgba(0,0,0,0); }
-[class^='bor'][class$='-darken-5'] { border-color: rgba(0,0,0,0.05); }
-[class^='bor'][class$='-darken-25'] { border-color: rgba(0,0,0,0.25); }
-[class^='bor'][class$='-darken-50'] { border-color: rgba(0,0,0,0.50); }
-[class^='bor'][class$='-darken-75'] { border-color: rgba(0,0,0,0.75); }
-[class^='bor'][class$='-lighten-10'] { border-color: rgba(255,255,255,0.10); }
-[class^='bor'][class$='-lighten-10'] { border-color: rgba(255,255,255,0.10); }
-[class^='bor'][class$='-lighten-25'] { border-color: rgba(255,255,255,0.25); }
-[class^='bor'][class$='-lighten-50'] { border-color: rgba(255,255,255,0.50); }
-[class^='bor'][class$='-lighten-75'] { border-color: rgba(255,255,255,0.75); }
+[class^='bor'][class$='-transparent'] { border-color: rgba(0, 0, 0, 0); }
+[class^='bor'][class$='-darken-5'] { border-color: rgba(0, 0, 0, 0.05); }
+[class^='bor'][class$='-darken-25'] { border-color: rgba(0, 0, 0, 0.25); }
+[class^='bor'][class$='-darken-50'] { border-color: rgba(0, 0, 0, 0.5); }
+[class^='bor'][class$='-darken-75'] { border-color: rgba(0, 0, 0, 0.75); }
+[class^='bor'][class$='-lighten-10'] { border-color: rgba(255, 255, 255, 0.1); }
+[class^='bor'][class$='-lighten-10'] { border-color: rgba(255, 255, 255, 0.1); }
+[class^='bor'][class$='-lighten-25'] { border-color: rgba(255, 255, 255, 0.25); }
+[class^='bor'][class$='-lighten-50'] { border-color: rgba(255, 255, 255, 0.5); }
+[class^='bor'][class$='-lighten-75'] { border-color: rgba(255, 255, 255, 0.75); }
 
 /**
  * Shadow classes.
  */
 
-.sh5 { box-shadow: 0 0 5px 0 rgba(0,0,0,0.3); }
-.sh10 { box-shadow: 0 0 10px 0 rgba(0,0,0,0.3); }
-.sh20 { box-shadow: 0 0 20px 0 rgba(0,0,0,0.3); }
-.sh30 { box-shadow: 0 0 30px 0 rgba(0,0,0,0.3); }
-.shb5 { box-shadow: 0 0 5px 0 rgba(0,0,0,0.9); }
-.shb10 { box-shadow: 0 0 10px 0 rgba(0,0,0,0.9); }
-.shb20 { box-shadow: 0 0 20px 0 rgba(0,0,0,0.9); }
-.shb30 { box-shadow: 0 0 30px 0 rgba(0,0,0,0.9); }
-
+.sh5 { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3); }
+.sh10 { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3); }
+.sh20 { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.3); }
+.sh30 { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3); }
+.shb5 { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.9); }
+.shb10 { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.9); }
+.shb20 { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.9); }
+.shb30 { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.9); }

--- a/src/typography.css
+++ b/src/typography.css
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-no-combinator, selector-no-type */
 /**
  * Inline elements
 */
@@ -105,7 +106,7 @@ textarea {
 .txt h3 {
   margin-top: 17.392px;
   font-size: 23px;
-  line-height: 1.0870;
+  line-height: 1.087;
 }
 
 .txt-h4,
@@ -158,9 +159,11 @@ textarea {
   font-style: italic;
 }
 
+/* stylelint-disable selector-no-universal */
 .txt *:target {
   padding-top: 20px;
 }
+/* stylelint-enable selector-no-universal */
 
 /**
  * Type classes
@@ -192,4 +195,3 @@ textarea {
   text-transform: uppercase;
   letter-spacing: 3px;
 }
-


### PR DESCRIPTION
Anybody have any concerns about the linting rules?

Notice that we can selectively disable rules with `/* stylelint-disable [rule], [rule] */` and then `/* stylelint-enable [rule], [rule] */`. I'm thinking we could have rules like `selector-no-combinator` enforced but use these comments for exceptions, because it forces us to think a little bit harder about the exceptions.

After this PR merges let's try not to merge anything unless the CI is passing. We should either stick to the rules we have or change them. Sound ok to everyone?