### PR TITLE
add more viewport units

### DIFF
--- a/src/sizing.css
+++ b/src/sizing.css
@@ -66,4 +66,8 @@
  *  <div class='row-full'></div>
  */
 
+.row-third { height: 33.3333vh; }
+.row-half { height: 50vh; }
+.row-twothirds { height: 66.6666vh; }
+.row-almost { height: 90vh; }
 .row-full { height: 100vh; }


### PR DESCRIPTION
More viewport units. `thirds` because 1/3rds look nice. `almost` because sometimes you want to tease the next section on a hero.