### PR TITLE
Adds inputs and textarea basics

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -26,7 +26,6 @@
     "declaration-block-no-duplicate-properties": [ true, {
       "ignore": ["consecutive-duplicates-with-different-values"]
     }],
-    "declaration-block-no-redundant-longhand-properties": true,
     "declaration-block-no-shorthand-property-overrides": true,
     "declaration-block-semicolon-newline-after": "always-multi-line",
     "declaration-block-semicolon-space-after": "always-single-line",

--- a/src/forms.css
+++ b/src/forms.css
@@ -1,7 +1,6 @@
-.legend {
-  display: block;
-  width: 100%;
-}
+/**
+ * @section Forms
+ */
 
 .fieldset,
 .input,
@@ -14,45 +13,87 @@
   box-shadow: none;
 }
 
-.input {
-  border: 1px solid #acb4b9;
+.input,
+.textarea {
+  transition: border-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+  border: 1px solid var(--gray-light);
+  border-radius: var(--border-radius);
   display: inline-block;
-  border-radius: 3px;
 }
 
-.input:focus {
-  border-color: #3bb2d0;
-}
-
-.input:hover {
-  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3);
+.input:focus,
+.textarea:focus {
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.22);
+  border: 1px solid var(--gray-light);
 }
 
 .input::placeholder {
-  color: #acb4b9;
+  color: var(--gray-light);
 }
 
+/**
+ * Text input. The following modifiers are available:
+ * - `input--s`: Small
+ * - `input--dark`: Dark
+ *
+ * Use `w*` width classes to change widths.
+ *
+ * @memberof Forms
+ * @example
+ * <input class='input' placeholder='basic' />
+ * <input class='input input--s' placeholder='small' />
+ * <input class='input input--dark' placeholder='dark' />
+ */
 .input {
   height: 40px;
   line-height: 38px; /* minus border */
-  padding: 0 10px;
+  padding: 0 12px;
 }
 
-.input--sm {
+.input--s {
   height: 30px;
   line-height: 28px; /* minus border */
-  padding: 0 5px;
+  padding: 0 10px;
+  font-size: 12px;
 }
 
+/**
+ * Textarea. The following modifiers are available:
+ * - `textarea--s`: Small
+ * - `textarea--dark`: Dark
+ *
+ * Use `w*` width classes to change widths.
+ *
+ * @memberof Forms
+ * @example
+ * <textarea class='textarea'>basic</textarea>
+ * <textarea class='textarea textarea--s'>small</textarea>
+ * <textarea class='textarea textarea--dark'>dark</textarea>
+ */
 .textarea {
-  border: 1px solid var(--darken50);
   resize: vertical;
-  border-radius: 3px;
-  padding: 10px;
+  padding-top: 8px; /* minus border to match input */
+  padding-bottom: 8px;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
+.textarea--s {
+  font-size: 12px; /* match input--s */
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+/* Dark */
+.input--dark,
+.textarea--dark {
+  background-color: var(--gray-dark);
+  color: #fff;
+}
+
+/* Select */
 .select {
-  border: 2px solid #acb4b9;
+  border: 2px solid var(--gray-light);
   padding-right: 15px;
 }
 
@@ -347,3 +388,8 @@ input:checked + .color-purple,
   color: var(--purple-dark);
 }
 /* stylelint-enable selector-no-combinator, selector-no-type, selector-no-qualifying-type */
+
+.legend {
+  display: block;
+  width: 100%;
+}


### PR DESCRIPTION
Adds some basics and examples for inputs and text areas. Dimensions match https://cloud.githubusercontent.com/assets/5186564/21028703/59523b32-bd64-11e6-931b-adde375d396b.png, but color differences made it so the hover/focus states depicted did not seem to make sense. Also I did not enforce the 12px font-size. I don't understand this aspect of the typographic scale.

@mayagao @samanpwbb either of you want to pick this up? Or do you have suggestions?