### PR TITLE
Remove unnecessary font-face lines

### DIFF
--- a/src/fonts.css
+++ b/src/fonts.css
@@ -47,6 +47,4 @@
   src: url('../fonts/leaguespartan-bold-webfont.eot');
   src: url('../fonts/leaguespartan-bold-webfont.eot?#iefix') format('embedded-opentype'),
     url('../fonts/leaguespartan-bold-webfont.woff') format('woff');
-  font-weight: bold;
-  font-style: normal;
 }


### PR DESCRIPTION
I *think* these two lines are unnecessary, because the `'Headline'`s font family has only one font weight.

@katydecorah for review.