### PR TITLE
State Utilities, Cursors

### DIFF
--- a/src/theming.css
+++ b/src/theming.css
@@ -7,34 +7,34 @@
  * Round classes.
  */
 .round { border-radius: var(--border-radius); }
-.round-top { border-radius: 4px 4px 0 0; }
-.round-right { border-radius: 0 4px 4px 0; }
-.round-bottom { border-radius: 0 0 4px 4px; }
-.round-left { border-radius: 4px 0 0 4px; }
-.round-topleft { border-top-left-radius: 4px; }
-.round-topright { border-top-right-radius: 4px; }
-.round-bottomright { border-bottom-right-radius: 4px; }
-.round-bottomleft { border-bottom-left-radius: 4px; }
+.round-t { border-radius: 4px 4px 0 0; }
+.round-r { border-radius: 0 4px 4px 0; }
+.round-b { border-radius: 0 0 4px 4px; }
+.round-l { border-radius: 4px 0 0 4px; }
+.round-tl { border-top-left-radius: 4px; }
+.round-tr { border-top-right-radius: 4px; }
+.round-br { border-bottom-right-radius: 4px; }
+.round-bl { border-bottom-left-radius: 4px; }
 
 .round-bold { border-radius: var(--border-radius-bold); }
-.round-bold-top { border-radius: 8px 8px 0 0; }
-.round-bold-right { border-radius: 0 8px 8px 0; }
-.round-bold-bottom { border-radius: 0 0 8px 8px; }
-.round-bold-left { border-radius: 8px 0 0 8px; }
-.round-bold-topleft { border-top-left-radius: 8px; }
-.round-bold-topright { border-top-right-radius: 8px; }
-.round-bold-bottomright { border-bottom-right-radius: 8px; }
-.round-bold-bottomleft { border-bottom-left-radius: 8px; }
+.round-bold-t { border-radius: 8px 8px 0 0; }
+.round-bold-r { border-radius: 0 8px 8px 0; }
+.round-bold-b { border-radius: 0 0 8px 8px; }
+.round-bold-l { border-radius: 8px 0 0 8px; }
+.round-bold-tl { border-top-left-radius: 8px; }
+.round-bold-tr { border-top-right-radius: 8px; }
+.round-bold-br { border-bottom-right-radius: 8px; }
+.round-bold-bl { border-bottom-left-radius: 8px; }
 
 .round-full { border-radius: 50%; }
-.round-full-top { border-radius: 50% 50% 0 0; }
-.round-full-right { border-radius: 0 50% 50% 0; }
-.round-full-bottom { border-radius: 0 0 50% 50%; }
-.round-full-left { border-radius: 50% 0 0 50%; }
-.round-full-topleft { border-top-left-radius: 50%; }
-.round-full-topright { border-top-right-radius: 50%; }
-.round-full-bottomright { border-bottom-right-radius: 50%; }
-.round-full-bottomleft { border-bottom-left-radius: 50%; }
+.round-full-t { border-radius: 50% 50% 0 0; }
+.round-full-r { border-radius: 0 50% 50% 0; }
+.round-full-b { border-radius: 0 0 50% 50%; }
+.round-full-l { border-radius: 50% 0 0 50%; }
+.round-full-tl { border-top-left-radius: 50%; }
+.round-full-tr { border-top-right-radius: 50%; }
+.round-full-br { border-bottom-right-radius: 50%; }
+.round-full-bl { border-bottom-left-radius: 50%; }
 
 /**
  * Border classes.
@@ -43,10 +43,10 @@
 .border--2 { border-width: 2px; }
 .border--dash { border-style: dashed; }
 
-.border-left { border-left: 1px solid; }
-.border-top { border-top: 1px solid; }
-.border-right { border-right: 1px solid; }
-.border-bottom { border-bottom: 1px solid; }
+.border-l { border-left: 1px solid; }
+.border-t { border-top: 1px solid; }
+.border-r { border-right: 1px solid; }
+.border-b { border-bottom: 1px solid; }
 
 .border--gray { border-color: #acb4b9; }
 .border--blue { border-color: #0077cc; }
@@ -120,68 +120,68 @@
  */
 .hover-shadow5:hover,
 .focus-shadow5:focus,
-.active-shadow5:active { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3); }
+.active-shadow5:active { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3) !important; }
 .hover-shadow10:hover,
 .focus-shadow10:focus,
-.active-shadow10:active { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3); }
+.active-shadow10:active { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3) !important; }
 .hover-shadow20:hover,
 .focus-shadow20:focus,
-.active-shadow20:active { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.3); }
+.active-shadow20:active { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.3) !important; }
 .hover-shadow30:hover,
 .focus-shadow30:focus,
-.active-shadow30:active { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3); }
+.active-shadow30:active { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3) !important; }
 
 .hover-shadow-bold5:hover,
 .focus-shadow-bold5:focus,
-.active-shadow-bold5:active { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.9); }
+.active-shadow-bold5:active { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.9) !important; }
 .hover-shadow-bold10:hover,
 .focus-shadow-bold10:focus,
-.active-shadow-bold10:active { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.9); }
+.active-shadow-bold10:active { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.9) !important; }
 .hover-shadow-bold20:hover,
 .focus-shadow-bold20:focus,
-.active-shadow-bold20:active { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.9); }
+.active-shadow-bold20:active { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.9) !important; }
 .hover-shadow-bold30:hover,
 .focus-shadow-bold30:focus,
-.active-shadow-bold30:active { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.9); }
+.active-shadow-bold30:active { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.9) !important; }
 
 .hover-txt-shadow5:hover,
 .focus-txt-shadow5:focus,
-.active-txt-shadow5:active { text-shadow: 0 0 5px rgba(0, 0, 0, 0.3); }
+.active-txt-shadow5:active { text-shadow: 0 0 5px rgba(0, 0, 0, 0.3) !important; }
 .hover-txt-shadow10:hover,
 .focus-txt-shadow10:focus,
-.active-txt-shadow10:active { text-shadow: 0 0 10px rgba(0, 0, 0, 0.3); }
+.active-txt-shadow10:active { text-shadow: 0 0 10px rgba(0, 0, 0, 0.3) !important; }
 .hover-txt-shadow20:hover,
 .focus-txt-shadow20:focus,
-.active-txt-shadow20:active { text-shadow: 0 0 20px rgba(0, 0, 0, 0.3); }
+.active-txt-shadow20:active { text-shadow: 0 0 20px rgba(0, 0, 0, 0.3) !important; }
 .hover-txt-shadow30:hover,
 .focus-txt-shadow30:focus,
-.active-txt-shadow30:active { text-shadow: 0 0 30px rgba(0, 0, 0, 0.3); }
+.active-txt-shadow30:active { text-shadow: 0 0 30px rgba(0, 0, 0, 0.3) !important; }
 
 .hover-txt-shadow-bold5:hover,
 .focus-txt-shadow-bold5:focus,
-.active-txt-shadow-bold5:active { text-shadow: 0 0 5px rgba(0, 0, 0, 0.9); }
+.active-txt-shadow-bold5:active { text-shadow: 0 0 5px rgba(0, 0, 0, 0.9) !important; }
 .hover-txt-shadow-bold10:hover,
 .focus-txt-shadow-bold10:focus,
-.active-txt-shadow-bold10:active { text-shadow: 0 0 10px rgba(0, 0, 0, 0.9); }
+.active-txt-shadow-bold10:active { text-shadow: 0 0 10px rgba(0, 0, 0, 0.9) !important; }
 .hover-txt-shadow-bold20:hover,
 .focus-txt-shadow-bold20:focus,
-.active-txt-shadow-bold20:active { text-shadow: 0 0 20px rgba(0, 0, 0, 0.9); }
+.active-txt-shadow-bold20:active { text-shadow: 0 0 20px rgba(0, 0, 0, 0.9) !important; }
 .hover-txt-shadow-bold30:hover,
 .focus-txt-shadow-bold30:focus,
-.active-txt-shadow-bold30:active { text-shadow: 0 0 30px rgba(0, 0, 0, 0.9); }
+.active-txt-shadow-bold30:active { text-shadow: 0 0 30px rgba(0, 0, 0, 0.9) !important; }
 
 .hover-alpha0:hover,
 .focus-alpha0:focus,
-.active-alpha0:active { opacity: 0; }
+.active-alpha0:active { opacity: 0 !important; }
 .hover-alpha25:hover,
 .focus-alpha25:focus,
-.active-alpha25:active { opacity: 0.25; }
+.active-alpha25:active { opacity: 0.25 !important; }
 .hover-alpha50:hover,
 .focus-alpha50:focus,
-.active-alpha50:active { opacity: 0.5; }
+.active-alpha50:active { opacity: 0.5 !important; }
 .hover-alpha75:hover,
 .focus-alpha75:focus,
-.active-alpha75:active { opacity: 0.75; }
+.active-alpha75:active { opacity: 0.75 !important; }
 .hover-alpha100:hover,
 .focus-alpha100:focus,
-.active-alpha100:active { opacity: 1; }
+.active-alpha100:active { opacity: 1 !important; }


### PR DESCRIPTION
* Adds `txt-shadow*` classes
* These classes have the same variations as the existing `shadow*` classes. I chose to be consistent with these classes, even though you probably wouldn't ever use a text-shadow with a 30px blur radius..? 

Per https://github.com/mapbox/base-core/issues/89:
* Adds utilities for default, pointer, crosshair, and move cursors. Didn't want to get carried away so I picked a few. Are there other cursors folks want?

Per https://github.com/mapbox/base-core/issues/34:
* Adds utility classes for `hover-`, `focus-`, and `active-` using *CSS selectors*.
* These utility classes duplicate `alpha*`, `shadow*`, and `txt-shadow*` classes exactly.
* I grouped these utilities together to reduce redundancy, how do we feel about this..?

Per https://github.com/mapbox/base-core/pull/127

* Updates `-t`, `-r`, `-b` ... prefixes to `-top`, `-right`, `-bottom` etc.