### PR TITLE
Add watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-build: $(find src -type f)
-	npm run build
-
-clean:
-	rm -rf dist/*

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "css": "node scripts/process-css.js",
-    "svgs": "node scripts/create-svg-sprite.js",
-    "build": "rm -rf dist && mkdir dist && npm run css && npm run svgs",
+    "css": "node scripts/process-css",
+    "svgs": "node scripts/create-svg-sprite",
+    "build": "rm -rf dist && mkdir -p dist && npm run css && npm run svgs",
     "debug": "npm run build && http-server",
     "lint:css": "stylelint src/*.css",
     "lint:js": "eslint scripts",
     "lint": "npm run lint:css && npm run lint:js",
     "test": "npm run lint",
-    "docs": "budo docs/index.js"
+    "watch": "mkdir -p dist && node scripts/watch-src",
+    "docs": "npm run build && budo docs/index.js -o -l"
   },
   "browserify": {
     "transform": [
@@ -40,6 +41,7 @@
     "babelify": "^7.3.0",
     "browserify": "^13.1.1",
     "budo": "^9.2.2",
+    "chokidar": "^1.6.1",
     "concat-with-sourcemaps": "^1.0.4",
     "cssnano": "^3.8.1",
     "d3-queue": "^3.0.3",
@@ -52,8 +54,8 @@
     "lodash": "^4.17.2",
     "pify": "^2.3.0",
     "postcss": "^5.2.6",
-    "postcss-custom-properties": "^5.0.1",
     "postcss-custom-media": "^5.0.1",
+    "postcss-custom-properties": "^5.0.1",
     "postcss-reporter": "^2.0.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/scripts/create-svg-sprite
+++ b/scripts/create-svg-sprite
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+require('../build/create-svg-sprite')();

--- a/scripts/process-css
+++ b/scripts/process-css
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+require('../build/process-css')();

--- a/scripts/watch-src
+++ b/scripts/watch-src
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const chokidar = require('chokidar');
+const processCss = require('../build/process-css');
+
+const cssGlob = path.join(__dirname, '../src/*.css');
+
+console.log('Watching for changes to CSS ...');
+
+function rebuild() {
+  const now = new Date();
+  console.log(`[${now.getHours()}:${now.getMinutes()}:${now.getSeconds()}] Rebuilding CSS ...`);
+  processCss();
+}
+
+chokidar.watch(cssGlob, {
+  ignoreInitial: true
+}).on('all', rebuild);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,7 +1278,7 @@ cheerio@^0.20.0:
   optionalDependencies:
     jsdom "^7.0.2"
 
-chokidar@^1.0.0, chokidar@^1.0.1:
+chokidar@^1.0.0, chokidar@^1.0.1, chokidar@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
   dependencies:
@@ -3289,17 +3289,13 @@ minimalistic-assert@^1.0.0:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"


### PR DESCRIPTION
- Removes makefile.
- Moves build logic to a `build/` directory, and puts simpler executable scripts in the `scripts/` directory.
- Adds a `watch-src` script that watches CSS files for changes and recompiles as needed.

Now to run docs and rebuild as you go, you can do `npm run docs` in one terminal, `npm run watch` in another.

@samanpwbb for review.