### PR TITLE
Remove attribute selectors

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -84,10 +84,6 @@
     "rule-non-nested-empty-line-before": ["always-multi-line", {
       "ignore": ["after-comment"]
     }],
-    "selector-attribute-brackets-space-inside": "never",
-    "selector-attribute-operator-space-after": "never",
-    "selector-attribute-operator-space-before": "never",
-    "selector-attribute-quotes": "always",
     "selector-class-pattern": "^[a-z]+[0-9]*$|^[a-z]{1,3}[0-9]*-((?!md-|sm-|lg-)[a-z0-9-]*)(-sm|-md|-lg)?$",
     "selector-combinator-space-after": "always",
     "selector-combinator-space-before": "always",
@@ -95,6 +91,7 @@
     "selector-list-comma-newline-after": "always",
     "selector-list-comma-space-before": "never",
     "selector-max-empty-lines": 0,
+    "selector-no-attribute": true,
     "selector-no-combinator": true,
     "selector-no-empty": true,
     "selector-no-id": true,

--- a/src/icons.css
+++ b/src/icons.css
@@ -8,19 +8,21 @@
  * @example
  * <svg class="icn-md" role="img"><use xlink:href="#base-svg-library"/></svg>
  */
-[class^='icn-'] { fill: currentColor; }
 
 .icn-sm {
+  fill: currentColor;
   height: 15px;
   width: 15px;
 }
 
 .icn-md {
+  fill: currentColor;
   height: 20px;
   width: 20px;
 }
 
 .icn-lg {
+  fill: currentColor;
   height: 40px;
   width: 40px;
 }

--- a/src/layout.css
+++ b/src/layout.css
@@ -51,19 +51,18 @@
 /**
  * Column classes
 */
-[class*='col'] { flex: 1; }
-.col1 { min-width: 08.3333%; }
-.col2 { min-width: 16.6666%; }
-.col3 { min-width: 25%; }
-.col4 { min-width: 33.3333%; }
-.col5 { min-width: 41.6666%; }
-.col6 { min-width: 50%; }
-.col7 { min-width: 58.3333%; }
-.col8 { min-width: 66.6666%; }
-.col9 { min-width: 75%; }
-.col10 { min-width: 83.3333%; }
-.col11 { min-width: 91.6666%; }
-.col12 { min-width: 100%; }
+.col1 { flex: 1; min-width: 08.3333%; }
+.col2 { flex: 1; min-width: 16.6666%; }
+.col3 { flex: 1; min-width: 25%; }
+.col4 { flex: 1; min-width: 33.3333%; }
+.col5 { flex: 1; min-width: 41.6666%; }
+.col6 { flex: 1; min-width: 50%; }
+.col7 { flex: 1; min-width: 58.3333%; }
+.col8 { flex: 1; min-width: 66.6666%; }
+.col9 { flex: 1; min-width: 75%; }
+.col10 { flex: 1; min-width: 83.3333%; }
+.col11 { flex: 1; min-width: 91.6666%; }
+.col12 { flex: 1; min-width: 100%; }
 
 /**
  * Max width containers
@@ -81,11 +80,80 @@
 /**
  * Column gutter classes
 */
-.grd-gut5 > [class*='col'] { padding-left: 5px; }
-.grd-gut10 > [class*='col'] { padding-left: 10px; }
-.grd-gut20 > [class*='col'] { padding-left: 20px; }
-.grd-gut40 > [class*='col'] { padding-left: 40px; }
-.grd-gut80 > [class*='col'] { padding-left: 80px; }
+.grd-gut5 > .col1,
+.grd-gut5 > .col2,
+.grd-gut5 > .col3,
+.grd-gut5 > .col4,
+.grd-gut5 > .col5,
+.grd-gut5 > .col6,
+.grd-gut5 > .col7,
+.grd-gut5 > .col8,
+.grd-gut5 > .col9,
+.grd-gut5 > .col10,
+.grd-gut5 > .col11,
+.grd-gut5 > .col12 {
+  padding-left: 5px;
+}
+
+.grd-gut10 > .col1,
+.grd-gut10 > .col2,
+.grd-gut10 > .col3,
+.grd-gut10 > .col4,
+.grd-gut10 > .col5,
+.grd-gut10 > .col6,
+.grd-gut10 > .col7,
+.grd-gut10 > .col8,
+.grd-gut10 > .col9,
+.grd-gut10 > .col10,
+.grd-gut10 > .col11,
+.grd-gut10 > .col12 {
+  padding-left: 10px;
+}
+
+.grd-gut20 > .col1,
+.grd-gut20 > .col2,
+.grd-gut20 > .col3,
+.grd-gut20 > .col4,
+.grd-gut20 > .col5,
+.grd-gut20 > .col6,
+.grd-gut20 > .col7,
+.grd-gut20 > .col8,
+.grd-gut20 > .col9,
+.grd-gut20 > .col10,
+.grd-gut20 > .col11,
+.grd-gut20 > .col12 {
+  padding-left: 20px;
+}
+
+.grd-gut40 > .col1,
+.grd-gut40 > .col2,
+.grd-gut40 > .col3,
+.grd-gut40 > .col4,
+.grd-gut40 > .col5,
+.grd-gut40 > .col6,
+.grd-gut40 > .col7,
+.grd-gut40 > .col8,
+.grd-gut40 > .col9,
+.grd-gut40 > .col10,
+.grd-gut40 > .col11,
+.grd-gut40 > .col12 {
+  padding-left: 40px;
+}
+
+.grd-gut80 > .col1,
+.grd-gut80 > .col2,
+.grd-gut80 > .col3,
+.grd-gut80 > .col4,
+.grd-gut80 > .col5,
+.grd-gut80 > .col6,
+.grd-gut80 > .col7,
+.grd-gut80 > .col8,
+.grd-gut80 > .col9,
+.grd-gut80 > .col10,
+.grd-gut80 > .col11,
+.grd-gut80 > .col12 {
+  padding-left: 80px;
+}
 /* stylelint-enable */
 
 /**
@@ -208,6 +276,5 @@
   margin-right: calc(50% - 50vw);
 }
 
-[class^='bld-'] { flex: 1; }
 .bld-right { margin-right: calc(50% - 50vw); }
 .bld-left { margin-left: calc(50% - 50vw); }

--- a/src/theming.css
+++ b/src/theming.css
@@ -40,48 +40,54 @@
  * Border classes.
  */
 
-[class^='bor'] { border: 0 solid currentColor; }
-[class^='bor'][class*='-dash'] { border-style: dashed; }
+.bor1 { border: 1px solid; }
+.bor1-dash { border: 1px dashed; }
+.bor2 { border: 2px solid; }
+.bor2-dash { border: 2px dashed; }
 
-.bor,
-.bor-dash { border-width: 1px; }
-[class^='bor'][class*='-top'] { border-top-width: 1px; }
-[class^='bor'][class*='-right'] { border-right-width: 1px; }
-[class^='bor'][class*='-bottom'] { border-bottom-width: 1px; }
-[class^='bor'][class*='-left'] { border-left-width: 1px; }
+.bor1-left { border-left: 1px solid; }
+.bor1-left-dash { border-left: 1px dashed; }
+.bor2-left { border-left: 2px solid; }
+.bor2-left-dash { border-left: 2px dashed; }
+.bor1-top { border-top: 1px solid; }
+.bor1-top-dash { border-top: 1px dashed; }
+.bor2-top { border-top: 2px solid; }
+.bor2-top-dash { border-top: 2px dashed; }
+.bor1-right { border-right: 1px solid; }
+.bor1-right-dash { border-right: 1px dashed; }
+.bor2-right { border-right: 2px solid; }
+.bor2-right-dash { border-right: 2px dashed; }
+.bor1-bottom { border-bottom: 1px solid; }
+.bor1-bottom-dash { border-bottom: 1px dashed; }
+.bor2-bottom { border-bottom: 2px solid; }
+.bor2-bottom-dash { border-bottom: 2px dashed; }
 
-.bor2,
-.bor2-dash { border-width: 2px; }
-[class^='bor2'][class*='-top'] { border-top-width: 2px; }
-[class^='bor2'][class*='-right'] { border-right-width: 2px; }
-[class^='bor2'][class*='-bottom'] { border-bottom-width: 2px; }
-[class^='bor2'][class*='-left'] { border-left-width: 2px; }
-
-[class^='bor'][class$='-gray'] { border-color: #acb4b9; }
-[class^='bor'][class$='-blue'] { border-color: #0077cc; }
-[class^='bor'][class$='-purple'] { border-color: #5500cc; }
-[class^='bor'][class$='-pink'] { border-color: #cc0077; }
-[class^='bor'][class$='-red'] { border-color: #cc0011; }
-[class^='bor'][class$='-orange'] { border-color: #cc5500; }
-[class^='bor'][class$='-mustard'] { border-color: #ffbf16; }
-[class^='bor'][class$='-yellow'] { border-color: #ffeb3b; }
-[class^='bor'][class$='-green'] { border-color: #11cc00; }
-[class^='bor'][class$='-teal'] { border-color: #3fbfbc; }
-[class^='bor'][class$='-cyan'] { border-color: #00ccbb; }
-[class^='bor'][class$='-denim'] { border-color: #34607f; }
-[class^='bor'][class$='-navy'] { border-color: #0a3a5c; }
-[class^='bor'][class$='-white'] { border-color: #fff; }
-[class^='bor'][class$='-light'] { border-color: #f2f2f2; }
-[class^='bor'][class$='-transparent'] { border-color: rgba(0, 0, 0, 0); }
-[class^='bor'][class$='-darken-5'] { border-color: rgba(0, 0, 0, 0.05); }
-[class^='bor'][class$='-darken-25'] { border-color: rgba(0, 0, 0, 0.25); }
-[class^='bor'][class$='-darken-50'] { border-color: rgba(0, 0, 0, 0.5); }
-[class^='bor'][class$='-darken-75'] { border-color: rgba(0, 0, 0, 0.75); }
-[class^='bor'][class$='-lighten-10'] { border-color: rgba(255, 255, 255, 0.1); }
-[class^='bor'][class$='-lighten-10'] { border-color: rgba(255, 255, 255, 0.1); }
-[class^='bor'][class$='-lighten-25'] { border-color: rgba(255, 255, 255, 0.25); }
-[class^='bor'][class$='-lighten-50'] { border-color: rgba(255, 255, 255, 0.5); }
-[class^='bor'][class$='-lighten-75'] { border-color: rgba(255, 255, 255, 0.75); }
+.bor-gray { border-color: #acb4b9; }
+.bor-blue { border-color: #0077cc; }
+.bor-purple { border-color: #5500cc; }
+.bor-pink { border-color: #cc0077; }
+.bor-red { border-color: #cc0011; }
+.bor-orange { border-color: #cc5500; }
+.bor-mustard { border-color: #ffbf16; }
+.bor-yellow { border-color: #ffeb3b; }
+.bor-green { border-color: #11cc00; }
+.bor-teal { border-color: #3fbfbc; }
+.bor-cyan { border-color: #00ccbb; }
+.bor-denim { border-color: #34607f; }
+.bor-navy { border-color: #0a3a5c; }
+.bor-white { border-color: #fff; }
+.bor-light { border-color: #f2f2f2; }
+.bor-transparent { border-color: rgba(0, 0, 0, 0); }
+.bor-darken-5 { border-color: rgba(0, 0, 0, 0.05); }
+.bor-darken-10 { border-color: rgba(0, 0, 0, 0.1); }
+.bor-darken-25 { border-color: rgba(0, 0, 0, 0.25); }
+.bor-darken-50 { border-color: rgba(0, 0, 0, 0.5); }
+.bor-darken-75 { border-color: rgba(0, 0, 0, 0.75); }
+.bor-lighten-5 { border-color: rgba(255, 255, 255, 0.05); }
+.bor-lighten-10 { border-color: rgba(255, 255, 255, 0.1); }
+.bor-lighten-25 { border-color: rgba(255, 255, 255, 0.25); }
+.bor-lighten-50 { border-color: rgba(255, 255, 255, 0.5); }
+.bor-lighten-75 { border-color: rgba(255, 255, 255, 0.75); }
 
 /**
  * Shadow classes.

--- a/src/typography.css
+++ b/src/typography.css
@@ -59,26 +59,25 @@ textarea {
  *    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. <strong>Incidunt magnam</strong>, cum consectetur maiores corrupti nulla iste saepe <em>porro repellat</em> beatae modi laudantium laborum magni voluptate impedit sint pariatur?</p>
  *  </div>
 */
-[class*='txt-h'],
-.txt-p,
-.txt h1,
-.txt h2,
-.txt h3,
-.txt h4,
-.txt h5,
-.txt h6,
-.txt p {
+.txt p,
+.txt-p {
   margin-bottom: 25px;
 }
 
-[class*='txt-h'],
+.txt-h1,
 .txt h1,
+.txt-h2,
 .txt h2,
+.txt-h3,
 .txt h3,
+.txt-h4,
 .txt h4,
+.txt-h5,
 .txt h5,
+.txt-h6,
 .txt h6 {
   font-weight: bold;
+  margin-bottom: 25px;
 }
 
 .txt-h1,


### PR DESCRIPTION
Closes #67 by removing attribute selectors, replacing them with class selectors, and adding a stylelint rule to prevent attribute selectors in the future.

Everything should work the same as before ... except one thing. The only thing I intended to change was to avoid a mad proliferation of border classes. Instead of creating classes for every permutation of every color, I thought maybe we'd leave border colors to their own classes, and expect users to add that class if they want a special color, e.g. `bor2-top-dashed bor-red`.

@dasulit for review.

