### PR TITLE
Underline tabs = negative margins

### DIFF
--- a/debug/tabs/index.html
+++ b/debug/tabs/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset='utf-8' />
+  <title></title>
+  <meta name='viewport' content='width=device-width, initial-scale=1'>
+  <link href='/dist/base-core.css' rel='stylesheet' />
+  <script src='/dist/base-svgs.js'></script>
+</head>
+<body>
+
+<div class="mb20">
+  <div class="grd">
+    <div class="col6">
+      <div class="bor-bottom-transparent flx flx-stretch-y txt-small row30 bg-yellow">
+        <div class="bor-bottom flx flx-center-y mb-neg1 px5">
+          one
+        </div>
+        <div class="bor-bottom txt-gray flx flx-center-y mb-neg1 px5 ml10">
+          two
+        </div>
+      </div>
+    </div>
+    <div class="col6">
+      <div class="flx flx-stretch-y txt-small row30 bg-yellow">
+        <div class="flx flx-center-y px5">
+          one
+        </div>
+        <div class="txt-gray flx flx-center-y px5 ml10">
+          two
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="mb20">
+  <div class="bor2-bottom-transparent flx flx-stretch-y txt-small row40 bg-yellow">
+    <div class="bor2-bottom flx flx-center-y mb-neg2 px5">
+      one
+    </div>
+    <div class="bor2-bottom txt-gray flx flx-center-y mb-neg2 px5 ml10">
+      two
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/scripts/process-css.js
+++ b/scripts/process-css.js
@@ -26,6 +26,7 @@ const cssFiles = [
   getCssPath('theming'),
   getCssPath('positioning'),
   getCssPath('layout'),
+  getCssPath('theming'),
   getCssPath('icons')
 ];
 

--- a/src/layout.css
+++ b/src/layout.css
@@ -22,9 +22,11 @@
 .flx-right { justify-content: flex-end; }
 .flx-center-x { justify-content: center; }
 .flx-center-y { align-items: center; }
+.flx-stretch-x { justify-content: stretch; }
+.flx-stretch-y { align-items: stretch; }
 .flx-noshrink { flex-shrink: 0; }
 
-.flx-stretch {
+.flx-fill {
   flex-grow: 1;
   /* prevent overflowing chidlren
   cf. https://css-tricks.com/flexbox-truncated-text/ */

--- a/src/positioning.css
+++ b/src/positioning.css
@@ -118,6 +118,8 @@ Zero out positioning
  *  <div class='mt100'></div>
  *  <div class='mt200'></div>
  */
+.mb-neg1 { margin-bottom: -1px; }
+.mb-neg2 { margin-bottom: -2px; }
 .mb5 { margin-bottom: 5px; }
 .mb10 { margin-bottom: 10px; }
 .mb20 { margin-bottom: 20px; }


### PR DESCRIPTION
I went down this path by trying to create classes for [the underline tab pattern](https://github.com/mapbox/base-core/issues/15#issuecomment-265176123) that we want to enable.

I ended up realizing that the best way to enable that pattern is probably just to add two negative margin classes — no component classes after all. That's the only way to avoid building in all kinds of assumptions, which would lead to all kinds of variations, which would end up making the classes less useful and less used.

With negative margin classes, that underline-tab pattern can be implemented like so:

```html
<div class="bor-bottom-transparent flx flx-stretch-y row30">
  <div class="bor-bottom flx flx-center-y mb-1 px5">
    active
  </div>
  <div class="bor-bottom txt-gray flx flx-center-y mb-1 px5 ml10">
    inactive
  </div>
</div>
```

You can vary the border colors by changing the border classes, the text colors by changing text classes, the height by changing the row class, the spacing by changing the padding and margin classes.

I'm not sure `mb-1` is the best way to represent negative one. Maybe `mb-neg1`?

@samanpwbb for review.