### PR TITLE
Apply !important

### DIFF
--- a/src/buttons.css
+++ b/src/buttons.css
@@ -96,99 +96,104 @@
 
 /* Color variations */
 .btn.bg-gray:hover,
-.btn.bg-gray.is-active { background-color: var(--gray-dark); }
+.btn.bg-gray.is-active { background-color: var(--gray-dark) !important; }
 .btn.btn--stroke.color-gray:hover,
-.btn.btn--stroke.color-gray.is-active { color: var(--gray-dark); }
+.btn.btn--stroke.color-gray.is-active { color: var(--gray-dark) !important; }
 
 .btn.bg-pink:hover,
-.btn.bg-pink.is-active { background-color: var(--pink-dark); }
+.btn.bg-pink.is-active { background-color: var(--pink-dark) !important; }
 .btn.btn--stroke.color-pink:hover,
-.btn.btn--stroke.color-pink.is-active { color: var(--pink-dark); }
+.btn.btn--stroke.color-pink.is-active { color: var(--pink-dark) !important; }
 
 .btn.bg-red:hover,
-.btn.bg-red.is-active { background-color: var(--red-dark); }
+.btn.bg-red.is-active { background-color: var(--red-dark) !important; }
 .btn.btn--stroke.color-red:hover,
-.btn.btn--stroke.color-red.is-active { color: var(--red-dark); }
+.btn.btn--stroke.color-red.is-active { color: var(--red-dark) !important; }
 
 .btn.bg-orange:hover,
-.btn.bg-orange.is-active { background-color: var(--orange-dark); }
+.btn.bg-orange.is-active { background-color: var(--orange-dark) !important; }
 .btn.btn--stroke.color-orange:hover,
-.btn.btn--stroke.color-orange.is-active { color: var(--orange-dark); }
+.btn.btn--stroke.color-orange.is-active { color: var(--orange-dark) !important; }
 
 .btn.bg-yellow:hover,
-.btn.bg-yellow.is-active { background-color: var(--yellow-dark); }
+.btn.bg-yellow.is-active { background-color: var(--yellow-dark) !important; }
 .btn.btn--stroke.color-yellow:hover,
-.btn.btn--stroke.color-yellow.is-active { color: var(--yellow-dark); }
+.btn.btn--stroke.color-yellow.is-active { color: var(--yellow-dark) !important; }
 
 .btn.bg-green:hover,
-.btn.bg-green.is-active { background-color: var(--green-dark); }
+.btn.bg-green.is-active { background-color: var(--green-dark) !important; }
 .btn.btn--stroke.color-green:hover,
-.btn.btn--stroke.color-green.is-active { color: var(--green-dark); }
+.btn.btn--stroke.color-green.is-active { color: var(--green-dark) !important; }
 
 .btn.bg-teal:hover,
-.btn.bg-teal.is-active { background-color: var(--teal-dark); }
+.btn.bg-teal.is-active { background-color: var(--teal-dark) !important; }
 .btn.btn--stroke.color-teal:hover,
-.btn.btn--stroke.color-teal.is-active { color: var(--teal-dark); }
+.btn.btn--stroke.color-teal.is-active { color: var(--teal-dark) !important; }
+
+.btn.bg-blue:hover,
+.btn.bg-blue.is-active { background-color: var(--blue-dark) !important; }
+.btn.btn--stroke.color-blue:hover,
+.btn.btn--stroke.color-blue.is-active { color: var(--blue-dark) !important; }
 
 .btn.bg-purple:hover,
-.btn.bg-purple.is-active { background-color: var(--purple-dark); }
+.btn.bg-purple.is-active { background-color: var(--purple-dark) !important; }
 .btn.btn--stroke.color-purple:hover,
-.btn.btn--stroke.color-purple.is-active { color: var(--purple-dark); }
+.btn.btn--stroke.color-purple.is-active { color: var(--purple-dark) !important; }
 
 .btn.bg-white:hover,
-.btn.bg-white.is-active { background-color: var(--gray-faint); }
+.btn.bg-white.is-active { background-color: var(--gray-faint) !important; }
 .btn.btn--stroke.color-white:hover,
-.btn.btn--stroke.color-white.is-active { color: var(--gray-faint); }
+.btn.btn--stroke.color-white.is-active { color: var(--gray-faint) !important; }
 
 .btn.bg-lighten5:hover,
-.btn.bg-lighten5.is-active { background-color: transparent; }
+.btn.bg-lighten5.is-active { background-color: transparent !important; }
 .btn.btn--stroke.color-lighten5:hover,
-.btn.btn--stroke.color-lighten5.is-active { color: transparent; }
+.btn.btn--stroke.color-lighten5.is-active { color: transparent !important; }
 
 .btn.bg-lighten10:hover,
-.btn.bg-lighten10.is-active { background-color: var(--lighten5); }
+.btn.bg-lighten10.is-active { background-color: var(--lighten5) !important; }
 .btn.btn--stroke.color-lighten10:hover,
-.btn.btn--stroke.color-lighten10.is-active { color: var(--lighten5); }
+.btn.btn--stroke.color-lighten10.is-active { color: var(--lighten5) !important; }
 
 .btn.bg-lighten25:hover,
-.btn.bg-lighten25.is-active { background-color: var(--lighten10); }
+.btn.bg-lighten25.is-active { background-color: var(--lighten10) !important; }
 .btn.btn--stroke.color-lighten25:hover,
-.btn.btn--stroke.color-lighten25.is-active { color: var(--lighten10); }
+.btn.btn--stroke.color-lighten25.is-active { color: var(--lighten10) !important; }
 
 .btn.bg-lighten50:hover,
-.btn.bg-lighten50.is-active { background-color: var(--lighten25); }
+.btn.bg-lighten50.is-active { background-color: var(--lighten25) !important; }
 .btn.btn--stroke.color-lighten50:hover,
-.btn.btn--stroke.color-lighten50.is-active { color: var(--lighten25); }
+.btn.btn--stroke.color-lighten50.is-active { color: var(--lighten25) !important; }
 
 .btn.bg-lighten75:hover,
-.btn.bg-lighten75.is-active { background-color: var(--lighten50); }
+.btn.bg-lighten75.is-active { background-color: var(--lighten50) !important; }
 .btn.btn--stroke.color-lighten75:hover,
-.btn.btn--stroke.color-lighten75.is-active { color: var(--lighten50); }
+.btn.btn--stroke.color-lighten75.is-active { color: var(--lighten50) !important; }
 
 .btn.bg-darken5:hover,
-.btn.bg-darken5.is-active { background-color: var(--darken10); }
+.btn.bg-darken5.is-active { background-color: var(--darken10) !important; }
 .btn.btn--stroke.color-darken5:hover,
-.btn.btn--stroke.color-darken5.is-active { color: var(--darken10); }
+.btn.btn--stroke.color-darken5.is-active { color: var(--darken10) !important; }
 
 .btn.bg-darken10:hover,
-.btn.bg-darken10.is-active { background-color: var(--darken25); }
+.btn.bg-darken10.is-active { background-color: var(--darken25) !important; }
 .btn.btn--stroke.color-darken10:hover,
-.btn.btn--stroke.color-darken10.is-active { color: var(--darken25); }
+.btn.btn--stroke.color-darken10.is-active { color: var(--darken25) !important; }
 
 .btn.bg-darken25:hover,
-.btn.bg-darken25.is-active { background-color: var(--darken50); }
+.btn.bg-darken25.is-active { background-color: var(--darken50) !important; }
 .btn.btn--stroke.color-darken25:hover,
-.btn.btn--stroke.color-darken25.is-active { color: var(--darken50); }
+.btn.btn--stroke.color-darken25.is-active { color: var(--darken50) !important; }
 
 .btn.bg-darken50:hover,
-.btn.bg-darken50.is-active { background-color: var(--darken75); }
+.btn.bg-darken50.is-active { background-color: var(--darken75) !important; }
 .btn.btn--stroke.color-darken50:hover,
-.btn.btn--stroke.color-darken50.is-active { color: var(--darken75); }
+.btn.btn--stroke.color-darken50.is-active { color: var(--darken75) !important; }
 
 .btn.bg-darken75:hover,
-.btn.bg-darken75.is-active { background-color: var(--black); }
+.btn.bg-darken75.is-active { background-color: var(--black) !important; }
 .btn.btn--stroke.color-darken75:hover,
-.btn.btn--stroke.color-darken75.is-active { color: var(--black); }
+.btn.btn--stroke.color-darken75.is-active { color: var(--black) !important; }
 
 /**
  * Classes to create pill button groups. Every button in a pill group

--- a/src/colors.css
+++ b/src/colors.css
@@ -68,65 +68,65 @@
  * </div>
  */
 
-.bg-gray-dark { background-color: var(--gray-dark); }
-.bg-gray { background-color: var(--gray); }
-.bg-gray-light { background-color: var(--gray-light); }
-.bg-gray-faint { background-color: var(--gray-faint); }
+.bg-gray-dark { background-color: var(--gray-dark) !important; }
+.bg-gray { background-color: var(--gray) !important; }
+.bg-gray-light { background-color: var(--gray-light) !important; }
+.bg-gray-faint { background-color: var(--gray-faint) !important; }
 
-.bg-pink-dark { background-color: var(--pink-dark); }
-.bg-pink { background-color: var(--pink); }
-.bg-pink-light { background-color: var(--pink-light); }
-.bg-pink-faint { background-color: var(--pink-faint); }
+.bg-pink-dark { background-color: var(--pink-dark) !important; }
+.bg-pink { background-color: var(--pink) !important; }
+.bg-pink-light { background-color: var(--pink-light) !important; }
+.bg-pink-faint { background-color: var(--pink-faint) !important; }
 
-.bg-red-dark { background-color: var(--red-dark); }
-.bg-red { background-color: var(--red); }
-.bg-red-light { background-color: var(--red-light); }
-.bg-red-faint { background-color: var(--red-faint); }
+.bg-red-dark { background-color: var(--red-dark) !important; }
+.bg-red { background-color: var(--red) !important; }
+.bg-red-light { background-color: var(--red-light) !important; }
+.bg-red-faint { background-color: var(--red-faint) !important; }
 
-.bg-orange-dark { background-color: var(--orange-dark); }
-.bg-orange { background-color: var(--orange); }
-.bg-orange-light { background-color: var(--orange-light); }
-.bg-orange-faint { background-color: var(--orange-faint); }
+.bg-orange-dark { background-color: var(--orange-dark) !important; }
+.bg-orange { background-color: var(--orange) !important; }
+.bg-orange-light { background-color: var(--orange-light) !important; }
+.bg-orange-faint { background-color: var(--orange-faint) !important; }
 
-.bg-yellow-dark { background-color: var(--yellow-dark); }
-.bg-yellow { background-color: var(--yellow); }
-.bg-yellow-light { background-color: var(--yellow-light); }
-.bg-yellow-faint { background-color: var(--yellow-faint); }
+.bg-yellow-dark { background-color: var(--yellow-dark) !important; }
+.bg-yellow { background-color: var(--yellow) !important; }
+.bg-yellow-light { background-color: var(--yellow-light) !important; }
+.bg-yellow-faint { background-color: var(--yellow-faint) !important; }
 
-.bg-green-dark { background-color: var(--green-dark); }
-.bg-green { background-color: var(--green); }
-.bg-green-light { background-color: var(--green-light); }
-.bg-green-faint { background-color: var(--green-faint); }
+.bg-green-dark { background-color: var(--green-dark) !important; }
+.bg-green { background-color: var(--green) !important; }
+.bg-green-light { background-color: var(--green-light) !important; }
+.bg-green-faint { background-color: var(--green-faint) !important; }
 
-.bg-teal-dark { background-color: var(--teal-dark); }
-.bg-teal { background-color: var(--teal); }
-.bg-teal-light { background-color: var(--teal-light); }
-.bg-teal-faint { background-color: var(--teal-faint); }
+.bg-teal-dark { background-color: var(--teal-dark) !important; }
+.bg-teal { background-color: var(--teal) !important; }
+.bg-teal-light { background-color: var(--teal-light) !important; }
+.bg-teal-faint { background-color: var(--teal-faint) !important; }
 
-.bg-blue-dark { background-color: var(--blue-dark); }
-.bg-blue { background-color: var(--blue); }
-.bg-blue-light { background-color: var(--blue-light); }
-.bg-blue-faint { background-color: var(--blue-faint); }
+.bg-blue-dark { background-color: var(--blue-dark) !important; }
+.bg-blue { background-color: var(--blue) !important; }
+.bg-blue-light { background-color: var(--blue-light) !important; }
+.bg-blue-faint { background-color: var(--blue-faint) !important; }
 
-.bg-purple-dark { background-color: var(--purple-dark); }
-.bg-purple { background-color: var(--purple); }
-.bg-purple-light { background-color: var(--purple-light); }
-.bg-purple-faint { background-color: var(--purple-faint); }
+.bg-purple-dark { background-color: var(--purple-dark) !important; }
+.bg-purple { background-color: var(--purple) !important; }
+.bg-purple-light { background-color: var(--purple-light) !important; }
+.bg-purple-faint { background-color: var(--purple-faint) !important; }
 
-.bg-darken5 { background-color: var(--darken5); }
-.bg-darken10 { background-color: var(--darken10); }
-.bg-darken25 { background-color: var(--darken25); }
-.bg-darken50 { background-color: var(--darken50); }
-.bg-darken75 { background-color: var(--darken75); }
+.bg-darken5 { background-color: var(--darken5) !important; }
+.bg-darken10 { background-color: var(--darken10) !important; }
+.bg-darken25 { background-color: var(--darken25) !important; }
+.bg-darken50 { background-color: var(--darken50) !important; }
+.bg-darken75 { background-color: var(--darken75) !important; }
 
-.bg-lighten5 { background-color: var(--lighten5); }
-.bg-lighten10 { background-color: var(--lighten10); }
-.bg-lighten25 { background-color: var(--lighten25); }
-.bg-lighten50 { background-color: var(--lighten50); }
-.bg-lighten75 { background-color: var(--lighten75); }
+.bg-lighten5 { background-color: var(--lighten5) !important; }
+.bg-lighten10 { background-color: var(--lighten10) !important; }
+.bg-lighten25 { background-color: var(--lighten25) !important; }
+.bg-lighten50 { background-color: var(--lighten50) !important; }
+.bg-lighten75 { background-color: var(--lighten75) !important; }
 
-.bg-black { background-color: var(--black); }
-.bg-white { background-color: var(--white); }
+.bg-black { background-color: var(--black) !important; }
+.bg-white { background-color: var(--white) !important; }
 /** @endgroup */
 
 /**
@@ -173,67 +173,67 @@
  * <div class='mb10 color-black'>color-black</div>
  * <div class='mb10 color-white'>color-white</div>
  */
-.color-gray-dark { color: var(--gray-dark); }
-.color-gray { color: var(--gray); }
-.color-gray-light { color: var(--gray-light); }
-.color-gray-faint { color: var(--gray-faint); }
+.color-gray-dark { color: var(--gray-dark) !important; }
+.color-gray { color: var(--gray) !important; }
+.color-gray-light { color: var(--gray-light) !important; }
+.color-gray-faint { color: var(--gray-faint) !important; }
 
-.color-pink-dark { color: var(--pink-dark); }
-.color-pink { color: var(--pink); }
-.color-pink-light { color: var(--pink-light); }
-.color-pink-faint { color: var(--pink-faint); }
+.color-pink-dark { color: var(--pink-dark) !important; }
+.color-pink { color: var(--pink) !important; }
+.color-pink-light { color: var(--pink-light) !important; }
+.color-pink-faint { color: var(--pink-faint) !important; }
 
-.color-red-dark { color: var(--red-dark); }
-.color-red { color: var(--red); }
-.color-red-light { color: var(--red-light); }
-.color-red-faint { color: var(--red-faint); }
+.color-red-dark { color: var(--red-dark) !important; }
+.color-red { color: var(--red) !important; }
+.color-red-light { color: var(--red-light) !important; }
+.color-red-faint { color: var(--red-faint) !important; }
 
-.color-orange-dark { color: var(--orange-dark); }
-.color-orange { color: var(--orange); }
-.color-orange-light { color: var(--orange-light); }
-.color-orange-faint { color: var(--orange-faint); }
+.color-orange-dark { color: var(--orange-dark) !important; }
+.color-orange { color: var(--orange) !important; }
+.color-orange-light { color: var(--orange-light) !important; }
+.color-orange-faint { color: var(--orange-faint) !important; }
 
-.color-yellow-dark { color: var(--yellow-dark); }
-.color-yellow { color: var(--yellow); }
-.color-yellow-light { color: var(--yellow-light); }
-.color-yellow-faint { color: var(--yellow-faint); }
+.color-yellow-dark { color: var(--yellow-dark) !important; }
+.color-yellow { color: var(--yellow) !important; }
+.color-yellow-light { color: var(--yellow-light) !important; }
+.color-yellow-faint { color: var(--yellow-faint) !important; }
 
-.color-green-dark { color: var(--green-dark); }
-.color-green { color: var(--green); }
-.color-green-light { color: var(--green-light); }
-.color-green-faint { color: var(--green-faint); }
+.color-green-dark { color: var(--green-dark) !important; }
+.color-green { color: var(--green) !important; }
+.color-green-light { color: var(--green-light) !important; }
+.color-green-faint { color: var(--green-faint) !important; }
 
-.color-teal-dark { color: var(--teal-dark); }
-.color-teal { color: var(--teal); }
-.color-teal-light { color: var(--teal-light); }
-.color-teal-faint { color: var(--teal-faint); }
+.color-teal-dark { color: var(--teal-dark) !important; }
+.color-teal { color: var(--teal) !important; }
+.color-teal-light { color: var(--teal-light) !important; }
+.color-teal-faint { color: var(--teal-faint) !important; }
 
-.color-blue-dark { color: var(--blue-dark); }
-.color-blue { color: var(--blue); }
-.color-blue-light { color: var(--blue-light); }
-.color-blue-faint { color: var(--blue-faint); }
+.color-blue-dark { color: var(--blue-dark) !important; }
+.color-blue { color: var(--blue) !important; }
+.color-blue-light { color: var(--blue-light) !important; }
+.color-blue-faint { color: var(--blue-faint) !important; }
 
-.color-purple-dark { color: var(--purple-dark); }
-.color-purple { color: var(--purple); }
-.color-purple-light { color: var(--purple-light); }
-.color-purple-faint { color: var(--purple-faint); }
+.color-purple-dark { color: var(--purple-dark) !important; }
+.color-purple { color: var(--purple) !important; }
+.color-purple-light { color: var(--purple-light) !important; }
+.color-purple-faint { color: var(--purple-faint) !important; }
 
-.color-darken5 { color: var(--darken5); }
-.color-darken10 { color: var(--darken10); }
-.color-darken25 { color: var(--darken25); }
-.color-darken50 { color: var(--darken50); }
-.color-darken75 { color: var(--darken75); }
+.color-darken5 { color: var(--darken5) !important; }
+.color-darken10 { color: var(--darken10) !important; }
+.color-darken25 { color: var(--darken25) !important; }
+.color-darken50 { color: var(--darken50) !important; }
+.color-darken75 { color: var(--darken75) !important; }
 
-.color-lighten5 { color: var(--lighten5); }
-.color-lighten10 { color: var(--lighten10); }
-.color-lighten25 { color: var(--lighten25); }
-.color-lighten50 { color: var(--lighten50); }
-.color-lighten75 { color: var(--lighten75); }
+.color-lighten5 { color: var(--lighten5) !important; }
+.color-lighten10 { color: var(--lighten10) !important; }
+.color-lighten25 { color: var(--lighten25) !important; }
+.color-lighten50 { color: var(--lighten50) !important; }
+.color-lighten75 { color: var(--lighten75) !important; }
 
-.color-black { color: var(--black); }
-.color-white { color: var(--white); }
+.color-black { color: var(--black) !important; }
+.color-white { color: var(--white) !important; }
 
-.color-text { color: var(--text-color); }
+.color-text { color: var(--text-color) !important; }
 /** @endgroup */
 
 /**
@@ -267,76 +267,76 @@
     to bottom right,
     var(--gray),
     transparent
-  );
+  ) !important;
 }
 .bg-pink-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--pink),
     transparent
-  );
+  ) !important;
 }
 .bg-red-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--red),
     transparent
-  );
+  ) !important;
 }
 .bg-orange-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--orange),
     transparent
-  );
+  ) !important;
 }
 .bg-yellow-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--yellow),
     transparent
-  );
+  ) !important;
 }
 .bg-green-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--green),
     transparent
-  );
+  ) !important;
 }
 .bg-teal-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--teal),
     transparent
-  );
+  ) !important;
 }
 .bg-blue-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--blue),
     transparent
-  );
+  ) !important;
 }
 .bg-purple-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--purple),
     transparent
-  );
+  ) !important;
 }
 .bg-black-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--black),
     transparent
-  );
+  ) !important;
 }
 .bg-white-to-transparent {
   background-image: linear-gradient(
     to bottom right,
     var(--white),
     transparent
-  );
+  ) !important;
 }
 /** @endgroup */

--- a/src/forms.css
+++ b/src/forms.css
@@ -302,90 +302,90 @@ input:checked + .radio,
 /* Color variations */
 input:checked + .bg-gray:not(.checkbox--stroke),
 .bg-gray.is-active:not(.checkbox--stroke) {
-  background-color: var(--gray-dark);
+  background-color: var(--gray-dark) !important;
 }
 input:checked + .color-gray.checkbox--stroke,
 .color-gray.checkbox--stroke.is-active,
 input:checked + .color-gray,
 .color-gray.is-active {
-  color: var(--gray-dark);
+  color: var(--gray-dark) !important;
 }
 
 input:checked + .bg-pink:not(.checkbox--stroke),
 .bg-pink.is-active:not(.checkbox--stroke) {
-  background-color: var(--pink-dark);
+  background-color: var(--pink-dark) !important;
 }
 input:checked + .color-pink.checkbox--stroke,
 .color-pink.checkbox--stroke.is-active,
 input:checked + .color-pink,
 .color-pink.is-active {
-  color: var(--pink-dark);
+  color: var(--pink-dark) !important;
 }
 
 input:checked + .bg-red:not(.checkbox--stroke),
 .bg-red.is-active:not(.checkbox--stroke) {
-  background-color: var(--red-dark);
+  background-color: var(--red-dark) !important;
 }
 input:checked + .color-red.checkbox--stroke,
 .color-red.checkbox--stroke.is-active,
 input:checked + .color-red,
 .color-red.is-active {
-  color: var(--red-dark);
+  color: var(--red-dark) !important;
 }
 
 input:checked + .bg-orange:not(.checkbox--stroke),
 .bg-orange.is-active:not(.checkbox--stroke) {
-  background-color: var(--orange-dark);
+  background-color: var(--orange-dark) !important;
 }
 input:checked + .color-orange.checkbox--stroke,
 .color-orange.checkbox--stroke.is-active,
 input:checked + .color-orange,
 .color-orange.is-active {
-  color: var(--orange-dark);
+  color: var(--orange-dark) !important;
 }
 
 input:checked + .bg-yellow:not(.checkbox--stroke),
 .bg-yellow.is-active:not(.checkbox--stroke) {
-  background-color: var(--yellow-dark);
+  background-color: var(--yellow-dark) !important;
 }
 input:checked + .color-yellow.checkbox--stroke,
 .color-yellow.checkbox--stroke.is-active,
 input:checked + .color-yellow,
 .color-yellow.is-active {
-  color: var(--yellow-dark);
+  color: var(--yellow-dark) !important;
 }
 
 input:checked + .bg-green:not(.checkbox--stroke),
 .bg-green.is-active:not(.checkbox--stroke) {
-  background-color: var(--green-dark);
+  background-color: var(--green-dark) !important;
 }
 input:checked + .color-green.checkbox--stroke,
 .color-green.checkbox--stroke.is-active,
 input:checked + .color-green,
 .color-green.is-active {
-  color: var(--green-dark);
+  color: var(--green-dark) !important;
 }
 
 input:checked + .bg-teal:not(.checkbox--stroke),
 .bg-teal.is-active:not(.checkbox--stroke) {
-  background-color: var(--teal-dark);
+  background-color: var(--teal-dark) !important;
 }
 input:checked + .color-teal.checkbox--stroke,
 .color-teal.checkbox--stroke.is-active,
 input:checked + .color-teal,
 .color-teal.is-active {
-  color: var(--teal-dark);
+  color: var(--teal-dark) !important;
 }
 
 input:checked + .bg-purple:not(.checkbox--stroke),
 .bg-purple.is-active:not(.checkbox--stroke) {
-  background-color: var(--purple-dark);
+  background-color: var(--purple-dark) !important;
 }
 input:checked + .color-purple.checkbox--stroke,
 .color-purple.checkbox--stroke.is-active,
 input:checked + .color-purple,
 .color-purple.is-active {
-  color: var(--purple-dark);
+  color: var(--purple-dark) !important;
 }
 /* stylelint-enable selector-no-combinator, selector-no-type, selector-no-qualifying-type */
 

--- a/src/icons.css
+++ b/src/icons.css
@@ -24,12 +24,12 @@
 }
 
 .icn--s {
-  height: 15px;
-  width: 15px;
+  height: 15px !important;
+  width: 15px !important;
 }
 
 .icn--l {
-  height: 40px;
-  width: 40px;
+  height: 40px !important;
+  width: 40px !important;
 }
 /** @endgroup */

--- a/src/layout.css
+++ b/src/layout.css
@@ -30,131 +30,131 @@
  * @memberof Layout
  * @group
  */
-.flx { display: flex; }
-.flx-inline { display: inline-flex; }
-.flx-column { flex-direction: column; }
+.flx { display: flex !important; }
+.flx-inline { display: inline-flex !important; }
+.flx-column { flex-direction: column !important; }
 .flx-wrap { flex-wrap: wrap; }
-.flx-end { justify-content: flex-end; }
-.flx-center-x { justify-content: center; }
-.flx-center-y { align-items: center; }
-.flx-stretch-y { align-items: stretch; }
-.flx-noshrink { flex-shrink: 0; }
+.flx-end { justify-content: flex-end !important; }
+.flx-center-x { justify-content: center !important; }
+.flx-center-y { align-items: center !important; }
+.flx-stretch-y { align-items: stretch !important; }
+.flx-noshrink { flex-shrink: 0 !important; }
 .flx-fill {
-  flex-grow: 1;
+  flex-grow: 1 !important;
   /* prevent overflowing chidlren
   clearfix. https://css-tricks.com/flexbox-truncated-text/ */
-  min-width: 0;
+  min-width: 0 !important;
 }
 /** @endgroup */
 
 @media only screen and (--large-screen) {
-  .flx-lg { display: flex; }
-  .flx-none-lg { flex: none; }
-  .flx-column-lg { flex-direction: column; }
+  .flx-lg { display: flex !important; }
+  .flx-none-lg { flex: none !important; }
+  .flx-column-lg { flex-direction: column !important; }
   .flx-wrap-lg { flex-wrap: wrap; }
-  .flx-end-lg { justify-content: flex-end; }
-  .flx-center-x-lg { justify-content: center; }
-  .flx-center-y-lg { align-items: center; }
-  .flx-stretch-y-lg { align-items: stretch; }
-  .flx-noshrink-lg { flex-shrink: 0; }
+  .flx-end-lg { justify-content: flex-end !important; }
+  .flx-center-x-lg { justify-content: center !important; }
+  .flx-center-y-lg { align-items: center !important; }
+  .flx-stretch-y-lg { align-items: stretch !important; }
+  .flx-noshrink-lg { flex-shrink: 0 !important; }
   .flx-fill-lg {
-    flex-grow: 1;
-    min-width: 0;
+    flex-grow: 1 !important;
+    min-width: 0 !important;
   }
 }
 
 @media only screen and (--medium-screen) {
-  .flx-md { display: flex; }
-  .flx-none-md { flex: none; }
-  .flx-column-md { flex-direction: column; }
+  .flx-md { display: flex !important; }
+  .flx-none-md { flex: none !important; }
+  .flx-column-md { flex-direction: column !important; }
   .flx-wrap-md { flex-wrap: wrap; }
-  .flx-end-md { justify-content: flex-end; }
-  .flx-center-x-md { justify-content: center; }
-  .flx-center-y-md { align-items: center; }
-  .flx-stretch-y-md { align-items: stretch; }
-  .flx-noshrink-md { flex-shrink: 0; }
+  .flx-end-md { justify-content: flex-end !important; }
+  .flx-center-x-md { justify-content: center !important; }
+  .flx-center-y-md { align-items: center !important; }
+  .flx-stretch-y-md { align-items: stretch !important; }
+  .flx-noshrink-md { flex-shrink: 0 !important; }
   .flx-fill-md {
-    flex-grow: 1;
-    min-width: 0;
+    flex-grow: 1 !important;
+    min-width: 0 !important;
   }
 }
 
 @media only screen and (--small-screen) {
-  .flx-sm { display: flex; }
-  .flx-none-sm { flex: none; }
-  .flx-column-sm { flex-direction: column; }
+  .flx-sm { display: flex !important; }
+  .flx-none-sm { flex: none !important; }
+  .flx-column-sm { flex-direction: column !important; }
   .flx-wrap-sm { flex-wrap: wrap; }
-  .flx-end-sm { justify-content: flex-end; }
-  .flx-center-x-sm { justify-content: center; }
-  .flx-center-y-sm { align-items: center; }
-  .flx-stretch-y-sm { align-items: stretch; }
-  .flx-noshrink-sm { flex-shrink: 0; }
+  .flx-end-sm { justify-content: flex-end !important; }
+  .flx-center-x-sm { justify-content: center !important; }
+  .flx-center-y-sm { align-items: center !important; }
+  .flx-stretch-y-sm { align-items: stretch !important; }
+  .flx-noshrink-sm { flex-shrink: 0 !important; }
   .flx-fill-sm {
-    flex-grow: 1;
-    min-width: 0;
+    flex-grow: 1 !important;
+    min-width: 0 !important;
   }
 }
 
 /**
  * Column classes
  */
-.col { flex-shrink: 0; }
-.col--1 { width: 08.3333%; }
-.col--2 { width: 16.6666%; }
-.col--3 { width: 25%; }
-.col--4 { width: 33.3333%; }
-.col--5 { width: 41.6666%; }
-.col--6 { width: 50%; }
-.col--7 { width: 58.3333%; }
-.col--8 { width: 66.6666%; }
-.col--9 { width: 75%; }
-.col--10 { width: 83.3333%; }
-.col--11 { width: 91.6666%; }
-.col--12 { width: 100%; }
+.col { flex-shrink: 0 !important; }
+.col--1 { width: 08.3333% !important; }
+.col--2 { width: 16.6666% !important; }
+.col--3 { width: 25% !important; }
+.col--4 { width: 33.3333% !important; }
+.col--5 { width: 41.6666% !important; }
+.col--6 { width: 50% !important; }
+.col--7 { width: 58.3333% !important; }
+.col--8 { width: 66.6666% !important; }
+.col--9 { width: 75% !important; }
+.col--10 { width: 83.3333% !important; }
+.col--11 { width: 91.6666% !important; }
+.col--12 { width: 100% !important; }
 
 @media only screen and (--large-screen) {
-  .col--1-lg { width: 08.3333%; }
-  .col--2-lg { width: 16.6666%; }
-  .col--3-lg { width: 25%; }
-  .col--4-lg { width: 33.3333%; }
-  .col--5-lg { width: 41.6666%; }
-  .col--6-lg { width: 50%; }
-  .col--7-lg { width: 58.3333%; }
-  .col--8-lg { width: 66.6666%; }
-  .col--9-lg { width: 75%; }
-  .col--10-lg { width: 83.3333%; }
-  .col--11-lg { width: 91.6666%; }
-  .col--12-lg { width: 100%; }
+  .col--1-lg { width: 08.3333% !important; }
+  .col--2-lg { width: 16.6666% !important; }
+  .col--3-lg { width: 25% !important; }
+  .col--4-lg { width: 33.3333% !important; }
+  .col--5-lg { width: 41.6666% !important; }
+  .col--6-lg { width: 50% !important; }
+  .col--7-lg { width: 58.3333% !important; }
+  .col--8-lg { width: 66.6666% !important; }
+  .col--9-lg { width: 75% !important; }
+  .col--10-lg { width: 83.3333% !important; }
+  .col--11-lg { width: 91.6666% !important; }
+  .col--12-lg { width: 100% !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .col--1-md { width: 08.3333%; }
-  .col--2-md { width: 16.6666%; }
-  .col--3-md { width: 25%; }
-  .col--4-md { width: 33.3333%; }
-  .col--5-md { width: 41.6666%; }
-  .col--6-md { width: 50%; }
-  .col--7-md { width: 58.3333%; }
-  .col--8-md { width: 66.6666%; }
-  .col--9-md { width: 75%; }
-  .col--10-md { width: 83.3333%; }
-  .col--11-md { width: 91.6666%; }
-  .col--12-md { width: 100%; }
+  .col--1-md { width: 08.3333% !important; }
+  .col--2-md { width: 16.6666% !important; }
+  .col--3-md { width: 25% !important; }
+  .col--4-md { width: 33.3333% !important; }
+  .col--5-md { width: 41.6666% !important; }
+  .col--6-md { width: 50% !important; }
+  .col--7-md { width: 58.3333% !important; }
+  .col--8-md { width: 66.6666% !important; }
+  .col--9-md { width: 75% !important; }
+  .col--10-md { width: 83.3333% !important; }
+  .col--11-md { width: 91.6666% !important; }
+  .col--12-md { width: 100% !important; }
 }
 
 @media only screen and (--small-screen) {
-  .col--1-sm { width: 08.3333%; }
-  .col--2-sm { width: 16.6666%; }
-  .col--3-sm { width: 25%; }
-  .col--4-sm { width: 33.3333%; }
-  .col--5-sm { width: 41.6666%; }
-  .col--6-sm { width: 50%; }
-  .col--7-sm { width: 58.3333%; }
-  .col--8-sm { width: 66.6666%; }
-  .col--9-sm { width: 75%; }
-  .col--10-sm { width: 83.3333%; }
-  .col--11-sm { width: 91.6666%; }
-  .col--12-sm { width: 100%; }
+  .col--1-sm { width: 08.3333% !important; }
+  .col--2-sm { width: 16.6666% !important; }
+  .col--3-sm { width: 25% !important; }
+  .col--4-sm { width: 33.3333% !important; }
+  .col--5-sm { width: 41.6666% !important; }
+  .col--6-sm { width: 50% !important; }
+  .col--7-sm { width: 58.3333% !important; }
+  .col--8-sm { width: 66.6666% !important; }
+  .col--9-sm { width: 75% !important; }
+  .col--10-sm { width: 83.3333% !important; }
+  .col--11-sm { width: 91.6666% !important; }
+  .col--12-sm { width: 100% !important; }
 }
 
 /**
@@ -174,144 +174,144 @@
  * </div>
  */
 .grd {
-  display: flex;
-  flex-wrap: wrap;
+  display: flex !important;
+  flex-wrap: wrap !important;
 }
 
 /**
  * Column gutter classes
  */
-.grd--gut5 { margin-left: -5px; }
-.grd--gut10 { margin-left: -10px; }
-.grd--gut20 { margin-left: -20px; }
-.grd--gut40 { margin-left: -40px; }
-.grd--gut80 { margin-left: -80px; }
+.grd--gut5 { margin-left: -5px !important; }
+.grd--gut10 { margin-left: -10px !important; }
+.grd--gut20 { margin-left: -20px !important; }
+.grd--gut40 { margin-left: -40px !important; }
+.grd--gut80 { margin-left: -80px !important; }
 
 /* stylelint-disable selector-no-combinator */
-.grd--gut5 > .col { padding-left: 5px; }
-.grd--gut10 > .col { padding-left: 10px; }
-.grd--gut20 > .col { padding-left: 20px; }
-.grd--gut40 > .col { padding-left: 40px; }
-.grd--gut80 > .col { padding-left: 80px; }
+.grd--gut5 > .col { padding-left: 5px !important; }
+.grd--gut10 > .col { padding-left: 10px !important; }
+.grd--gut20 > .col { padding-left: 20px !important; }
+.grd--gut40 > .col { padding-left: 40px !important; }
+.grd--gut80 > .col { padding-left: 80px !important; }
 /* stylelint-enable selector-no-combinator */
 
 /**
  * Column offset classes
  */
-.col--offl1 { margin-left: 08.3333%; }
-.col--offl2 { margin-left: 16.6666%; }
-.col--offl3 { margin-left: 25%; }
-.col--offl4 { margin-left: 33.3333%; }
-.col--offl5 { margin-left: 41.6666%; }
-.col--offl6 { margin-left: 50%; }
-.col--offl7 { margin-left: 58.3333%; }
-.col--offl8 { margin-left: 66.6666%; }
-.col--offl9 { margin-left: 75%; }
-.col--offl10 { margin-left: 83.3333%; }
-.col--offl11 { margin-left: 91.6666%; }
-.col--offl12 { margin-left: 100%; }
+.col--offl1 { margin-left: 08.3333% !important; }
+.col--offl2 { margin-left: 16.6666% !important; }
+.col--offl3 { margin-left: 25% !important; }
+.col--offl4 { margin-left: 33.3333% !important; }
+.col--offl5 { margin-left: 41.6666% !important; }
+.col--offl6 { margin-left: 50% !important; }
+.col--offl7 { margin-left: 58.3333% !important; }
+.col--offl8 { margin-left: 66.6666% !important; }
+.col--offl9 { margin-left: 75% !important; }
+.col--offl10 { margin-left: 83.3333% !important; }
+.col--offl11 { margin-left: 91.6666% !important; }
+.col--offl12 { margin-left: 100% !important; }
 
 @media only screen and (--large-screen) {
-  .col--offl1-lg { margin-left: 08.3333%; }
-  .col--offl2-lg { margin-left: 16.6666%; }
-  .col--offl3-lg { margin-left: 25%; }
-  .col--offl4-lg { margin-left: 33.3333%; }
-  .col--offl5-lg { margin-left: 41.6666%; }
-  .col--offl6-lg { margin-left: 50%; }
-  .col--offl7-lg { margin-left: 58.3333%; }
-  .col--offl8-lg { margin-left: 66.6666%; }
-  .col--offl9-lg { margin-left: 75%; }
-  .col--offl10-lg { margin-left: 83.3333%; }
-  .col--offl11-lg { margin-left: 91.6666%; }
-  .col--offl12-lg { margin-left: 100%; }
+  .col--offl1-lg { margin-left: 08.3333% !important; }
+  .col--offl2-lg { margin-left: 16.6666% !important; }
+  .col--offl3-lg { margin-left: 25% !important; }
+  .col--offl4-lg { margin-left: 33.3333% !important; }
+  .col--offl5-lg { margin-left: 41.6666% !important; }
+  .col--offl6-lg { margin-left: 50% !important; }
+  .col--offl7-lg { margin-left: 58.3333% !important; }
+  .col--offl8-lg { margin-left: 66.6666% !important; }
+  .col--offl9-lg { margin-left: 75% !important; }
+  .col--offl10-lg { margin-left: 83.3333% !important; }
+  .col--offl11-lg { margin-left: 91.6666% !important; }
+  .col--offl12-lg { margin-left: 100% !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .col--offl1-md { margin-left: 08.3333%; }
-  .col--offl2-md { margin-left: 16.6666%; }
-  .col--offl3-md { margin-left: 25%; }
-  .col--offl4-md { margin-left: 33.3333%; }
-  .col--offl5-md { margin-left: 41.6666%; }
-  .col--offl6-md { margin-left: 50%; }
-  .col--offl7-md { margin-left: 58.3333%; }
-  .col--offl8-md { margin-left: 66.6666%; }
-  .col--offl9-md { margin-left: 75%; }
-  .col--offl10-md { margin-left: 83.3333%; }
-  .col--offl11-md { margin-left: 91.6666%; }
-  .col--offl12-md { margin-left: 100%; }
+  .col--offl1-md { margin-left: 08.3333% !important; }
+  .col--offl2-md { margin-left: 16.6666% !important; }
+  .col--offl3-md { margin-left: 25% !important; }
+  .col--offl4-md { margin-left: 33.3333% !important; }
+  .col--offl5-md { margin-left: 41.6666% !important; }
+  .col--offl6-md { margin-left: 50% !important; }
+  .col--offl7-md { margin-left: 58.3333% !important; }
+  .col--offl8-md { margin-left: 66.6666% !important; }
+  .col--offl9-md { margin-left: 75% !important; }
+  .col--offl10-md { margin-left: 83.3333% !important; }
+  .col--offl11-md { margin-left: 91.6666% !important; }
+  .col--offl12-md { margin-left: 100% !important; }
 }
 
 @media only screen and (--small-screen) {
-  .col--offl1-sm { margin-left: 08.3333%; }
-  .col--offl2-sm { margin-left: 16.6666%; }
-  .col--offl3-sm { margin-left: 25%; }
-  .col--offl4-sm { margin-left: 33.3333%; }
-  .col--offl5-sm { margin-left: 41.6666%; }
-  .col--offl6-sm { margin-left: 50%; }
-  .col--offl7-sm { margin-left: 58.3333%; }
-  .col--offl8-sm { margin-left: 66.6666%; }
-  .col--offl9-sm { margin-left: 75%; }
-  .col--offl10-sm { margin-left: 83.3333%; }
-  .col--offl11-sm { margin-left: 91.6666%; }
-  .col--offl12-sm { margin-left: 100%; }
+  .col--offl1-sm { margin-left: 08.3333% !important; }
+  .col--offl2-sm { margin-left: 16.6666% !important; }
+  .col--offl3-sm { margin-left: 25% !important; }
+  .col--offl4-sm { margin-left: 33.3333% !important; }
+  .col--offl5-sm { margin-left: 41.6666% !important; }
+  .col--offl6-sm { margin-left: 50% !important; }
+  .col--offl7-sm { margin-left: 58.3333% !important; }
+  .col--offl8-sm { margin-left: 66.6666% !important; }
+  .col--offl9-sm { margin-left: 75% !important; }
+  .col--offl10-sm { margin-left: 83.3333% !important; }
+  .col--offl11-sm { margin-left: 91.6666% !important; }
+  .col--offl12-sm { margin-left: 100% !important; }
 }
 
-.col--offr1 { margin-right: 08.3333%; }
-.col--offr2 { margin-right: 16.6666%; }
-.col--offr3 { margin-right: 25%; }
-.col--offr4 { margin-right: 33.3333%; }
-.col--offr5 { margin-right: 41.6666%; }
-.col--offr6 { margin-right: 50%; }
-.col--offr7 { margin-right: 58.3333%; }
-.col--offr8 { margin-right: 66.6666%; }
-.col--offr9 { margin-right: 75%; }
-.col--offr10 { margin-right: 83.3333%; }
-.col--offr11 { margin-right: 91.6666%; }
-.col--offr12 { margin-right: 100%; }
+.col--offr1 { margin-right: 08.3333% !important; }
+.col--offr2 { margin-right: 16.6666% !important; }
+.col--offr3 { margin-right: 25% !important; }
+.col--offr4 { margin-right: 33.3333% !important; }
+.col--offr5 { margin-right: 41.6666% !important; }
+.col--offr6 { margin-right: 50% !important; }
+.col--offr7 { margin-right: 58.3333% !important; }
+.col--offr8 { margin-right: 66.6666% !important; }
+.col--offr9 { margin-right: 75% !important; }
+.col--offr10 { margin-right: 83.3333% !important; }
+.col--offr11 { margin-right: 91.6666% !important; }
+.col--offr12 { margin-right: 100% !important; }
 
 @media only screen and (--large-screen) {
-  .col--offr1-lg { margin-right: 08.3333%; }
-  .col--offr2-lg { margin-right: 16.6666%; }
-  .col--offr3-lg { margin-right: 25%; }
-  .col--offr4-lg { margin-right: 33.3333%; }
-  .col--offr5-lg { margin-right: 41.6666%; }
-  .col--offr6-lg { margin-right: 50%; }
-  .col--offr7-lg { margin-right: 58.3333%; }
-  .col--offr8-lg { margin-right: 66.6666%; }
-  .col--offr9-lg { margin-right: 75%; }
-  .col--offr10-lg { margin-right: 83.3333%; }
-  .col--offr11-lg { margin-right: 91.6666%; }
-  .col--offr12-lg { margin-right: 100%; }
+  .col--offr1-lg { margin-right: 08.3333% !important; }
+  .col--offr2-lg { margin-right: 16.6666% !important; }
+  .col--offr3-lg { margin-right: 25% !important; }
+  .col--offr4-lg { margin-right: 33.3333% !important; }
+  .col--offr5-lg { margin-right: 41.6666% !important; }
+  .col--offr6-lg { margin-right: 50% !important; }
+  .col--offr7-lg { margin-right: 58.3333% !important; }
+  .col--offr8-lg { margin-right: 66.6666% !important; }
+  .col--offr9-lg { margin-right: 75% !important; }
+  .col--offr10-lg { margin-right: 83.3333% !important; }
+  .col--offr11-lg { margin-right: 91.6666% !important; }
+  .col--offr12-lg { margin-right: 100% !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .col--offr1-md { margin-right: 08.3333%; }
-  .col--offr2-md { margin-right: 16.6666%; }
-  .col--offr3-md { margin-right: 25%; }
-  .col--offr4-md { margin-right: 33.3333%; }
-  .col--offr5-md { margin-right: 41.6666%; }
-  .col--offr6-md { margin-right: 50%; }
-  .col--offr7-md { margin-right: 58.3333%; }
-  .col--offr8-md { margin-right: 66.6666%; }
-  .col--offr9-md { margin-right: 75%; }
-  .col--offr10-md { margin-right: 83.3333%; }
-  .col--offr11-md { margin-right: 91.6666%; }
-  .col--offr12-md { margin-right: 100%; }
+  .col--offr1-md { margin-right: 08.3333% !important; }
+  .col--offr2-md { margin-right: 16.6666% !important; }
+  .col--offr3-md { margin-right: 25% !important; }
+  .col--offr4-md { margin-right: 33.3333% !important; }
+  .col--offr5-md { margin-right: 41.6666% !important; }
+  .col--offr6-md { margin-right: 50% !important; }
+  .col--offr7-md { margin-right: 58.3333% !important; }
+  .col--offr8-md { margin-right: 66.6666% !important; }
+  .col--offr9-md { margin-right: 75% !important; }
+  .col--offr10-md { margin-right: 83.3333% !important; }
+  .col--offr11-md { margin-right: 91.6666% !important; }
+  .col--offr12-md { margin-right: 100% !important; }
 }
 
 @media only screen and (--small-screen) {
-  .col--offr1-sm { margin-right: 08.3333%; }
-  .col--offr2-sm { margin-right: 16.6666%; }
-  .col--offr3-sm { margin-right: 25%; }
-  .col--offr4-sm { margin-right: 33.3333%; }
-  .col--offr5-sm { margin-right: 41.6666%; }
-  .col--offr6-sm { margin-right: 50%; }
-  .col--offr7-sm { margin-right: 58.3333%; }
-  .col--offr8-sm { margin-right: 66.6666%; }
-  .col--offr9-sm { margin-right: 75%; }
-  .col--offr10-sm { margin-right: 83.3333%; }
-  .col--offr11-sm { margin-right: 91.6666%; }
-  .col--offr12-sm { margin-right: 100%; }
+  .col--offr1-sm { margin-right: 08.3333% !important; }
+  .col--offr2-sm { margin-right: 16.6666% !important; }
+  .col--offr3-sm { margin-right: 25% !important; }
+  .col--offr4-sm { margin-right: 33.3333% !important; }
+  .col--offr5-sm { margin-right: 41.6666% !important; }
+  .col--offr6-sm { margin-right: 50% !important; }
+  .col--offr7-sm { margin-right: 58.3333% !important; }
+  .col--offr8-sm { margin-right: 66.6666% !important; }
+  .col--offr9-sm { margin-right: 75% !important; }
+  .col--offr10-sm { margin-right: 83.3333% !important; }
+  .col--offr11-sm { margin-right: 91.6666% !important; }
+  .col--offr12-sm { margin-right: 100% !important; }
 }
 
 /**
@@ -323,12 +323,12 @@
  *
  */
 .bleed {
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
+  margin-left: calc(50% - 50vw) !important;
+  margin-right: calc(50% - 50vw) !important;
 }
 
-.bleed-r { flex: 1; margin-right: calc(50% - 50vw); }
-.bleed-l { flex: 1; margin-left: calc(50% - 50vw); }
+.bleed-r { flex: 1 !important; margin-right: calc(50% - 50vw) !important; }
+.bleed-l { flex: 1 !important; margin-left: calc(50% - 50vw) !important; }
 
 /**
  * For non-grid, non-flexbox layouts.
@@ -346,12 +346,12 @@
  *   <div class='fr'>right</div>
  * </div>
  */
-.fl { float: left; }
-.fr { float: right; }
+.fl { float: left !important; }
+.fr { float: right !important; }
 .clearfix::after {
-  content: '';
-  display: block;
-  clear: both;
+  content: '' !important;
+  display: block !important;
+  clear: both !important;
 }
 /** @endgroup */
 
@@ -384,31 +384,31 @@
  *   <div class="none border border--cyan bor-all">none</div>
  * </div>
  */
-.inline { display: inline; }
-.block { display: block; }
-.inline-block { display: inline-block; }
-.none { display: none; }
+.inline { display: inline !important; }
+.block { display: block !important; }
+.inline-block { display: inline-block !important; }
+.none { display: none !important; }
 /** @endgroup */
 
 @media only screen and (--large-screen) {
-  .inline-lg { display: inline; }
-  .block-lg { display: block; }
-  .inline-block-lg { display: inline-block; }
-  .none-lg { display: none; }
+  .inline-lg { display: inline !important; }
+  .block-lg { display: block !important; }
+  .inline-block-lg { display: inline-block !important; }
+  .none-lg { display: none !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .inline-md { display: inline; }
-  .block-md { display: block; }
-  .inline-block-md { display: inline-block; }
-  .none-md { display: none; }
+  .inline-md { display: inline !important; }
+  .block-md { display: block !important; }
+  .inline-block-md { display: inline-block !important; }
+  .none-md { display: none !important; }
 }
 
 @media only screen and (--small-screen) {
-  .inline-sm { display: inline; }
-  .block-sm { display: block; }
-  .inline-block-sm { display: inline-block; }
-  .none-sm { display: none; }
+  .inline-sm { display: inline !important; }
+  .block-sm { display: block !important; }
+  .inline-block-sm { display: inline-block !important; }
+  .none-sm { display: none !important; }
 }
 
 /**
@@ -425,31 +425,31 @@
  * @group
  * @memberof Positioning
  */
-.fixed { position: fixed; }
-.absolute { position: absolute; }
-.relative { position: relative; }
-.static { position: static; }
+.fixed { position: fixed !important; }
+.absolute { position: absolute !important; }
+.relative { position: relative !important; }
+.static { position: static !important; }
 /** @endgroup */
 
 @media only screen and (--large-screen) {
-  .fixed-lg { position: fixed; }
-  .absolute-lg { position: absolute; }
-  .relative-lg { position: relative; }
-  .static-lg { position: static; }
+  .fixed-lg { position: fixed !important; }
+  .absolute-lg { position: absolute !important; }
+  .relative-lg { position: relative !important; }
+  .static-lg { position: static !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .fixed-md { position: fixed; }
-  .absolute-md { position: absolute; }
-  .relative-md { position: relative; }
-  .static-md { position: static; }
+  .fixed-md { position: fixed !important; }
+  .absolute-md { position: absolute !important; }
+  .relative-md { position: relative !important; }
+  .static-md { position: static !important; }
 }
 
 @media only screen and (--small-screen) {
-  .fixed-sm { position: fixed; }
-  .absolute-sm { position: absolute; }
-  .relative-sm { position: relative; }
-  .static-sm { position: static; }
+  .fixed-sm { position: fixed !important; }
+  .absolute-sm { position: absolute !important; }
+  .relative-sm { position: relative !important; }
+  .static-sm { position: static !important; }
 }
 
 /**
@@ -460,31 +460,31 @@
  * @group
  * @memberof Positioning
  */
-.top { top: 0; }
-.right { right: 0; }
-.left { left: 0; }
-.bottom { bottom: 0; }
+.top { top: 0 !important; }
+.right { right: 0 !important; }
+.left { left: 0 !important; }
+.bottom { bottom: 0 !important; }
 /** @endgroup */
 
 @media only screen and (--large-screen) {
-  .top-lg { top: 0; }
-  .right-lg { right: 0; }
-  .left-lg { left: 0; }
-  .bottom-lg { bottom: 0; }
+  .top-lg { top: 0 !important; }
+  .right-lg { right: 0 !important; }
+  .left-lg { left: 0 !important; }
+  .bottom-lg { bottom: 0 !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .top-md { top: 0; }
-  .right-md { right: 0; }
-  .left-md { left: 0; }
-  .bottom-md { bottom: 0; }
+  .top-md { top: 0 !important; }
+  .right-md { right: 0 !important; }
+  .left-md { left: 0 !important; }
+  .bottom-md { bottom: 0 !important; }
 }
 
 @media only screen and (--small-screen) {
-  .top-sm { top: 0; }
-  .right-sm { right: 0; }
-  .left-sm { left: 0; }
-  .bottom-sm { bottom: 0; }
+  .top-sm { top: 0 !important; }
+  .right-sm { right: 0 !important; }
+  .left-sm { left: 0 !important; }
+  .bottom-sm { bottom: 0 !important; }
 }
 
 /**
@@ -496,43 +496,43 @@
  * @group
  * @memberof Positioning
  */
-.z-neg1 { z-index: -1; }
-.z0 { z-index: 0; }
-.z1 { z-index: 1; }
-.z2 { z-index: 2; }
-.z3 { z-index: 3; }
-.z4 { z-index: 4; }
-.z5 { z-index: 5; }
+.z-neg1 { z-index: -1 !important; }
+.z0 { z-index: 0 !important; }
+.z1 { z-index: 1 !important; }
+.z2 { z-index: 2 !important; }
+.z3 { z-index: 3 !important; }
+.z4 { z-index: 4 !important; }
+.z5 { z-index: 5 !important; }
 /** @endgroup */
 
 @media only screen and (--large-screen) {
-  .z-neg1-lg { z-index: -1; }
-  .z0-lg { z-index: 0; }
-  .z1-lg { z-index: 1; }
-  .z2-lg { z-index: 2; }
-  .z3-lg { z-index: 3; }
-  .z4-lg { z-index: 4; }
-  .z5-lg { z-index: 5; }
+  .z-neg1-lg { z-index: -1 !important; }
+  .z0-lg { z-index: 0 !important; }
+  .z1-lg { z-index: 1 !important; }
+  .z2-lg { z-index: 2 !important; }
+  .z3-lg { z-index: 3 !important; }
+  .z4-lg { z-index: 4 !important; }
+  .z5-lg { z-index: 5 !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .z-neg1-md { z-index: -1; }
-  .z0-md { z-index: 0; }
-  .z1-md { z-index: 1; }
-  .z2-md { z-index: 2; }
-  .z3-md { z-index: 3; }
-  .z4-md { z-index: 4; }
-  .z5-md { z-index: 5; }
+  .z-neg1-md { z-index: -1 !important; }
+  .z0-md { z-index: 0 !important; }
+  .z1-md { z-index: 1 !important; }
+  .z2-md { z-index: 2 !important; }
+  .z3-md { z-index: 3 !important; }
+  .z4-md { z-index: 4 !important; }
+  .z5-md { z-index: 5 !important; }
 }
 
 @media only screen and (--small-screen) {
-  .z-neg1-sm { z-index: -1; }
-  .z0-sm { z-index: 0; }
-  .z1-sm { z-index: 1; }
-  .z2-sm { z-index: 2; }
-  .z3-sm { z-index: 3; }
-  .z4-sm { z-index: 4; }
-  .z5-sm { z-index: 5; }
+  .z-neg1-sm { z-index: -1 !important; }
+  .z0-sm { z-index: 0 !important; }
+  .z1-sm { z-index: 1 !important; }
+  .z2-sm { z-index: 2 !important; }
+  .z3-sm { z-index: 3 !important; }
+  .z4-sm { z-index: 4 !important; }
+  .z5-sm { z-index: 5 !important; }
 }
 
 /**
@@ -570,635 +570,635 @@
  */
 
 /* Top margins */
-.mt0 { margin-top: 0; }
-.mt5 { margin-top: 5px; }
-.mt10 { margin-top: 10px; }
-.mt15 { margin-top: 15px; }
-.mt20 { margin-top: 20px; }
-.mt30 { margin-top: 30px; }
-.mt40 { margin-top: 40px; }
-.mt50 { margin-top: 50px; }
-.mt60 { margin-top: 60px; }
-.mt80 { margin-top: 80px; }
-.mt100 { margin-top: 100px; }
-.mt120 { margin-top: 120px; }
-.mt140 { margin-top: 140px; }
-.mt160 { margin-top: 160px; }
-.mt180 { margin-top: 180px; }
-.mt200 { margin-top: 200px; }
-.mt400 { margin-top: 400px; }
-.mt600 { margin-top: 600px; }
-.mt800 { margin-top: 800px; }
+.mt0 { margin-top: 0 !important; }
+.mt5 { margin-top: 5px !important; }
+.mt10 { margin-top: 10px !important; }
+.mt15 { margin-top: 15px !important; }
+.mt20 { margin-top: 20px !important; }
+.mt30 { margin-top: 30px !important; }
+.mt40 { margin-top: 40px !important; }
+.mt50 { margin-top: 50px !important; }
+.mt60 { margin-top: 60px !important; }
+.mt80 { margin-top: 80px !important; }
+.mt100 { margin-top: 100px !important; }
+.mt120 { margin-top: 120px !important; }
+.mt140 { margin-top: 140px !important; }
+.mt160 { margin-top: 160px !important; }
+.mt180 { margin-top: 180px !important; }
+.mt200 { margin-top: 200px !important; }
+.mt400 { margin-top: 400px !important; }
+.mt600 { margin-top: 600px !important; }
+.mt800 { margin-top: 800px !important; }
 
 @media only screen and (--large-screen) {
-  .mt0-lg { margin-top: 0; }
-  .mt5-lg { margin-top: 5px; }
-  .mt10-lg { margin-top: 10px; }
-  .mt15-lg { margin-top: 15px; }
-  .mt20-lg { margin-top: 20px; }
-  .mt30-lg { margin-top: 30px; }
-  .mt40-lg { margin-top: 40px; }
-  .mt50-lg { margin-top: 50px; }
-  .mt60-lg { margin-top: 60px; }
-  .mt80-lg { margin-top: 80px; }
-  .mt100-lg { margin-top: 100px; }
-  .mt120-lg { margin-top: 120px; }
-  .mt140-lg { margin-top: 140px; }
-  .mt160-lg { margin-top: 160px; }
-  .mt180-lg { margin-top: 180px; }
-  .mt200-lg { margin-top: 200px; }
-  .mt400-lg { margin-top: 400px; }
-  .mt600-lg { margin-top: 600px; }
-  .mt800-lg { margin-top: 800px; }
+  .mt0-lg { margin-top: 0 !important; }
+  .mt5-lg { margin-top: 5px !important; }
+  .mt10-lg { margin-top: 10px !important; }
+  .mt15-lg { margin-top: 15px !important; }
+  .mt20-lg { margin-top: 20px !important; }
+  .mt30-lg { margin-top: 30px !important; }
+  .mt40-lg { margin-top: 40px !important; }
+  .mt50-lg { margin-top: 50px !important; }
+  .mt60-lg { margin-top: 60px !important; }
+  .mt80-lg { margin-top: 80px !important; }
+  .mt100-lg { margin-top: 100px !important; }
+  .mt120-lg { margin-top: 120px !important; }
+  .mt140-lg { margin-top: 140px !important; }
+  .mt160-lg { margin-top: 160px !important; }
+  .mt180-lg { margin-top: 180px !important; }
+  .mt200-lg { margin-top: 200px !important; }
+  .mt400-lg { margin-top: 400px !important; }
+  .mt600-lg { margin-top: 600px !important; }
+  .mt800-lg { margin-top: 800px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .mt0-md { margin-top: 0; }
-  .mt5-md { margin-top: 5px; }
-  .mt10-md { margin-top: 10px; }
-  .mt15-md { margin-top: 15px; }
-  .mt20-md { margin-top: 20px; }
-  .mt30-md { margin-top: 30px; }
-  .mt40-md { margin-top: 40px; }
-  .mt50-md { margin-top: 50px; }
-  .mt60-md { margin-top: 60px; }
-  .mt80-md { margin-top: 80px; }
-  .mt100-md { margin-top: 100px; }
-  .mt120-md { margin-top: 120px; }
-  .mt140-md { margin-top: 140px; }
-  .mt160-md { margin-top: 160px; }
-  .mt180-md { margin-top: 180px; }
-  .mt200-md { margin-top: 200px; }
-  .mt400-md { margin-top: 400px; }
-  .mt600-md { margin-top: 600px; }
-  .mt800-md { margin-top: 800px; }
+  .mt0-md { margin-top: 0 !important; }
+  .mt5-md { margin-top: 5px !important; }
+  .mt10-md { margin-top: 10px !important; }
+  .mt15-md { margin-top: 15px !important; }
+  .mt20-md { margin-top: 20px !important; }
+  .mt30-md { margin-top: 30px !important; }
+  .mt40-md { margin-top: 40px !important; }
+  .mt50-md { margin-top: 50px !important; }
+  .mt60-md { margin-top: 60px !important; }
+  .mt80-md { margin-top: 80px !important; }
+  .mt100-md { margin-top: 100px !important; }
+  .mt120-md { margin-top: 120px !important; }
+  .mt140-md { margin-top: 140px !important; }
+  .mt160-md { margin-top: 160px !important; }
+  .mt180-md { margin-top: 180px !important; }
+  .mt200-md { margin-top: 200px !important; }
+  .mt400-md { margin-top: 400px !important; }
+  .mt600-md { margin-top: 600px !important; }
+  .mt800-md { margin-top: 800px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .mt0-sm { margin-top: 0; }
-  .mt5-sm { margin-top: 5px; }
-  .mt10-sm { margin-top: 10px; }
-  .mt15-sm { margin-top: 15px; }
-  .mt20-sm { margin-top: 20px; }
-  .mt30-sm { margin-top: 30px; }
-  .mt40-sm { margin-top: 40px; }
-  .mt50-sm { margin-top: 50px; }
-  .mt60-sm { margin-top: 60px; }
-  .mt80-sm { margin-top: 80px; }
-  .mt100-sm { margin-top: 100px; }
-  .mt120-sm { margin-top: 120px; }
-  .mt140-sm { margin-top: 140px; }
-  .mt160-sm { margin-top: 160px; }
-  .mt180-sm { margin-top: 180px; }
-  .mt200-sm { margin-top: 200px; }
-  .mt400-sm { margin-top: 400px; }
-  .mt600-sm { margin-top: 600px; }
-  .mt800-sm { margin-top: 800px; }
+  .mt0-sm { margin-top: 0 !important; }
+  .mt5-sm { margin-top: 5px !important; }
+  .mt10-sm { margin-top: 10px !important; }
+  .mt15-sm { margin-top: 15px !important; }
+  .mt20-sm { margin-top: 20px !important; }
+  .mt30-sm { margin-top: 30px !important; }
+  .mt40-sm { margin-top: 40px !important; }
+  .mt50-sm { margin-top: 50px !important; }
+  .mt60-sm { margin-top: 60px !important; }
+  .mt80-sm { margin-top: 80px !important; }
+  .mt100-sm { margin-top: 100px !important; }
+  .mt120-sm { margin-top: 120px !important; }
+  .mt140-sm { margin-top: 140px !important; }
+  .mt160-sm { margin-top: 160px !important; }
+  .mt180-sm { margin-top: 180px !important; }
+  .mt200-sm { margin-top: 200px !important; }
+  .mt400-sm { margin-top: 400px !important; }
+  .mt600-sm { margin-top: 600px !important; }
+  .mt800-sm { margin-top: 800px !important; }
 }
 
 /* Right margins */
-.mr0 { margin-right: 0; }
-.mr5 { margin-right: 5px; }
-.mr10 { margin-right: 10px; }
-.mr15 { margin-right: 15px; }
-.mr20 { margin-right: 20px; }
-.mr30 { margin-right: 30px; }
-.mr40 { margin-right: 40px; }
-.mr50 { margin-right: 50px; }
-.mr60 { margin-right: 60px; }
-.mr80 { margin-right: 80px; }
-.mr100 { margin-right: 100px; }
-.mr120 { margin-right: 120px; }
-.mr140 { margin-right: 140px; }
-.mr160 { margin-right: 160px; }
-.mr180 { margin-right: 180px; }
-.mr200 { margin-right: 200px; }
-.mr400 { margin-right: 400px; }
-.mr600 { margin-right: 600px; }
-.mr800 { margin-right: 800px; }
+.mr0 { margin-right: 0 !important; }
+.mr5 { margin-right: 5px !important; }
+.mr10 { margin-right: 10px !important; }
+.mr15 { margin-right: 15px !important; }
+.mr20 { margin-right: 20px !important; }
+.mr30 { margin-right: 30px !important; }
+.mr40 { margin-right: 40px !important; }
+.mr50 { margin-right: 50px !important; }
+.mr60 { margin-right: 60px !important; }
+.mr80 { margin-right: 80px !important; }
+.mr100 { margin-right: 100px !important; }
+.mr120 { margin-right: 120px !important; }
+.mr140 { margin-right: 140px !important; }
+.mr160 { margin-right: 160px !important; }
+.mr180 { margin-right: 180px !important; }
+.mr200 { margin-right: 200px !important; }
+.mr400 { margin-right: 400px !important; }
+.mr600 { margin-right: 600px !important; }
+.mr800 { margin-right: 800px !important; }
 
 @media only screen and (--large-screen) {
-  .mr0-lg { margin-right: 0; }
-  .mr5-lg { margin-right: 5px; }
-  .mr10-lg { margin-right: 10px; }
-  .mr15-lg { margin-right: 15px; }
-  .mr20-lg { margin-right: 20px; }
-  .mr30-lg { margin-right: 30px; }
-  .mr40-lg { margin-right: 40px; }
-  .mr50-lg { margin-right: 50px; }
-  .mr60-lg { margin-right: 60px; }
-  .mr80-lg { margin-right: 80px; }
-  .mr100-lg { margin-right: 100px; }
-  .mr120-lg { margin-right: 120px; }
-  .mr140-lg { margin-right: 140px; }
-  .mr160-lg { margin-right: 160px; }
-  .mr180-lg { margin-right: 180px; }
-  .mr200-lg { margin-right: 200px; }
-  .mr400-lg { margin-right: 400px; }
-  .mr600-lg { margin-right: 600px; }
-  .mr800-lg { margin-right: 800px; }
+  .mr0-lg { margin-right: 0 !important; }
+  .mr5-lg { margin-right: 5px !important; }
+  .mr10-lg { margin-right: 10px !important; }
+  .mr15-lg { margin-right: 15px !important; }
+  .mr20-lg { margin-right: 20px !important; }
+  .mr30-lg { margin-right: 30px !important; }
+  .mr40-lg { margin-right: 40px !important; }
+  .mr50-lg { margin-right: 50px !important; }
+  .mr60-lg { margin-right: 60px !important; }
+  .mr80-lg { margin-right: 80px !important; }
+  .mr100-lg { margin-right: 100px !important; }
+  .mr120-lg { margin-right: 120px !important; }
+  .mr140-lg { margin-right: 140px !important; }
+  .mr160-lg { margin-right: 160px !important; }
+  .mr180-lg { margin-right: 180px !important; }
+  .mr200-lg { margin-right: 200px !important; }
+  .mr400-lg { margin-right: 400px !important; }
+  .mr600-lg { margin-right: 600px !important; }
+  .mr800-lg { margin-right: 800px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .mr0-md { margin-right: 0; }
-  .mr5-md { margin-right: 5px; }
-  .mr10-md { margin-right: 10px; }
-  .mr15-md { margin-right: 15px; }
-  .mr20-md { margin-right: 20px; }
-  .mr30-md { margin-right: 30px; }
-  .mr40-md { margin-right: 40px; }
-  .mr50-md { margin-right: 50px; }
-  .mr60-md { margin-right: 60px; }
-  .mr80-md { margin-right: 80px; }
-  .mr100-md { margin-right: 100px; }
-  .mr120-md { margin-right: 120px; }
-  .mr140-md { margin-right: 140px; }
-  .mr160-md { margin-right: 160px; }
-  .mr180-md { margin-right: 180px; }
-  .mr200-md { margin-right: 200px; }
-  .mr400-md { margin-right: 400px; }
-  .mr600-md { margin-right: 600px; }
-  .mr800-md { margin-right: 800px; }
+  .mr0-md { margin-right: 0 !important; }
+  .mr5-md { margin-right: 5px !important; }
+  .mr10-md { margin-right: 10px !important; }
+  .mr15-md { margin-right: 15px !important; }
+  .mr20-md { margin-right: 20px !important; }
+  .mr30-md { margin-right: 30px !important; }
+  .mr40-md { margin-right: 40px !important; }
+  .mr50-md { margin-right: 50px !important; }
+  .mr60-md { margin-right: 60px !important; }
+  .mr80-md { margin-right: 80px !important; }
+  .mr100-md { margin-right: 100px !important; }
+  .mr120-md { margin-right: 120px !important; }
+  .mr140-md { margin-right: 140px !important; }
+  .mr160-md { margin-right: 160px !important; }
+  .mr180-md { margin-right: 180px !important; }
+  .mr200-md { margin-right: 200px !important; }
+  .mr400-md { margin-right: 400px !important; }
+  .mr600-md { margin-right: 600px !important; }
+  .mr800-md { margin-right: 800px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .mr0-sm { margin-right: 0; }
-  .mr5-sm { margin-right: 5px; }
-  .mr10-sm { margin-right: 10px; }
-  .mr15-sm { margin-right: 15px; }
-  .mr20-sm { margin-right: 20px; }
-  .mr30-sm { margin-right: 30px; }
-  .mr40-sm { margin-right: 40px; }
-  .mr50-sm { margin-right: 50px; }
-  .mr60-sm { margin-right: 60px; }
-  .mr80-sm { margin-right: 80px; }
-  .mr100-sm { margin-right: 100px; }
-  .mr120-sm { margin-right: 120px; }
-  .mr140-sm { margin-right: 140px; }
-  .mr160-sm { margin-right: 160px; }
-  .mr180-sm { margin-right: 180px; }
-  .mr200-sm { margin-right: 200px; }
-  .mr400-sm { margin-right: 400px; }
-  .mr600-sm { margin-right: 600px; }
-  .mr800-sm { margin-right: 800px; }
+  .mr0-sm { margin-right: 0 !important; }
+  .mr5-sm { margin-right: 5px !important; }
+  .mr10-sm { margin-right: 10px !important; }
+  .mr15-sm { margin-right: 15px !important; }
+  .mr20-sm { margin-right: 20px !important; }
+  .mr30-sm { margin-right: 30px !important; }
+  .mr40-sm { margin-right: 40px !important; }
+  .mr50-sm { margin-right: 50px !important; }
+  .mr60-sm { margin-right: 60px !important; }
+  .mr80-sm { margin-right: 80px !important; }
+  .mr100-sm { margin-right: 100px !important; }
+  .mr120-sm { margin-right: 120px !important; }
+  .mr140-sm { margin-right: 140px !important; }
+  .mr160-sm { margin-right: 160px !important; }
+  .mr180-sm { margin-right: 180px !important; }
+  .mr200-sm { margin-right: 200px !important; }
+  .mr400-sm { margin-right: 400px !important; }
+  .mr600-sm { margin-right: 600px !important; }
+  .mr800-sm { margin-right: 800px !important; }
 }
 
 /* Bottom margins */
-.mb-neg1 { margin-bottom: -1px; }
-.mb-neg2 { margin-bottom: -2px; }
-.mb0 { margin-bottom: 0; }
-.mb5 { margin-bottom: 5px; }
-.mb10 { margin-bottom: 10px; }
-.mb15 { margin-bottom: 15px; }
-.mb20 { margin-bottom: 20px; }
-.mb30 { margin-bottom: 30px; }
-.mb40 { margin-bottom: 40px; }
-.mb50 { margin-bottom: 50px; }
-.mb60 { margin-bottom: 60px; }
-.mb80 { margin-bottom: 80px; }
-.mb100 { margin-bottom: 100px; }
-.mb120 { margin-bottom: 120px; }
-.mb140 { margin-bottom: 140px; }
-.mb160 { margin-bottom: 160px; }
-.mb180 { margin-bottom: 180px; }
-.mb200 { margin-bottom: 200px; }
-.mb400 { margin-bottom: 400px; }
-.mb600 { margin-bottom: 600px; }
-.mb800 { margin-bottom: 800px; }
+.mb-neg1 { margin-bottom: -1px !important; }
+.mb-neg2 { margin-bottom: -2px !important; }
+.mb0 { margin-bottom: 0 !important; }
+.mb5 { margin-bottom: 5px !important; }
+.mb10 { margin-bottom: 10px !important; }
+.mb15 { margin-bottom: 15px !important; }
+.mb20 { margin-bottom: 20px !important; }
+.mb30 { margin-bottom: 30px !important; }
+.mb40 { margin-bottom: 40px !important; }
+.mb50 { margin-bottom: 50px !important; }
+.mb60 { margin-bottom: 60px !important; }
+.mb80 { margin-bottom: 80px !important; }
+.mb100 { margin-bottom: 100px !important; }
+.mb120 { margin-bottom: 120px !important; }
+.mb140 { margin-bottom: 140px !important; }
+.mb160 { margin-bottom: 160px !important; }
+.mb180 { margin-bottom: 180px !important; }
+.mb200 { margin-bottom: 200px !important; }
+.mb400 { margin-bottom: 400px !important; }
+.mb600 { margin-bottom: 600px !important; }
+.mb800 { margin-bottom: 800px !important; }
 
 @media only screen and (--large-screen) {
-  .mb-neg1-lg { margin-bottom: -1px; }
-  .mb-neg2-lg { margin-bottom: -2px; }
-  .mb0-lg { margin-bottom: 0; }
-  .mb5-lg { margin-bottom: 5px; }
-  .mb10-lg { margin-bottom: 10px; }
-  .mb15-lg { margin-bottom: 15px; }
-  .mb20-lg { margin-bottom: 20px; }
-  .mb30-lg { margin-bottom: 30px; }
-  .mb40-lg { margin-bottom: 40px; }
-  .mb50-lg { margin-bottom: 50px; }
-  .mb60-lg { margin-bottom: 60px; }
-  .mb80-lg { margin-bottom: 80px; }
-  .mb100-lg { margin-bottom: 100px; }
-  .mb120-lg { margin-bottom: 120px; }
-  .mb140-lg { margin-bottom: 140px; }
-  .mb160-lg { margin-bottom: 160px; }
-  .mb180-lg { margin-bottom: 180px; }
-  .mb200-lg { margin-bottom: 200px; }
-  .mb400-lg { margin-bottom: 400px; }
-  .mb600-lg { margin-bottom: 600px; }
-  .mb800-lg { margin-bottom: 800px; }
+  .mb-neg1-lg { margin-bottom: -1px !important; }
+  .mb-neg2-lg { margin-bottom: -2px !important; }
+  .mb0-lg { margin-bottom: 0 !important; }
+  .mb5-lg { margin-bottom: 5px !important; }
+  .mb10-lg { margin-bottom: 10px !important; }
+  .mb15-lg { margin-bottom: 15px !important; }
+  .mb20-lg { margin-bottom: 20px !important; }
+  .mb30-lg { margin-bottom: 30px !important; }
+  .mb40-lg { margin-bottom: 40px !important; }
+  .mb50-lg { margin-bottom: 50px !important; }
+  .mb60-lg { margin-bottom: 60px !important; }
+  .mb80-lg { margin-bottom: 80px !important; }
+  .mb100-lg { margin-bottom: 100px !important; }
+  .mb120-lg { margin-bottom: 120px !important; }
+  .mb140-lg { margin-bottom: 140px !important; }
+  .mb160-lg { margin-bottom: 160px !important; }
+  .mb180-lg { margin-bottom: 180px !important; }
+  .mb200-lg { margin-bottom: 200px !important; }
+  .mb400-lg { margin-bottom: 400px !important; }
+  .mb600-lg { margin-bottom: 600px !important; }
+  .mb800-lg { margin-bottom: 800px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .mb-neg1-md { margin-bottom: -1px; }
-  .mb-neg2-md { margin-bottom: -2px; }
-  .mb0-md { margin-bottom: 0; }
-  .mb5-md { margin-bottom: 5px; }
-  .mb10-md { margin-bottom: 10px; }
-  .mb15-md { margin-bottom: 15px; }
-  .mb20-md { margin-bottom: 20px; }
-  .mb30-md { margin-bottom: 30px; }
-  .mb40-md { margin-bottom: 40px; }
-  .mb50-md { margin-bottom: 50px; }
-  .mb60-md { margin-bottom: 60px; }
-  .mb80-md { margin-bottom: 80px; }
-  .mb100-md { margin-bottom: 100px; }
-  .mb120-md { margin-bottom: 120px; }
-  .mb140-md { margin-bottom: 140px; }
-  .mb160-md { margin-bottom: 160px; }
-  .mb180-md { margin-bottom: 180px; }
-  .mb200-md { margin-bottom: 200px; }
-  .mb400-md { margin-bottom: 400px; }
-  .mb600-md { margin-bottom: 600px; }
-  .mb800-md { margin-bottom: 800px; }
+  .mb-neg1-md { margin-bottom: -1px !important; }
+  .mb-neg2-md { margin-bottom: -2px !important; }
+  .mb0-md { margin-bottom: 0 !important; }
+  .mb5-md { margin-bottom: 5px !important; }
+  .mb10-md { margin-bottom: 10px !important; }
+  .mb15-md { margin-bottom: 15px !important; }
+  .mb20-md { margin-bottom: 20px !important; }
+  .mb30-md { margin-bottom: 30px !important; }
+  .mb40-md { margin-bottom: 40px !important; }
+  .mb50-md { margin-bottom: 50px !important; }
+  .mb60-md { margin-bottom: 60px !important; }
+  .mb80-md { margin-bottom: 80px !important; }
+  .mb100-md { margin-bottom: 100px !important; }
+  .mb120-md { margin-bottom: 120px !important; }
+  .mb140-md { margin-bottom: 140px !important; }
+  .mb160-md { margin-bottom: 160px !important; }
+  .mb180-md { margin-bottom: 180px !important; }
+  .mb200-md { margin-bottom: 200px !important; }
+  .mb400-md { margin-bottom: 400px !important; }
+  .mb600-md { margin-bottom: 600px !important; }
+  .mb800-md { margin-bottom: 800px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .mb-neg1-sm { margin-bottom: -1px; }
-  .mb-neg2-sm { margin-bottom: -2px; }
-  .mb0-sm { margin-bottom: 0; }
-  .mb5-sm { margin-bottom: 5px; }
-  .mb10-sm { margin-bottom: 10px; }
-  .mb15-sm { margin-bottom: 15px; }
-  .mb20-sm { margin-bottom: 20px; }
-  .mb30-sm { margin-bottom: 30px; }
-  .mb40-sm { margin-bottom: 40px; }
-  .mb50-sm { margin-bottom: 50px; }
-  .mb60-sm { margin-bottom: 60px; }
-  .mb80-sm { margin-bottom: 80px; }
-  .mb100-sm { margin-bottom: 100px; }
-  .mb120-sm { margin-bottom: 120px; }
-  .mb140-sm { margin-bottom: 140px; }
-  .mb160-sm { margin-bottom: 160px; }
-  .mb180-sm { margin-bottom: 180px; }
-  .mb200-sm { margin-bottom: 200px; }
-  .mb400-sm { margin-bottom: 400px; }
-  .mb600-sm { margin-bottom: 600px; }
-  .mb800-sm { margin-bottom: 800px; }
+  .mb-neg1-sm { margin-bottom: -1px !important; }
+  .mb-neg2-sm { margin-bottom: -2px !important; }
+  .mb0-sm { margin-bottom: 0 !important; }
+  .mb5-sm { margin-bottom: 5px !important; }
+  .mb10-sm { margin-bottom: 10px !important; }
+  .mb15-sm { margin-bottom: 15px !important; }
+  .mb20-sm { margin-bottom: 20px !important; }
+  .mb30-sm { margin-bottom: 30px !important; }
+  .mb40-sm { margin-bottom: 40px !important; }
+  .mb50-sm { margin-bottom: 50px !important; }
+  .mb60-sm { margin-bottom: 60px !important; }
+  .mb80-sm { margin-bottom: 80px !important; }
+  .mb100-sm { margin-bottom: 100px !important; }
+  .mb120-sm { margin-bottom: 120px !important; }
+  .mb140-sm { margin-bottom: 140px !important; }
+  .mb160-sm { margin-bottom: 160px !important; }
+  .mb180-sm { margin-bottom: 180px !important; }
+  .mb200-sm { margin-bottom: 200px !important; }
+  .mb400-sm { margin-bottom: 400px !important; }
+  .mb600-sm { margin-bottom: 600px !important; }
+  .mb800-sm { margin-bottom: 800px !important; }
 }
 
 /* Left margins */
-.ml0 { margin-left: 0; }
-.ml5 { margin-left: 5px; }
-.ml10 { margin-left: 10px; }
-.ml15 { margin-left: 15px; }
-.ml20 { margin-left: 20px; }
-.ml30 { margin-left: 30px; }
-.ml40 { margin-left: 40px; }
-.ml50 { margin-left: 50px; }
-.ml60 { margin-left: 60px; }
-.ml80 { margin-left: 80px; }
-.ml100 { margin-left: 100px; }
-.ml120 { margin-left: 120px; }
-.ml140 { margin-left: 140px; }
-.ml160 { margin-left: 160px; }
-.ml180 { margin-left: 180px; }
-.ml200 { margin-left: 200px; }
-.ml400 { margin-left: 400px; }
-.ml600 { margin-left: 600px; }
-.ml800 { margin-left: 800px; }
+.ml0 { margin-left: 0 !important; }
+.ml5 { margin-left: 5px !important; }
+.ml10 { margin-left: 10px !important; }
+.ml15 { margin-left: 15px !important; }
+.ml20 { margin-left: 20px !important; }
+.ml30 { margin-left: 30px !important; }
+.ml40 { margin-left: 40px !important; }
+.ml50 { margin-left: 50px !important; }
+.ml60 { margin-left: 60px !important; }
+.ml80 { margin-left: 80px !important; }
+.ml100 { margin-left: 100px !important; }
+.ml120 { margin-left: 120px !important; }
+.ml140 { margin-left: 140px !important; }
+.ml160 { margin-left: 160px !important; }
+.ml180 { margin-left: 180px !important; }
+.ml200 { margin-left: 200px !important; }
+.ml400 { margin-left: 400px !important; }
+.ml600 { margin-left: 600px !important; }
+.ml800 { margin-left: 800px !important; }
 
 @media only screen and (--large-screen) {
-  .ml0-lg { margin-left: 0; }
-  .ml5-lg { margin-left: 5px; }
-  .ml10-lg { margin-left: 10px; }
-  .ml15-lg { margin-left: 15px; }
-  .ml20-lg { margin-left: 20px; }
-  .ml30-lg { margin-left: 30px; }
-  .ml40-lg { margin-left: 40px; }
-  .ml50-lg { margin-left: 50px; }
-  .ml60-lg { margin-left: 60px; }
-  .ml80-lg { margin-left: 80px; }
-  .ml100-lg { margin-left: 100px; }
-  .ml120-lg { margin-left: 120px; }
-  .ml140-lg { margin-left: 140px; }
-  .ml160-lg { margin-left: 160px; }
-  .ml180-lg { margin-left: 180px; }
-  .ml200-lg { margin-left: 200px; }
-  .ml400-lg { margin-left: 400px; }
-  .ml600-lg { margin-left: 600px; }
-  .ml800-lg { margin-left: 800px; }
+  .ml0-lg { margin-left: 0 !important; }
+  .ml5-lg { margin-left: 5px !important; }
+  .ml10-lg { margin-left: 10px !important; }
+  .ml15-lg { margin-left: 15px !important; }
+  .ml20-lg { margin-left: 20px !important; }
+  .ml30-lg { margin-left: 30px !important; }
+  .ml40-lg { margin-left: 40px !important; }
+  .ml50-lg { margin-left: 50px !important; }
+  .ml60-lg { margin-left: 60px !important; }
+  .ml80-lg { margin-left: 80px !important; }
+  .ml100-lg { margin-left: 100px !important; }
+  .ml120-lg { margin-left: 120px !important; }
+  .ml140-lg { margin-left: 140px !important; }
+  .ml160-lg { margin-left: 160px !important; }
+  .ml180-lg { margin-left: 180px !important; }
+  .ml200-lg { margin-left: 200px !important; }
+  .ml400-lg { margin-left: 400px !important; }
+  .ml600-lg { margin-left: 600px !important; }
+  .ml800-lg { margin-left: 800px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .ml0-md { margin-left: 0; }
-  .ml5-md { margin-left: 5px; }
-  .ml10-md { margin-left: 10px; }
-  .ml15-md { margin-left: 15px; }
-  .ml20-md { margin-left: 20px; }
-  .ml30-md { margin-left: 30px; }
-  .ml40-md { margin-left: 40px; }
-  .ml50-md { margin-left: 50px; }
-  .ml60-md { margin-left: 60px; }
-  .ml80-md { margin-left: 80px; }
-  .ml100-md { margin-left: 100px; }
-  .ml120-md { margin-left: 120px; }
-  .ml140-md { margin-left: 140px; }
-  .ml160-md { margin-left: 160px; }
-  .ml180-md { margin-left: 180px; }
-  .ml200-md { margin-left: 200px; }
-  .ml400-md { margin-left: 400px; }
-  .ml600-md { margin-left: 600px; }
-  .ml800-md { margin-left: 800px; }
+  .ml0-md { margin-left: 0 !important; }
+  .ml5-md { margin-left: 5px !important; }
+  .ml10-md { margin-left: 10px !important; }
+  .ml15-md { margin-left: 15px !important; }
+  .ml20-md { margin-left: 20px !important; }
+  .ml30-md { margin-left: 30px !important; }
+  .ml40-md { margin-left: 40px !important; }
+  .ml50-md { margin-left: 50px !important; }
+  .ml60-md { margin-left: 60px !important; }
+  .ml80-md { margin-left: 80px !important; }
+  .ml100-md { margin-left: 100px !important; }
+  .ml120-md { margin-left: 120px !important; }
+  .ml140-md { margin-left: 140px !important; }
+  .ml160-md { margin-left: 160px !important; }
+  .ml180-md { margin-left: 180px !important; }
+  .ml200-md { margin-left: 200px !important; }
+  .ml400-md { margin-left: 400px !important; }
+  .ml600-md { margin-left: 600px !important; }
+  .ml800-md { margin-left: 800px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .ml0-sm { margin-left: 0; }
-  .ml5-sm { margin-left: 5px; }
-  .ml10-sm { margin-left: 10px; }
-  .ml15-sm { margin-left: 15px; }
-  .ml20-sm { margin-left: 20px; }
-  .ml30-sm { margin-left: 30px; }
-  .ml40-sm { margin-left: 40px; }
-  .ml50-sm { margin-left: 50px; }
-  .ml60-sm { margin-left: 60px; }
-  .ml80-sm { margin-left: 80px; }
-  .ml100-sm { margin-left: 100px; }
-  .ml120-sm { margin-left: 120px; }
-  .ml140-sm { margin-left: 140px; }
-  .ml160-sm { margin-left: 160px; }
-  .ml180-sm { margin-left: 180px; }
-  .ml200-sm { margin-left: 200px; }
-  .ml400-sm { margin-left: 400px; }
-  .ml600-sm { margin-left: 600px; }
-  .ml800-sm { margin-left: 800px; }
+  .ml0-sm { margin-left: 0 !important; }
+  .ml5-sm { margin-left: 5px !important; }
+  .ml10-sm { margin-left: 10px !important; }
+  .ml15-sm { margin-left: 15px !important; }
+  .ml20-sm { margin-left: 20px !important; }
+  .ml30-sm { margin-left: 30px !important; }
+  .ml40-sm { margin-left: 40px !important; }
+  .ml50-sm { margin-left: 50px !important; }
+  .ml60-sm { margin-left: 60px !important; }
+  .ml80-sm { margin-left: 80px !important; }
+  .ml100-sm { margin-left: 100px !important; }
+  .ml120-sm { margin-left: 120px !important; }
+  .ml140-sm { margin-left: 140px !important; }
+  .ml160-sm { margin-left: 160px !important; }
+  .ml180-sm { margin-left: 180px !important; }
+  .ml200-sm { margin-left: 200px !important; }
+  .ml400-sm { margin-left: 400px !important; }
+  .ml600-sm { margin-left: 600px !important; }
+  .ml800-sm { margin-left: 800px !important; }
 }
 
 /* Padding on all sides */
-.p0 { padding: 0; }
-.p5 { padding: 5px; }
-.p10 { padding: 10px; }
-.p15 { padding: 15px; }
-.p20 { padding: 20px; }
-.p30 { padding: 30px; }
-.p40 { padding: 40px; }
-.p45 { padding: 50px; }
-.p60 { padding: 60px; }
-.p80 { padding: 80px; }
-.p100 { padding: 100px; }
+.p0 { padding: 0 !important; }
+.p5 { padding: 5px !important; }
+.p10 { padding: 10px !important; }
+.p15 { padding: 15px !important; }
+.p20 { padding: 20px !important; }
+.p30 { padding: 30px !important; }
+.p40 { padding: 40px !important; }
+.p45 { padding: 50px !important; }
+.p60 { padding: 60px !important; }
+.p80 { padding: 80px !important; }
+.p100 { padding: 100px !important; }
 
 @media only screen and (--large-screen) {
-  .p0-lg { padding: 0; }
-  .p5-lg { padding: 5px; }
-  .p10-lg { padding: 10px; }
-  .p15-lg { padding: 15px; }
-  .p20-lg { padding: 20px; }
-  .p30-lg { padding: 30px; }
-  .p40-lg { padding: 40px; }
-  .p45-lg { padding: 50px; }
-  .p60-lg { padding: 60px; }
-  .p80-lg { padding: 80px; }
-  .p100-lg { padding: 100px; }
+  .p0-lg { padding: 0 !important; }
+  .p5-lg { padding: 5px !important; }
+  .p10-lg { padding: 10px !important; }
+  .p15-lg { padding: 15px !important; }
+  .p20-lg { padding: 20px !important; }
+  .p30-lg { padding: 30px !important; }
+  .p40-lg { padding: 40px !important; }
+  .p45-lg { padding: 50px !important; }
+  .p60-lg { padding: 60px !important; }
+  .p80-lg { padding: 80px !important; }
+  .p100-lg { padding: 100px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .p0-md { padding: 0; }
-  .p5-md { padding: 5px; }
-  .p10-md { padding: 10px; }
-  .p15-md { padding: 15px; }
-  .p20-md { padding: 20px; }
-  .p30-md { padding: 30px; }
-  .p40-md { padding: 40px; }
-  .p45-md { padding: 50px; }
-  .p60-md { padding: 60px; }
-  .p80-md { padding: 80px; }
-  .p100-md { padding: 100px; }
+  .p0-md { padding: 0 !important; }
+  .p5-md { padding: 5px !important; }
+  .p10-md { padding: 10px !important; }
+  .p15-md { padding: 15px !important; }
+  .p20-md { padding: 20px !important; }
+  .p30-md { padding: 30px !important; }
+  .p40-md { padding: 40px !important; }
+  .p45-md { padding: 50px !important; }
+  .p60-md { padding: 60px !important; }
+  .p80-md { padding: 80px !important; }
+  .p100-md { padding: 100px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .p0-sm { padding: 0; }
-  .p5-sm { padding: 5px; }
-  .p10-sm { padding: 10px; }
-  .p15-sm { padding: 15px; }
-  .p20-sm { padding: 20px; }
-  .p30-sm { padding: 30px; }
-  .p40-sm { padding: 40px; }
-  .p45-sm { padding: 50px; }
-  .p60-sm { padding: 60px; }
-  .p80-sm { padding: 80px; }
-  .p100-sm { padding: 100px; }
+  .p0-sm { padding: 0 !important; }
+  .p5-sm { padding: 5px !important; }
+  .p10-sm { padding: 10px !important; }
+  .p15-sm { padding: 15px !important; }
+  .p20-sm { padding: 20px !important; }
+  .p30-sm { padding: 30px !important; }
+  .p40-sm { padding: 40px !important; }
+  .p45-sm { padding: 50px !important; }
+  .p60-sm { padding: 60px !important; }
+  .p80-sm { padding: 80px !important; }
+  .p100-sm { padding: 100px !important; }
 }
 
 /* Top padding */
-.pt0 { padding-top: 0; }
-.pt5 { padding-top: 5px; }
-.pt10 { padding-top: 10px; }
-.pt15 { padding-top: 15px; }
-.pt20 { padding-top: 20px; }
-.pt30 { padding-top: 30px; }
-.pt40 { padding-top: 40px; }
-.pt50 { padding-top: 50px; }
-.pt60 { padding-top: 60px; }
-.pt80 { padding-top: 80px; }
-.pt100 { padding-top: 100px; }
+.pt0 { padding-top: 0 !important; }
+.pt5 { padding-top: 5px !important; }
+.pt10 { padding-top: 10px !important; }
+.pt15 { padding-top: 15px !important; }
+.pt20 { padding-top: 20px !important; }
+.pt30 { padding-top: 30px !important; }
+.pt40 { padding-top: 40px !important; }
+.pt50 { padding-top: 50px !important; }
+.pt60 { padding-top: 60px !important; }
+.pt80 { padding-top: 80px !important; }
+.pt100 { padding-top: 100px !important; }
 
 @media only screen and (--large-screen) {
-  .pt0-lg { padding-top: 0; }
-  .pt5-lg { padding-top: 5px; }
-  .pt10-lg { padding-top: 10px; }
-  .pt15-lg { padding-top: 15px; }
-  .pt20-lg { padding-top: 20px; }
-  .pt30-lg { padding-top: 30px; }
-  .pt40-lg { padding-top: 40px; }
-  .pt50-lg { padding-top: 50px; }
-  .pt60-lg { padding-top: 60px; }
-  .pt80-lg { padding-top: 80px; }
-  .pt100-lg { padding-top: 100px; }
+  .pt0-lg { padding-top: 0 !important; }
+  .pt5-lg { padding-top: 5px !important; }
+  .pt10-lg { padding-top: 10px !important; }
+  .pt15-lg { padding-top: 15px !important; }
+  .pt20-lg { padding-top: 20px !important; }
+  .pt30-lg { padding-top: 30px !important; }
+  .pt40-lg { padding-top: 40px !important; }
+  .pt50-lg { padding-top: 50px !important; }
+  .pt60-lg { padding-top: 60px !important; }
+  .pt80-lg { padding-top: 80px !important; }
+  .pt100-lg { padding-top: 100px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .pt0-md { padding-top: 0; }
-  .pt5-md { padding-top: 5px; }
-  .pt10-md { padding-top: 10px; }
-  .pt15-md { padding-top: 15px; }
-  .pt20-md { padding-top: 20px; }
-  .pt30-md { padding-top: 30px; }
-  .pt40-md { padding-top: 40px; }
-  .pt50-md { padding-top: 50px; }
-  .pt60-md { padding-top: 60px; }
-  .pt80-md { padding-top: 80px; }
-  .pt100-md { padding-top: 100px; }
+  .pt0-md { padding-top: 0 !important; }
+  .pt5-md { padding-top: 5px !important; }
+  .pt10-md { padding-top: 10px !important; }
+  .pt15-md { padding-top: 15px !important; }
+  .pt20-md { padding-top: 20px !important; }
+  .pt30-md { padding-top: 30px !important; }
+  .pt40-md { padding-top: 40px !important; }
+  .pt50-md { padding-top: 50px !important; }
+  .pt60-md { padding-top: 60px !important; }
+  .pt80-md { padding-top: 80px !important; }
+  .pt100-md { padding-top: 100px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .pt0-sm { padding-top: 0; }
-  .pt5-sm { padding-top: 5px; }
-  .pt10-sm { padding-top: 10px; }
-  .pt15-sm { padding-top: 15px; }
-  .pt20-sm { padding-top: 20px; }
-  .pt30-sm { padding-top: 30px; }
-  .pt40-sm { padding-top: 40px; }
-  .pt50-sm { padding-top: 50px; }
-  .pt60-sm { padding-top: 60px; }
-  .pt80-sm { padding-top: 80px; }
-  .pt100-sm { padding-top: 100px; }
+  .pt0-sm { padding-top: 0 !important; }
+  .pt5-sm { padding-top: 5px !important; }
+  .pt10-sm { padding-top: 10px !important; }
+  .pt15-sm { padding-top: 15px !important; }
+  .pt20-sm { padding-top: 20px !important; }
+  .pt30-sm { padding-top: 30px !important; }
+  .pt40-sm { padding-top: 40px !important; }
+  .pt50-sm { padding-top: 50px !important; }
+  .pt60-sm { padding-top: 60px !important; }
+  .pt80-sm { padding-top: 80px !important; }
+  .pt100-sm { padding-top: 100px !important; }
 }
 
 /* Right padding */
-.pr0 { padding-right: 0; }
-.pr5 { padding-right: 5px; }
-.pr10 { padding-right: 10px; }
-.pr15 { padding-right: 15px; }
-.pr20 { padding-right: 20px; }
-.pr30 { padding-right: 30px; }
-.pr40 { padding-right: 40px; }
-.pr50 { padding-right: 50px; }
-.pr60 { padding-right: 60px; }
-.pr80 { padding-right: 80px; }
-.pr100 { padding-right: 100px; }
+.pr0 { padding-right: 0 !important; }
+.pr5 { padding-right: 5px !important; }
+.pr10 { padding-right: 10px !important; }
+.pr15 { padding-right: 15px !important; }
+.pr20 { padding-right: 20px !important; }
+.pr30 { padding-right: 30px !important; }
+.pr40 { padding-right: 40px !important; }
+.pr50 { padding-right: 50px !important; }
+.pr60 { padding-right: 60px !important; }
+.pr80 { padding-right: 80px !important; }
+.pr100 { padding-right: 100px !important; }
 
 @media only screen and (--large-screen) {
-  .pr0-lg { padding-right: 0; }
-  .pr5-lg { padding-right: 5px; }
-  .pr10-lg { padding-right: 10px; }
-  .pr15-lg { padding-right: 15px; }
-  .pr20-lg { padding-right: 20px; }
-  .pr30-lg { padding-right: 30px; }
-  .pr40-lg { padding-right: 40px; }
-  .pr50-lg { padding-right: 50px; }
-  .pr60-lg { padding-right: 60px; }
-  .pr80-lg { padding-right: 80px; }
-  .pr100-lg { padding-right: 100px; }
+  .pr0-lg { padding-right: 0 !important; }
+  .pr5-lg { padding-right: 5px !important; }
+  .pr10-lg { padding-right: 10px !important; }
+  .pr15-lg { padding-right: 15px !important; }
+  .pr20-lg { padding-right: 20px !important; }
+  .pr30-lg { padding-right: 30px !important; }
+  .pr40-lg { padding-right: 40px !important; }
+  .pr50-lg { padding-right: 50px !important; }
+  .pr60-lg { padding-right: 60px !important; }
+  .pr80-lg { padding-right: 80px !important; }
+  .pr100-lg { padding-right: 100px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .pr0-md { padding-right: 0; }
-  .pr5-md { padding-right: 5px; }
-  .pr10-md { padding-right: 10px; }
-  .pr15-md { padding-right: 15px; }
-  .pr20-md { padding-right: 20px; }
-  .pr30-md { padding-right: 30px; }
-  .pr40-md { padding-right: 40px; }
-  .pr50-md { padding-right: 50px; }
-  .pr60-md { padding-right: 60px; }
-  .pr80-md { padding-right: 80px; }
-  .pr100-md { padding-right: 100px; }
+  .pr0-md { padding-right: 0 !important; }
+  .pr5-md { padding-right: 5px !important; }
+  .pr10-md { padding-right: 10px !important; }
+  .pr15-md { padding-right: 15px !important; }
+  .pr20-md { padding-right: 20px !important; }
+  .pr30-md { padding-right: 30px !important; }
+  .pr40-md { padding-right: 40px !important; }
+  .pr50-md { padding-right: 50px !important; }
+  .pr60-md { padding-right: 60px !important; }
+  .pr80-md { padding-right: 80px !important; }
+  .pr100-md { padding-right: 100px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .pr0-sm { padding-right: 0; }
-  .pr5-sm { padding-right: 5px; }
-  .pr10-sm { padding-right: 10px; }
-  .pr15-sm { padding-right: 15px; }
-  .pr20-sm { padding-right: 20px; }
-  .pr30-sm { padding-right: 30px; }
-  .pr40-sm { padding-right: 40px; }
-  .pr50-sm { padding-right: 50px; }
-  .pr60-sm { padding-right: 60px; }
-  .pr80-sm { padding-right: 80px; }
-  .pr100-sm { padding-right: 100px; }
+  .pr0-sm { padding-right: 0 !important; }
+  .pr5-sm { padding-right: 5px !important; }
+  .pr10-sm { padding-right: 10px !important; }
+  .pr15-sm { padding-right: 15px !important; }
+  .pr20-sm { padding-right: 20px !important; }
+  .pr30-sm { padding-right: 30px !important; }
+  .pr40-sm { padding-right: 40px !important; }
+  .pr50-sm { padding-right: 50px !important; }
+  .pr60-sm { padding-right: 60px !important; }
+  .pr80-sm { padding-right: 80px !important; }
+  .pr100-sm { padding-right: 100px !important; }
 }
 
 /* Bottom padding */
-.pb0 { padding-bottom: 0; }
-.pb5 { padding-bottom: 5px; }
-.pb10 { padding-bottom: 10px; }
-.pb15 { padding-bottom: 15px; }
-.pb20 { padding-bottom: 20px; }
-.pb30 { padding-bottom: 30px; }
-.pb40 { padding-bottom: 40px; }
-.pb50 { padding-bottom: 50px; }
-.pb60 { padding-bottom: 60px; }
-.pb80 { padding-bottom: 80px; }
-.pb100 { padding-bottom: 100px; }
+.pb0 { padding-bottom: 0 !important; }
+.pb5 { padding-bottom: 5px !important; }
+.pb10 { padding-bottom: 10px !important; }
+.pb15 { padding-bottom: 15px !important; }
+.pb20 { padding-bottom: 20px !important; }
+.pb30 { padding-bottom: 30px !important; }
+.pb40 { padding-bottom: 40px !important; }
+.pb50 { padding-bottom: 50px !important; }
+.pb60 { padding-bottom: 60px !important; }
+.pb80 { padding-bottom: 80px !important; }
+.pb100 { padding-bottom: 100px !important; }
 
 @media only screen and (--large-screen) {
-  .pb0-lg { padding-bottom: 0; }
-  .pb5-lg { padding-bottom: 5px; }
-  .pb10-lg { padding-bottom: 10px; }
-  .pb15-lg { padding-bottom: 15px; }
-  .pb20-lg { padding-bottom: 20px; }
-  .pb30-lg { padding-bottom: 30px; }
-  .pb40-lg { padding-bottom: 40px; }
-  .pb50-lg { padding-bottom: 50px; }
-  .pb60-lg { padding-bottom: 60px; }
-  .pb80-lg { padding-bottom: 80px; }
-  .pb100-lg { padding-bottom: 100px; }
+  .pb0-lg { padding-bottom: 0 !important; }
+  .pb5-lg { padding-bottom: 5px !important; }
+  .pb10-lg { padding-bottom: 10px !important; }
+  .pb15-lg { padding-bottom: 15px !important; }
+  .pb20-lg { padding-bottom: 20px !important; }
+  .pb30-lg { padding-bottom: 30px !important; }
+  .pb40-lg { padding-bottom: 40px !important; }
+  .pb50-lg { padding-bottom: 50px !important; }
+  .pb60-lg { padding-bottom: 60px !important; }
+  .pb80-lg { padding-bottom: 80px !important; }
+  .pb100-lg { padding-bottom: 100px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .pb0-md { padding-bottom: 0; }
-  .pb5-md { padding-bottom: 5px; }
-  .pb10-md { padding-bottom: 10px; }
-  .pb15-md { padding-bottom: 15px; }
-  .pb20-md { padding-bottom: 20px; }
-  .pb30-md { padding-bottom: 30px; }
-  .pb40-md { padding-bottom: 40px; }
-  .pb50-md { padding-bottom: 50px; }
-  .pb60-md { padding-bottom: 60px; }
-  .pb80-md { padding-bottom: 80px; }
-  .pb100-md { padding-bottom: 100px; }
+  .pb0-md { padding-bottom: 0 !important; }
+  .pb5-md { padding-bottom: 5px !important; }
+  .pb10-md { padding-bottom: 10px !important; }
+  .pb15-md { padding-bottom: 15px !important; }
+  .pb20-md { padding-bottom: 20px !important; }
+  .pb30-md { padding-bottom: 30px !important; }
+  .pb40-md { padding-bottom: 40px !important; }
+  .pb50-md { padding-bottom: 50px !important; }
+  .pb60-md { padding-bottom: 60px !important; }
+  .pb80-md { padding-bottom: 80px !important; }
+  .pb100-md { padding-bottom: 100px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .pb0-sm { padding-bottom: 0; }
-  .pb5-sm { padding-bottom: 5px; }
-  .pb10-sm { padding-bottom: 10px; }
-  .pb15-sm { padding-bottom: 15px; }
-  .pb20-sm { padding-bottom: 20px; }
-  .pb30-sm { padding-bottom: 30px; }
-  .pb40-sm { padding-bottom: 40px; }
-  .pb50-sm { padding-bottom: 50px; }
-  .pb60-sm { padding-bottom: 60px; }
-  .pb80-sm { padding-bottom: 80px; }
-  .pb100-sm { padding-bottom: 100px; }
+  .pb0-sm { padding-bottom: 0 !important; }
+  .pb5-sm { padding-bottom: 5px !important; }
+  .pb10-sm { padding-bottom: 10px !important; }
+  .pb15-sm { padding-bottom: 15px !important; }
+  .pb20-sm { padding-bottom: 20px !important; }
+  .pb30-sm { padding-bottom: 30px !important; }
+  .pb40-sm { padding-bottom: 40px !important; }
+  .pb50-sm { padding-bottom: 50px !important; }
+  .pb60-sm { padding-bottom: 60px !important; }
+  .pb80-sm { padding-bottom: 80px !important; }
+  .pb100-sm { padding-bottom: 100px !important; }
 }
 
 /* Left padding */
-.pl0 { padding-left: 0; }
-.pl5 { padding-left: 5px; }
-.pl10 { padding-left: 10px; }
-.pl15 { padding-left: 15px; }
-.pl20 { padding-left: 20px; }
-.pl30 { padding-left: 30px; }
-.pl40 { padding-left: 40px; }
-.pl50 { padding-left: 50px; }
-.pl60 { padding-left: 60px; }
-.pl80 { padding-left: 80px; }
-.pl100 { padding-left: 100px; }
+.pl0 { padding-left: 0 !important; }
+.pl5 { padding-left: 5px !important; }
+.pl10 { padding-left: 10px !important; }
+.pl15 { padding-left: 15px !important; }
+.pl20 { padding-left: 20px !important; }
+.pl30 { padding-left: 30px !important; }
+.pl40 { padding-left: 40px !important; }
+.pl50 { padding-left: 50px !important; }
+.pl60 { padding-left: 60px !important; }
+.pl80 { padding-left: 80px !important; }
+.pl100 { padding-left: 100px !important; }
 
 @media only screen and (--large-screen) {
-  .pl0-lg { padding-left: 0; }
-  .pl5-lg { padding-left: 5px; }
-  .pl10-lg { padding-left: 10px; }
-  .pl15-lg { padding-left: 15px; }
-  .pl20-lg { padding-left: 20px; }
-  .pl30-lg { padding-left: 30px; }
-  .pl40-lg { padding-left: 40px; }
-  .pl50-lg { padding-left: 50px; }
-  .pl60-lg { padding-left: 60px; }
-  .pl80-lg { padding-left: 80px; }
-  .pl100-lg { padding-left: 100px; }
+  .pl0-lg { padding-left: 0 !important; }
+  .pl5-lg { padding-left: 5px !important; }
+  .pl10-lg { padding-left: 10px !important; }
+  .pl15-lg { padding-left: 15px !important; }
+  .pl20-lg { padding-left: 20px !important; }
+  .pl30-lg { padding-left: 30px !important; }
+  .pl40-lg { padding-left: 40px !important; }
+  .pl50-lg { padding-left: 50px !important; }
+  .pl60-lg { padding-left: 60px !important; }
+  .pl80-lg { padding-left: 80px !important; }
+  .pl100-lg { padding-left: 100px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .pl0-md { padding-left: 0; }
-  .pl5-md { padding-left: 5px; }
-  .pl10-md { padding-left: 10px; }
-  .pl15-md { padding-left: 15px; }
-  .pl20-md { padding-left: 20px; }
-  .pl30-md { padding-left: 30px; }
-  .pl40-md { padding-left: 40px; }
-  .pl50-md { padding-left: 50px; }
-  .pl60-md { padding-left: 60px; }
-  .pl80-md { padding-left: 80px; }
-  .pl100-md { padding-left: 100px; }
+  .pl0-md { padding-left: 0 !important; }
+  .pl5-md { padding-left: 5px !important; }
+  .pl10-md { padding-left: 10px !important; }
+  .pl15-md { padding-left: 15px !important; }
+  .pl20-md { padding-left: 20px !important; }
+  .pl30-md { padding-left: 30px !important; }
+  .pl40-md { padding-left: 40px !important; }
+  .pl50-md { padding-left: 50px !important; }
+  .pl60-md { padding-left: 60px !important; }
+  .pl80-md { padding-left: 80px !important; }
+  .pl100-md { padding-left: 100px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .pb0-sm { padding-bottom: 0; }
-  .pl0-sm { padding-left: 0; }
-  .pl5-sm { padding-left: 5px; }
-  .pl10-sm { padding-left: 10px; }
-  .pl15-sm { padding-left: 15px; }
-  .pl20-sm { padding-left: 20px; }
-  .pl30-sm { padding-left: 30px; }
-  .pl40-sm { padding-left: 40px; }
-  .pl50-sm { padding-left: 50px; }
-  .pl60-sm { padding-left: 60px; }
-  .pl80-sm { padding-left: 80px; }
-  .pl100-sm { padding-left: 100px; }
+  .pb0-sm { padding-bottom: 0 !important; }
+  .pl0-sm { padding-left: 0 !important; }
+  .pl5-sm { padding-left: 5px !important; }
+  .pl10-sm { padding-left: 10px !important; }
+  .pl15-sm { padding-left: 15px !important; }
+  .pl20-sm { padding-left: 20px !important; }
+  .pl30-sm { padding-left: 30px !important; }
+  .pl40-sm { padding-left: 40px !important; }
+  .pl50-sm { padding-left: 50px !important; }
+  .pl60-sm { padding-left: 60px !important; }
+  .pl80-sm { padding-left: 80px !important; }
+  .pl100-sm { padding-left: 100px !important; }
 }
 
 /**
@@ -1233,493 +1233,493 @@
  */
 
 /* Widths */
-.w5 { width: 5px; }
-.w10 { width: 10px; }
-.w20 { width: 20px; }
-.w30 { width: 30px; }
-.w40 { width: 40px; }
-.w50 { width: 50px; }
-.w60 { width: 60px; }
-.w80 { width: 80px; }
-.w100 { width: 100px; }
-.w120 { width: 120px; }
-.w140 { width: 140px; }
-.w160 { width: 160px; }
-.w180 { width: 180px; }
-.w200 { width: 200px; }
-.w400 { width: 400px; }
-.w600 { width: 600px; }
-.w800 { width: 800px; }
+.w5 { width: 5px !important; }
+.w10 { width: 10px !important; }
+.w20 { width: 20px !important; }
+.w30 { width: 30px !important; }
+.w40 { width: 40px !important; }
+.w50 { width: 50px !important; }
+.w60 { width: 60px !important; }
+.w80 { width: 80px !important; }
+.w100 { width: 100px !important; }
+.w120 { width: 120px !important; }
+.w140 { width: 140px !important; }
+.w160 { width: 160px !important; }
+.w180 { width: 180px !important; }
+.w200 { width: 200px !important; }
+.w400 { width: 400px !important; }
+.w600 { width: 600px !important; }
+.w800 { width: 800px !important; }
 
 @media only screen and (--large-screen) {
-  .w5-lg { width: 5px; }
-  .w10-lg { width: 10px; }
-  .w20-lg { width: 20px; }
-  .w30-lg { width: 30px; }
-  .w40-lg { width: 40px; }
-  .w50-lg { width: 50px; }
-  .w60-lg { width: 60px; }
-  .w80-lg { width: 80px; }
-  .w100-lg { width: 100px; }
-  .w120-lg { width: 120px; }
-  .w140-lg { width: 140px; }
-  .w160-lg { width: 160px; }
-  .w180-lg { width: 180px; }
-  .w200-lg { width: 200px; }
-  .w400-lg { width: 400px; }
-  .w600-lg { width: 600px; }
-  .w800-lg { width: 800px; }
+  .w5-lg { width: 5px !important; }
+  .w10-lg { width: 10px !important; }
+  .w20-lg { width: 20px !important; }
+  .w30-lg { width: 30px !important; }
+  .w40-lg { width: 40px !important; }
+  .w50-lg { width: 50px !important; }
+  .w60-lg { width: 60px !important; }
+  .w80-lg { width: 80px !important; }
+  .w100-lg { width: 100px !important; }
+  .w120-lg { width: 120px !important; }
+  .w140-lg { width: 140px !important; }
+  .w160-lg { width: 160px !important; }
+  .w180-lg { width: 180px !important; }
+  .w200-lg { width: 200px !important; }
+  .w400-lg { width: 400px !important; }
+  .w600-lg { width: 600px !important; }
+  .w800-lg { width: 800px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .w5-md { width: 5px; }
-  .w10-md { width: 10px; }
-  .w20-md { width: 20px; }
-  .w30-md { width: 30px; }
-  .w40-md { width: 40px; }
-  .w50-md { width: 50px; }
-  .w60-md { width: 60px; }
-  .w80-md { width: 80px; }
-  .w100-md { width: 100px; }
-  .w120-md { width: 120px; }
-  .w140-md { width: 140px; }
-  .w160-md { width: 160px; }
-  .w180-md { width: 180px; }
-  .w200-md { width: 200px; }
-  .w400-md { width: 400px; }
-  .w600-md { width: 600px; }
-  .w800-md { width: 800px; }
+  .w5-md { width: 5px !important; }
+  .w10-md { width: 10px !important; }
+  .w20-md { width: 20px !important; }
+  .w30-md { width: 30px !important; }
+  .w40-md { width: 40px !important; }
+  .w50-md { width: 50px !important; }
+  .w60-md { width: 60px !important; }
+  .w80-md { width: 80px !important; }
+  .w100-md { width: 100px !important; }
+  .w120-md { width: 120px !important; }
+  .w140-md { width: 140px !important; }
+  .w160-md { width: 160px !important; }
+  .w180-md { width: 180px !important; }
+  .w200-md { width: 200px !important; }
+  .w400-md { width: 400px !important; }
+  .w600-md { width: 600px !important; }
+  .w800-md { width: 800px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .w5-sm { width: 5px; }
-  .w10-sm { width: 10px; }
-  .w20-sm { width: 20px; }
-  .w30-sm { width: 30px; }
-  .w40-sm { width: 40px; }
-  .w50-sm { width: 50px; }
-  .w60-sm { width: 60px; }
-  .w80-sm { width: 80px; }
-  .w100-sm { width: 100px; }
-  .w120-sm { width: 120px; }
-  .w140-sm { width: 140px; }
-  .w160-sm { width: 160px; }
-  .w180-sm { width: 180px; }
-  .w200-sm { width: 200px; }
-  .w400-sm { width: 400px; }
-  .w600-sm { width: 600px; }
-  .w800-sm { width: 800px; }
+  .w5-sm { width: 5px !important; }
+  .w10-sm { width: 10px !important; }
+  .w20-sm { width: 20px !important; }
+  .w30-sm { width: 30px !important; }
+  .w40-sm { width: 40px !important; }
+  .w50-sm { width: 50px !important; }
+  .w60-sm { width: 60px !important; }
+  .w80-sm { width: 80px !important; }
+  .w100-sm { width: 100px !important; }
+  .w120-sm { width: 120px !important; }
+  .w140-sm { width: 140px !important; }
+  .w160-sm { width: 160px !important; }
+  .w180-sm { width: 180px !important; }
+  .w200-sm { width: 200px !important; }
+  .w400-sm { width: 400px !important; }
+  .w600-sm { width: 600px !important; }
+  .w800-sm { width: 800px !important; }
 }
 
 /* Max widths */
-.wmax5 { max-width: 5px; }
-.wmax10 { max-width: 10px; }
-.wmax20 { max-width: 20px; }
-.wmax30 { max-width: 30px; }
-.wmax40 { max-width: 40px; }
-.wmax50 { max-width: 50px; }
-.wmax60 { max-width: 60px; }
-.wmax80 { max-width: 80px; }
-.wmax100 { max-width: 100px; }
-.wmax120 { max-width: 120px; }
-.wmax140 { max-width: 140px; }
-.wmax160 { max-width: 160px; }
-.wmax180 { max-width: 180px; }
-.wmax200 { max-width: 200px; }
-.wmax400 { max-width: 400px; }
-.wmax600 { max-width: 600px; }
-.wmax800 { max-width: 800px; }
-.wmax1200 { max-width: 1200px; }
-.wmax1600 { max-width: 1600px; }
+.wmax5 { max-width: 5px !important; }
+.wmax10 { max-width: 10px !important; }
+.wmax20 { max-width: 20px !important; }
+.wmax30 { max-width: 30px !important; }
+.wmax40 { max-width: 40px !important; }
+.wmax50 { max-width: 50px !important; }
+.wmax60 { max-width: 60px !important; }
+.wmax80 { max-width: 80px !important; }
+.wmax100 { max-width: 100px !important; }
+.wmax120 { max-width: 120px !important; }
+.wmax140 { max-width: 140px !important; }
+.wmax160 { max-width: 160px !important; }
+.wmax180 { max-width: 180px !important; }
+.wmax200 { max-width: 200px !important; }
+.wmax400 { max-width: 400px !important; }
+.wmax600 { max-width: 600px !important; }
+.wmax800 { max-width: 800px !important; }
+.wmax1200 { max-width: 1200px !important; }
+.wmax1600 { max-width: 1600px !important; }
 
 @media only screen and (--large-screen) {
-  .wmax5-lg { max-width: 5px; }
-  .wmax10-lg { max-width: 10px; }
-  .wmax20-lg { max-width: 20px; }
-  .wmax30-lg { max-width: 30px; }
-  .wmax40-lg { max-width: 40px; }
-  .wmax50-lg { max-width: 50px; }
-  .wmax60-lg { max-width: 60px; }
-  .wmax80-lg { max-width: 80px; }
-  .wmax100-lg { max-width: 100px; }
-  .wmax120-lg { max-width: 120px; }
-  .wmax140-lg { max-width: 140px; }
-  .wmax160-lg { max-width: 160px; }
-  .wmax180-lg { max-width: 180px; }
-  .wmax200-lg { max-width: 200px; }
-  .wmax400-lg { max-width: 400px; }
-  .wmax600-lg { max-width: 600px; }
-  .wmax800-lg { max-width: 800px; }
-  .wmax1200-lg { max-width: 1200px; }
-  .wmax1600-lg { max-width: 1600px; }
+  .wmax5-lg { max-width: 5px !important; }
+  .wmax10-lg { max-width: 10px !important; }
+  .wmax20-lg { max-width: 20px !important; }
+  .wmax30-lg { max-width: 30px !important; }
+  .wmax40-lg { max-width: 40px !important; }
+  .wmax50-lg { max-width: 50px !important; }
+  .wmax60-lg { max-width: 60px !important; }
+  .wmax80-lg { max-width: 80px !important; }
+  .wmax100-lg { max-width: 100px !important; }
+  .wmax120-lg { max-width: 120px !important; }
+  .wmax140-lg { max-width: 140px !important; }
+  .wmax160-lg { max-width: 160px !important; }
+  .wmax180-lg { max-width: 180px !important; }
+  .wmax200-lg { max-width: 200px !important; }
+  .wmax400-lg { max-width: 400px !important; }
+  .wmax600-lg { max-width: 600px !important; }
+  .wmax800-lg { max-width: 800px !important; }
+  .wmax1200-lg { max-width: 1200px !important; }
+  .wmax1600-lg { max-width: 1600px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .wmax5-md { max-width: 5px; }
-  .wmax10-md { max-width: 10px; }
-  .wmax20-md { max-width: 20px; }
-  .wmax30-md { max-width: 30px; }
-  .wmax40-md { max-width: 40px; }
-  .wmax50-md { max-width: 50px; }
-  .wmax60-md { max-width: 60px; }
-  .wmax80-md { max-width: 80px; }
-  .wmax100-md { max-width: 100px; }
-  .wmax120-md { max-width: 120px; }
-  .wmax140-md { max-width: 140px; }
-  .wmax160-md { max-width: 160px; }
-  .wmax180-md { max-width: 180px; }
-  .wmax200-md { max-width: 200px; }
-  .wmax400-md { max-width: 400px; }
-  .wmax600-md { max-width: 600px; }
-  .wmax800-md { max-width: 800px; }
-  .wmax1200-md { max-width: 1200px; }
-  .wmax1600-md { max-width: 1600px; }
+  .wmax5-md { max-width: 5px !important; }
+  .wmax10-md { max-width: 10px !important; }
+  .wmax20-md { max-width: 20px !important; }
+  .wmax30-md { max-width: 30px !important; }
+  .wmax40-md { max-width: 40px !important; }
+  .wmax50-md { max-width: 50px !important; }
+  .wmax60-md { max-width: 60px !important; }
+  .wmax80-md { max-width: 80px !important; }
+  .wmax100-md { max-width: 100px !important; }
+  .wmax120-md { max-width: 120px !important; }
+  .wmax140-md { max-width: 140px !important; }
+  .wmax160-md { max-width: 160px !important; }
+  .wmax180-md { max-width: 180px !important; }
+  .wmax200-md { max-width: 200px !important; }
+  .wmax400-md { max-width: 400px !important; }
+  .wmax600-md { max-width: 600px !important; }
+  .wmax800-md { max-width: 800px !important; }
+  .wmax1200-md { max-width: 1200px !important; }
+  .wmax1600-md { max-width: 1600px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .wmax5-sm { max-width: 5px; }
-  .wmax10-sm { max-width: 10px; }
-  .wmax20-sm { max-width: 20px; }
-  .wmax30-sm { max-width: 30px; }
-  .wmax40-sm { max-width: 40px; }
-  .wmax50-sm { max-width: 50px; }
-  .wmax60-sm { max-width: 60px; }
-  .wmax80-sm { max-width: 80px; }
-  .wmax100-sm { max-width: 100px; }
-  .wmax120-sm { max-width: 120px; }
-  .wmax140-sm { max-width: 140px; }
-  .wmax160-sm { max-width: 160px; }
-  .wmax180-sm { max-width: 180px; }
-  .wmax200-sm { max-width: 200px; }
-  .wmax400-sm { max-width: 400px; }
-  .wmax600-sm { max-width: 600px; }
-  .wmax800-sm { max-width: 800px; }
-  .wmax1200-sm { max-width: 1200px; }
-  .wmax1600-sm { max-width: 1600px; }
+  .wmax5-sm { max-width: 5px !important; }
+  .wmax10-sm { max-width: 10px !important; }
+  .wmax20-sm { max-width: 20px !important; }
+  .wmax30-sm { max-width: 30px !important; }
+  .wmax40-sm { max-width: 40px !important; }
+  .wmax50-sm { max-width: 50px !important; }
+  .wmax60-sm { max-width: 60px !important; }
+  .wmax80-sm { max-width: 80px !important; }
+  .wmax100-sm { max-width: 100px !important; }
+  .wmax120-sm { max-width: 120px !important; }
+  .wmax140-sm { max-width: 140px !important; }
+  .wmax160-sm { max-width: 160px !important; }
+  .wmax180-sm { max-width: 180px !important; }
+  .wmax200-sm { max-width: 200px !important; }
+  .wmax400-sm { max-width: 400px !important; }
+  .wmax600-sm { max-width: 600px !important; }
+  .wmax800-sm { max-width: 800px !important; }
+  .wmax1200-sm { max-width: 1200px !important; }
+  .wmax1600-sm { max-width: 1600px !important; }
 }
 
 /* Min widths */
-.wmin5 { min-width: 5px; }
-.wmin10 { min-width: 10px; }
-.wmin20 { min-width: 20px; }
-.wmin30 { min-width: 30px; }
-.wmin40 { min-width: 40px; }
-.wmin50 { min-width: 50px; }
-.wmin60 { min-width: 60px; }
-.wmin80 { min-width: 80px; }
-.wmin100 { min-width: 100px; }
-.wmin120 { min-width: 120px; }
-.wmin140 { min-width: 140px; }
-.wmin160 { min-width: 160px; }
-.wmin180 { min-width: 180px; }
-.wmin200 { min-width: 200px; }
-.wmin400 { min-width: 400px; }
-.wmin600 { min-width: 600px; }
-.wmin800 { min-width: 800px; }
+.wmin5 { min-width: 5px !important; }
+.wmin10 { min-width: 10px !important; }
+.wmin20 { min-width: 20px !important; }
+.wmin30 { min-width: 30px !important; }
+.wmin40 { min-width: 40px !important; }
+.wmin50 { min-width: 50px !important; }
+.wmin60 { min-width: 60px !important; }
+.wmin80 { min-width: 80px !important; }
+.wmin100 { min-width: 100px !important; }
+.wmin120 { min-width: 120px !important; }
+.wmin140 { min-width: 140px !important; }
+.wmin160 { min-width: 160px !important; }
+.wmin180 { min-width: 180px !important; }
+.wmin200 { min-width: 200px !important; }
+.wmin400 { min-width: 400px !important; }
+.wmin600 { min-width: 600px !important; }
+.wmin800 { min-width: 800px !important; }
 
 @media only screen and (--large-screen) {
-  .wmin5-lg { min-width: 5px; }
-  .wmin10-lg { min-width: 10px; }
-  .wmin20-lg { min-width: 20px; }
-  .wmin30-lg { min-width: 30px; }
-  .wmin40-lg { min-width: 40px; }
-  .wmin50-lg { min-width: 50px; }
-  .wmin60-lg { min-width: 60px; }
-  .wmin80-lg { min-width: 80px; }
-  .wmin100-lg { min-width: 100px; }
-  .wmin120-lg { min-width: 120px; }
-  .wmin140-lg { min-width: 140px; }
-  .wmin160-lg { min-width: 160px; }
-  .wmin180-lg { min-width: 180px; }
-  .wmin200-lg { min-width: 200px; }
-  .wmin400-lg { min-width: 400px; }
-  .wmin600-lg { min-width: 600px; }
-  .wmin800-lg { min-width: 800px; }
+  .wmin5-lg { min-width: 5px !important; }
+  .wmin10-lg { min-width: 10px !important; }
+  .wmin20-lg { min-width: 20px !important; }
+  .wmin30-lg { min-width: 30px !important; }
+  .wmin40-lg { min-width: 40px !important; }
+  .wmin50-lg { min-width: 50px !important; }
+  .wmin60-lg { min-width: 60px !important; }
+  .wmin80-lg { min-width: 80px !important; }
+  .wmin100-lg { min-width: 100px !important; }
+  .wmin120-lg { min-width: 120px !important; }
+  .wmin140-lg { min-width: 140px !important; }
+  .wmin160-lg { min-width: 160px !important; }
+  .wmin180-lg { min-width: 180px !important; }
+  .wmin200-lg { min-width: 200px !important; }
+  .wmin400-lg { min-width: 400px !important; }
+  .wmin600-lg { min-width: 600px !important; }
+  .wmin800-lg { min-width: 800px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .wmin5-md { min-width: 5px; }
-  .wmin10-md { min-width: 10px; }
-  .wmin20-md { min-width: 20px; }
-  .wmin30-md { min-width: 30px; }
-  .wmin40-md { min-width: 40px; }
-  .wmin50-md { min-width: 50px; }
-  .wmin60-md { min-width: 60px; }
-  .wmin80-md { min-width: 80px; }
-  .wmin100-md { min-width: 100px; }
-  .wmin120-md { min-width: 120px; }
-  .wmin140-md { min-width: 140px; }
-  .wmin160-md { min-width: 160px; }
-  .wmin180-md { min-width: 180px; }
-  .wmin200-md { min-width: 200px; }
-  .wmin400-md { min-width: 400px; }
-  .wmin600-md { min-width: 600px; }
-  .wmin800-md { min-width: 800px; }
+  .wmin5-md { min-width: 5px !important; }
+  .wmin10-md { min-width: 10px !important; }
+  .wmin20-md { min-width: 20px !important; }
+  .wmin30-md { min-width: 30px !important; }
+  .wmin40-md { min-width: 40px !important; }
+  .wmin50-md { min-width: 50px !important; }
+  .wmin60-md { min-width: 60px !important; }
+  .wmin80-md { min-width: 80px !important; }
+  .wmin100-md { min-width: 100px !important; }
+  .wmin120-md { min-width: 120px !important; }
+  .wmin140-md { min-width: 140px !important; }
+  .wmin160-md { min-width: 160px !important; }
+  .wmin180-md { min-width: 180px !important; }
+  .wmin200-md { min-width: 200px !important; }
+  .wmin400-md { min-width: 400px !important; }
+  .wmin600-md { min-width: 600px !important; }
+  .wmin800-md { min-width: 800px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .wmin5-sm { min-width: 5px; }
-  .wmin10-sm { min-width: 10px; }
-  .wmin20-sm { min-width: 20px; }
-  .wmin30-sm { min-width: 30px; }
-  .wmin40-sm { min-width: 40px; }
-  .wmin50-sm { min-width: 50px; }
-  .wmin60-sm { min-width: 60px; }
-  .wmin80-sm { min-width: 80px; }
-  .wmin100-sm { min-width: 100px; }
-  .wmin120-sm { min-width: 120px; }
-  .wmin140-sm { min-width: 140px; }
-  .wmin160-sm { min-width: 160px; }
-  .wmin180-sm { min-width: 180px; }
-  .wmin200-sm { min-width: 200px; }
-  .wmin400-sm { min-width: 400px; }
-  .wmin600-sm { min-width: 600px; }
-  .wmin800-sm { min-width: 800px; }
+  .wmin5-sm { min-width: 5px !important; }
+  .wmin10-sm { min-width: 10px !important; }
+  .wmin20-sm { min-width: 20px !important; }
+  .wmin30-sm { min-width: 30px !important; }
+  .wmin40-sm { min-width: 40px !important; }
+  .wmin50-sm { min-width: 50px !important; }
+  .wmin60-sm { min-width: 60px !important; }
+  .wmin80-sm { min-width: 80px !important; }
+  .wmin100-sm { min-width: 100px !important; }
+  .wmin120-sm { min-width: 120px !important; }
+  .wmin140-sm { min-width: 140px !important; }
+  .wmin160-sm { min-width: 160px !important; }
+  .wmin180-sm { min-width: 180px !important; }
+  .wmin200-sm { min-width: 200px !important; }
+  .wmin400-sm { min-width: 400px !important; }
+  .wmin600-sm { min-width: 600px !important; }
+  .wmin800-sm { min-width: 800px !important; }
 }
 
 /* Heights */
-.h5 { height: 5px; }
-.h10 { height: 10px; }
-.h20 { height: 20px; }
-.h30 { height: 30px; }
-.h40 { height: 40px; }
-.h50 { height: 50px; }
-.h60 { height: 60px; }
-.h80 { height: 80px; }
-.h100 { height: 100px; }
-.h120 { height: 120px; }
-.h140 { height: 140px; }
-.h160 { height: 160px; }
-.h180 { height: 180px; }
-.h200 { height: 200px; }
-.h400 { height: 400px; }
-.h600 { height: 600px; }
-.h800 { height: 800px; }
+.h5 { height: 5px !important; }
+.h10 { height: 10px !important; }
+.h20 { height: 20px !important; }
+.h30 { height: 30px !important; }
+.h40 { height: 40px !important; }
+.h50 { height: 50px !important; }
+.h60 { height: 60px !important; }
+.h80 { height: 80px !important; }
+.h100 { height: 100px !important; }
+.h120 { height: 120px !important; }
+.h140 { height: 140px !important; }
+.h160 { height: 160px !important; }
+.h180 { height: 180px !important; }
+.h200 { height: 200px !important; }
+.h400 { height: 400px !important; }
+.h600 { height: 600px !important; }
+.h800 { height: 800px !important; }
 
 @media only screen and (--large-screen) {
-  .h5-lg { height: 5px; }
-  .h10-lg { height: 10px; }
-  .h20-lg { height: 20px; }
-  .h30-lg { height: 30px; }
-  .h40-lg { height: 40px; }
-  .h50-lg { height: 50px; }
-  .h60-lg { height: 60px; }
-  .h80-lg { height: 80px; }
-  .h100-lg { height: 100px; }
-  .h120-lg { height: 120px; }
-  .h140-lg { height: 140px; }
-  .h160-lg { height: 160px; }
-  .h180-lg { height: 180px; }
-  .h200-lg { height: 200px; }
-  .h400-lg { height: 400px; }
-  .h600-lg { height: 600px; }
-  .h800-lg { height: 800px; }
+  .h5-lg { height: 5px !important; }
+  .h10-lg { height: 10px !important; }
+  .h20-lg { height: 20px !important; }
+  .h30-lg { height: 30px !important; }
+  .h40-lg { height: 40px !important; }
+  .h50-lg { height: 50px !important; }
+  .h60-lg { height: 60px !important; }
+  .h80-lg { height: 80px !important; }
+  .h100-lg { height: 100px !important; }
+  .h120-lg { height: 120px !important; }
+  .h140-lg { height: 140px !important; }
+  .h160-lg { height: 160px !important; }
+  .h180-lg { height: 180px !important; }
+  .h200-lg { height: 200px !important; }
+  .h400-lg { height: 400px !important; }
+  .h600-lg { height: 600px !important; }
+  .h800-lg { height: 800px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .h5-md { height: 5px; }
-  .h10-md { height: 10px; }
-  .h20-md { height: 20px; }
-  .h30-md { height: 30px; }
-  .h40-md { height: 40px; }
-  .h50-md { height: 50px; }
-  .h60-md { height: 60px; }
-  .h80-md { height: 80px; }
-  .h100-md { height: 100px; }
-  .h120-md { height: 120px; }
-  .h140-md { height: 140px; }
-  .h160-md { height: 160px; }
-  .h180-md { height: 180px; }
-  .h200-md { height: 200px; }
-  .h400-md { height: 400px; }
-  .h600-md { height: 600px; }
-  .h800-md { height: 800px; }
+  .h5-md { height: 5px !important; }
+  .h10-md { height: 10px !important; }
+  .h20-md { height: 20px !important; }
+  .h30-md { height: 30px !important; }
+  .h40-md { height: 40px !important; }
+  .h50-md { height: 50px !important; }
+  .h60-md { height: 60px !important; }
+  .h80-md { height: 80px !important; }
+  .h100-md { height: 100px !important; }
+  .h120-md { height: 120px !important; }
+  .h140-md { height: 140px !important; }
+  .h160-md { height: 160px !important; }
+  .h180-md { height: 180px !important; }
+  .h200-md { height: 200px !important; }
+  .h400-md { height: 400px !important; }
+  .h600-md { height: 600px !important; }
+  .h800-md { height: 800px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .h5-sm { height: 5px; }
-  .h10-sm { height: 10px; }
-  .h20-sm { height: 20px; }
-  .h30-sm { height: 30px; }
-  .h40-sm { height: 40px; }
-  .h50-sm { height: 50px; }
-  .h60-sm { height: 60px; }
-  .h80-sm { height: 80px; }
-  .h100-sm { height: 100px; }
-  .h120-sm { height: 120px; }
-  .h140-sm { height: 140px; }
-  .h160-sm { height: 160px; }
-  .h180-sm { height: 180px; }
-  .h200-sm { height: 200px; }
-  .h400-sm { height: 400px; }
-  .h600-sm { height: 600px; }
-  .h800-sm { height: 800px; }
+  .h5-sm { height: 5px !important; }
+  .h10-sm { height: 10px !important; }
+  .h20-sm { height: 20px !important; }
+  .h30-sm { height: 30px !important; }
+  .h40-sm { height: 40px !important; }
+  .h50-sm { height: 50px !important; }
+  .h60-sm { height: 60px !important; }
+  .h80-sm { height: 80px !important; }
+  .h100-sm { height: 100px !important; }
+  .h120-sm { height: 120px !important; }
+  .h140-sm { height: 140px !important; }
+  .h160-sm { height: 160px !important; }
+  .h180-sm { height: 180px !important; }
+  .h200-sm { height: 200px !important; }
+  .h400-sm { height: 400px !important; }
+  .h600-sm { height: 600px !important; }
+  .h800-sm { height: 800px !important; }
 }
 
 /* Max heights */
-.hmax5 { max-height: 5px; }
-.hmax10 { max-height: 10px; }
-.hmax20 { max-height: 20px; }
-.hmax30 { max-height: 30px; }
-.hmax40 { max-height: 40px; }
-.hmax50 { max-height: 50px; }
-.hmax60 { max-height: 60px; }
-.hmax80 { max-height: 80px; }
-.hmax100 { max-height: 100px; }
-.hmax120 { max-height: 120px; }
-.hmax140 { max-height: 140px; }
-.hmax160 { max-height: 160px; }
-.hmax180 { max-height: 180px; }
-.hmax200 { max-height: 200px; }
-.hmax400 { max-height: 400px; }
-.hmax600 { max-height: 600px; }
-.hmax800 { max-height: 800px; }
-.hmax1200 { max-height: 1200px; }
-.hmax1600 { max-height: 1600px; }
+.hmax5 { max-height: 5px !important; }
+.hmax10 { max-height: 10px !important; }
+.hmax20 { max-height: 20px !important; }
+.hmax30 { max-height: 30px !important; }
+.hmax40 { max-height: 40px !important; }
+.hmax50 { max-height: 50px !important; }
+.hmax60 { max-height: 60px !important; }
+.hmax80 { max-height: 80px !important; }
+.hmax100 { max-height: 100px !important; }
+.hmax120 { max-height: 120px !important; }
+.hmax140 { max-height: 140px !important; }
+.hmax160 { max-height: 160px !important; }
+.hmax180 { max-height: 180px !important; }
+.hmax200 { max-height: 200px !important; }
+.hmax400 { max-height: 400px !important; }
+.hmax600 { max-height: 600px !important; }
+.hmax800 { max-height: 800px !important; }
+.hmax1200 { max-height: 1200px !important; }
+.hmax1600 { max-height: 1600px !important; }
 
 @media only screen and (--large-screen) {
-  .hmax5-lg { max-height: 5px; }
-  .hmax10-lg { max-height: 10px; }
-  .hmax20-lg { max-height: 20px; }
-  .hmax30-lg { max-height: 30px; }
-  .hmax40-lg { max-height: 40px; }
-  .hmax50-lg { max-height: 50px; }
-  .hmax60-lg { max-height: 60px; }
-  .hmax80-lg { max-height: 80px; }
-  .hmax100-lg { max-height: 100px; }
-  .hmax120-lg { max-height: 120px; }
-  .hmax140-lg { max-height: 140px; }
-  .hmax160-lg { max-height: 160px; }
-  .hmax180-lg { max-height: 180px; }
-  .hmax200-lg { max-height: 200px; }
-  .hmax400-lg { max-height: 400px; }
-  .hmax600-lg { max-height: 600px; }
-  .hmax800-lg { max-height: 800px; }
-  .hmax1200-lg { max-height: 1200px; }
-  .hmax1600-lg { max-height: 1600px; }
+  .hmax5-lg { max-height: 5px !important; }
+  .hmax10-lg { max-height: 10px !important; }
+  .hmax20-lg { max-height: 20px !important; }
+  .hmax30-lg { max-height: 30px !important; }
+  .hmax40-lg { max-height: 40px !important; }
+  .hmax50-lg { max-height: 50px !important; }
+  .hmax60-lg { max-height: 60px !important; }
+  .hmax80-lg { max-height: 80px !important; }
+  .hmax100-lg { max-height: 100px !important; }
+  .hmax120-lg { max-height: 120px !important; }
+  .hmax140-lg { max-height: 140px !important; }
+  .hmax160-lg { max-height: 160px !important; }
+  .hmax180-lg { max-height: 180px !important; }
+  .hmax200-lg { max-height: 200px !important; }
+  .hmax400-lg { max-height: 400px !important; }
+  .hmax600-lg { max-height: 600px !important; }
+  .hmax800-lg { max-height: 800px !important; }
+  .hmax1200-lg { max-height: 1200px !important; }
+  .hmax1600-lg { max-height: 1600px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .hmax5-md { max-height: 5px; }
-  .hmax10-md { max-height: 10px; }
-  .hmax20-md { max-height: 20px; }
-  .hmax30-md { max-height: 30px; }
-  .hmax40-md { max-height: 40px; }
-  .hmax50-md { max-height: 50px; }
-  .hmax60-md { max-height: 60px; }
-  .hmax80-md { max-height: 80px; }
-  .hmax100-md { max-height: 100px; }
-  .hmax120-md { max-height: 120px; }
-  .hmax140-md { max-height: 140px; }
-  .hmax160-md { max-height: 160px; }
-  .hmax180-md { max-height: 180px; }
-  .hmax200-md { max-height: 200px; }
-  .hmax400-md { max-height: 400px; }
-  .hmax600-md { max-height: 600px; }
-  .hmax800-md { max-height: 800px; }
-  .hmax1200-md { max-height: 1200px; }
-  .hmax1600-md { max-height: 1600px; }
+  .hmax5-md { max-height: 5px !important; }
+  .hmax10-md { max-height: 10px !important; }
+  .hmax20-md { max-height: 20px !important; }
+  .hmax30-md { max-height: 30px !important; }
+  .hmax40-md { max-height: 40px !important; }
+  .hmax50-md { max-height: 50px !important; }
+  .hmax60-md { max-height: 60px !important; }
+  .hmax80-md { max-height: 80px !important; }
+  .hmax100-md { max-height: 100px !important; }
+  .hmax120-md { max-height: 120px !important; }
+  .hmax140-md { max-height: 140px !important; }
+  .hmax160-md { max-height: 160px !important; }
+  .hmax180-md { max-height: 180px !important; }
+  .hmax200-md { max-height: 200px !important; }
+  .hmax400-md { max-height: 400px !important; }
+  .hmax600-md { max-height: 600px !important; }
+  .hmax800-md { max-height: 800px !important; }
+  .hmax1200-md { max-height: 1200px !important; }
+  .hmax1600-md { max-height: 1600px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .hmax5-sm { max-height: 5px; }
-  .hmax10-sm { max-height: 10px; }
-  .hmax20-sm { max-height: 20px; }
-  .hmax30-sm { max-height: 30px; }
-  .hmax40-sm { max-height: 40px; }
-  .hmax50-sm { max-height: 50px; }
-  .hmax60-sm { max-height: 60px; }
-  .hmax80-sm { max-height: 80px; }
-  .hmax100-sm { max-height: 100px; }
-  .hmax120-sm { max-height: 120px; }
-  .hmax140-sm { max-height: 140px; }
-  .hmax160-sm { max-height: 160px; }
-  .hmax180-sm { max-height: 180px; }
-  .hmax200-sm { max-height: 200px; }
-  .hmax400-sm { max-height: 400px; }
-  .hmax600-sm { max-height: 600px; }
-  .hmax800-sm { max-height: 800px; }
-  .hmax1200-sm { max-height: 1200px; }
-  .hmax1600-sm { max-height: 1600px; }
+  .hmax5-sm { max-height: 5px !important; }
+  .hmax10-sm { max-height: 10px !important; }
+  .hmax20-sm { max-height: 20px !important; }
+  .hmax30-sm { max-height: 30px !important; }
+  .hmax40-sm { max-height: 40px !important; }
+  .hmax50-sm { max-height: 50px !important; }
+  .hmax60-sm { max-height: 60px !important; }
+  .hmax80-sm { max-height: 80px !important; }
+  .hmax100-sm { max-height: 100px !important; }
+  .hmax120-sm { max-height: 120px !important; }
+  .hmax140-sm { max-height: 140px !important; }
+  .hmax160-sm { max-height: 160px !important; }
+  .hmax180-sm { max-height: 180px !important; }
+  .hmax200-sm { max-height: 200px !important; }
+  .hmax400-sm { max-height: 400px !important; }
+  .hmax600-sm { max-height: 600px !important; }
+  .hmax800-sm { max-height: 800px !important; }
+  .hmax1200-sm { max-height: 1200px !important; }
+  .hmax1600-sm { max-height: 1600px !important; }
 }
 
 /* Min heights */
-.hmin5 { min-height: 5px; }
-.hmin10 { min-height: 10px; }
-.hmin20 { min-height: 20px; }
-.hmin30 { min-height: 30px; }
-.hmin40 { min-height: 40px; }
-.hmin50 { min-height: 50px; }
-.hmin60 { min-height: 60px; }
-.hmin80 { min-height: 80px; }
-.hmin100 { min-height: 100px; }
-.hmin120 { min-height: 120px; }
-.hmin140 { min-height: 140px; }
-.hmin160 { min-height: 160px; }
-.hmin180 { min-height: 180px; }
-.hmin200 { min-height: 200px; }
-.hmin400 { min-height: 400px; }
-.hmin600 { min-height: 600px; }
-.hmin800 { min-height: 800px; }
+.hmin5 { min-height: 5px !important; }
+.hmin10 { min-height: 10px !important; }
+.hmin20 { min-height: 20px !important; }
+.hmin30 { min-height: 30px !important; }
+.hmin40 { min-height: 40px !important; }
+.hmin50 { min-height: 50px !important; }
+.hmin60 { min-height: 60px !important; }
+.hmin80 { min-height: 80px !important; }
+.hmin100 { min-height: 100px !important; }
+.hmin120 { min-height: 120px !important; }
+.hmin140 { min-height: 140px !important; }
+.hmin160 { min-height: 160px !important; }
+.hmin180 { min-height: 180px !important; }
+.hmin200 { min-height: 200px !important; }
+.hmin400 { min-height: 400px !important; }
+.hmin600 { min-height: 600px !important; }
+.hmin800 { min-height: 800px !important; }
 
 @media only screen and (--large-screen) {
-  .hmin5-lg { min-height: 5px; }
-  .hmin10-lg { min-height: 10px; }
-  .hmin20-lg { min-height: 20px; }
-  .hmin30-lg { min-height: 30px; }
-  .hmin40-lg { min-height: 40px; }
-  .hmin50-lg { min-height: 50px; }
-  .hmin60-lg { min-height: 60px; }
-  .hmin80-lg { min-height: 80px; }
-  .hmin100-lg { min-height: 100px; }
-  .hmin120-lg { min-height: 120px; }
-  .hmin140-lg { min-height: 140px; }
-  .hmin160-lg { min-height: 160px; }
-  .hmin180-lg { min-height: 180px; }
-  .hmin200-lg { min-height: 200px; }
-  .hmin400-lg { min-height: 400px; }
-  .hmin600-lg { min-height: 600px; }
-  .hmin800-lg { min-height: 800px; }
+  .hmin5-lg { min-height: 5px !important; }
+  .hmin10-lg { min-height: 10px !important; }
+  .hmin20-lg { min-height: 20px !important; }
+  .hmin30-lg { min-height: 30px !important; }
+  .hmin40-lg { min-height: 40px !important; }
+  .hmin50-lg { min-height: 50px !important; }
+  .hmin60-lg { min-height: 60px !important; }
+  .hmin80-lg { min-height: 80px !important; }
+  .hmin100-lg { min-height: 100px !important; }
+  .hmin120-lg { min-height: 120px !important; }
+  .hmin140-lg { min-height: 140px !important; }
+  .hmin160-lg { min-height: 160px !important; }
+  .hmin180-lg { min-height: 180px !important; }
+  .hmin200-lg { min-height: 200px !important; }
+  .hmin400-lg { min-height: 400px !important; }
+  .hmin600-lg { min-height: 600px !important; }
+  .hmin800-lg { min-height: 800px !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .hmin5-md { min-height: 5px; }
-  .hmin10-md { min-height: 10px; }
-  .hmin20-md { min-height: 20px; }
-  .hmin30-md { min-height: 30px; }
-  .hmin40-md { min-height: 40px; }
-  .hmin50-md { min-height: 50px; }
-  .hmin60-md { min-height: 60px; }
-  .hmin80-md { min-height: 80px; }
-  .hmin100-md { min-height: 100px; }
-  .hmin120-md { min-height: 120px; }
-  .hmin140-md { min-height: 140px; }
-  .hmin160-md { min-height: 160px; }
-  .hmin180-md { min-height: 180px; }
-  .hmin200-md { min-height: 200px; }
-  .hmin400-md { min-height: 400px; }
-  .hmin600-md { min-height: 600px; }
-  .hmin800-md { min-height: 800px; }
+  .hmin5-md { min-height: 5px !important; }
+  .hmin10-md { min-height: 10px !important; }
+  .hmin20-md { min-height: 20px !important; }
+  .hmin30-md { min-height: 30px !important; }
+  .hmin40-md { min-height: 40px !important; }
+  .hmin50-md { min-height: 50px !important; }
+  .hmin60-md { min-height: 60px !important; }
+  .hmin80-md { min-height: 80px !important; }
+  .hmin100-md { min-height: 100px !important; }
+  .hmin120-md { min-height: 120px !important; }
+  .hmin140-md { min-height: 140px !important; }
+  .hmin160-md { min-height: 160px !important; }
+  .hmin180-md { min-height: 180px !important; }
+  .hmin200-md { min-height: 200px !important; }
+  .hmin400-md { min-height: 400px !important; }
+  .hmin600-md { min-height: 600px !important; }
+  .hmin800-md { min-height: 800px !important; }
 }
 
 @media only screen and (--small-screen) {
-  .hmin5-sm { min-height: 5px; }
-  .hmin10-sm { min-height: 10px; }
-  .hmin20-sm { min-height: 20px; }
-  .hmin30-sm { min-height: 30px; }
-  .hmin40-sm { min-height: 40px; }
-  .hmin50-sm { min-height: 50px; }
-  .hmin60-sm { min-height: 60px; }
-  .hmin80-sm { min-height: 80px; }
-  .hmin100-sm { min-height: 100px; }
-  .hmin120-sm { min-height: 120px; }
-  .hmin140-sm { min-height: 140px; }
-  .hmin160-sm { min-height: 160px; }
-  .hmin180-sm { min-height: 180px; }
-  .hmin200-sm { min-height: 200px; }
-  .hmin400-sm { min-height: 400px; }
-  .hmin600-sm { min-height: 600px; }
-  .hmin800-sm { min-height: 800px; }
+  .hmin5-sm { min-height: 5px !important; }
+  .hmin10-sm { min-height: 10px !important; }
+  .hmin20-sm { min-height: 20px !important; }
+  .hmin30-sm { min-height: 30px !important; }
+  .hmin40-sm { min-height: 40px !important; }
+  .hmin50-sm { min-height: 50px !important; }
+  .hmin60-sm { min-height: 60px !important; }
+  .hmin80-sm { min-height: 80px !important; }
+  .hmin100-sm { min-height: 100px !important; }
+  .hmin120-sm { min-height: 120px !important; }
+  .hmin140-sm { min-height: 140px !important; }
+  .hmin160-sm { min-height: 160px !important; }
+  .hmin180-sm { min-height: 180px !important; }
+  .hmin200-sm { min-height: 200px !important; }
+  .hmin400-sm { min-height: 400px !important; }
+  .hmin600-sm { min-height: 600px !important; }
+  .hmin800-sm { min-height: 800px !important; }
 }
 
 /**
@@ -1730,33 +1730,33 @@
  * @group
  * @memberof Sizing
  */
-.viewport-third { height: 33.3333vh; }
-.viewport-half { height: 50vh; }
-.viewport-twothirds { height: 66.6666vh; }
-.viewport-almost { height: 90vh; }
-.viewport-full { height: 100vh; }
+.viewport-third { height: 33.3333vh !important; }
+.viewport-half { height: 50vh !important; }
+.viewport-twothirds { height: 66.6666vh !important; }
+.viewport-almost { height: 90vh !important; }
+.viewport-full { height: 100vh !important; }
 /** @endgroup */
 
 @media only screen and (--large-screen) {
-  .viewport-third-lg { height: 33.3333vh; }
-  .viewport-half-lg { height: 50vh; }
-  .viewport-twothirds-lg { height: 66.6666vh; }
-  .viewport-almost-lg { height: 90vh; }
-  .viewport-full-lg { height: 100vh; }
+  .viewport-third-lg { height: 33.3333vh !important; }
+  .viewport-half-lg { height: 50vh !important; }
+  .viewport-twothirds-lg { height: 66.6666vh !important; }
+  .viewport-almost-lg { height: 90vh !important; }
+  .viewport-full-lg { height: 100vh !important; }
 }
 
 @media only screen and (--medium-screen) {
-  .viewport-third-md { height: 33.3333vh; }
-  .viewport-half-md { height: 50vh; }
-  .viewport-twothirds-md { height: 66.6666vh; }
-  .viewport-almost-md { height: 90vh; }
-  .viewport-full-md { height: 100vh; }
+  .viewport-third-md { height: 33.3333vh !important; }
+  .viewport-half-md { height: 50vh !important; }
+  .viewport-twothirds-md { height: 66.6666vh !important; }
+  .viewport-almost-md { height: 90vh !important; }
+  .viewport-full-md { height: 100vh !important; }
 }
 
 @media only screen and (--small-screen) {
-  .viewport-third-sm { height: 33.3333vh; }
-  .viewport-half-sm { height: 50vh; }
-  .viewport-twothirds-sm { height: 66.6666vh; }
-  .viewport-almost-sm { height: 90vh; }
-  .viewport-full-sm { height: 100vh; }
+  .viewport-third-sm { height: 33.3333vh !important; }
+  .viewport-half-sm { height: 50vh !important; }
+  .viewport-twothirds-sm { height: 66.6666vh !important; }
+  .viewport-almost-sm { height: 90vh !important; }
+  .viewport-full-sm { height: 100vh !important; }
 }

--- a/src/theming.css
+++ b/src/theming.css
@@ -6,114 +6,114 @@
 /**
  * Round classes.
  */
-.round { border-radius: var(--border-radius); }
-.round-t { border-radius: 4px 4px 0 0; }
-.round-r { border-radius: 0 4px 4px 0; }
-.round-b { border-radius: 0 0 4px 4px; }
-.round-l { border-radius: 4px 0 0 4px; }
-.round-tl { border-top-left-radius: 4px; }
-.round-tr { border-top-right-radius: 4px; }
-.round-br { border-bottom-right-radius: 4px; }
-.round-bl { border-bottom-left-radius: 4px; }
+.round { border-radius: var(--border-radius) !important; }
+.round-t { border-radius: 4px 4px 0 0 !important; }
+.round-r { border-radius: 0 4px 4px 0 !important; }
+.round-b { border-radius: 0 0 4px 4px !important; }
+.round-l { border-radius: 4px 0 0 4px !important; }
+.round-tl { border-top-left-radius: 4px !important; }
+.round-tr { border-top-right-radius: 4px !important; }
+.round-br { border-bottom-right-radius: 4px !important; }
+.round-bl { border-bottom-left-radius: 4px !important; }
 
-.round-bold { border-radius: var(--border-radius-bold); }
-.round-bold-t { border-radius: 8px 8px 0 0; }
-.round-bold-r { border-radius: 0 8px 8px 0; }
-.round-bold-b { border-radius: 0 0 8px 8px; }
-.round-bold-l { border-radius: 8px 0 0 8px; }
-.round-bold-tl { border-top-left-radius: 8px; }
-.round-bold-tr { border-top-right-radius: 8px; }
-.round-bold-br { border-bottom-right-radius: 8px; }
-.round-bold-bl { border-bottom-left-radius: 8px; }
+.round-bold { border-radius: var(--border-radius-bold) !important; }
+.round-bold-t { border-radius: 8px 8px 0 0 !important; }
+.round-bold-r { border-radius: 0 8px 8px 0 !important; }
+.round-bold-b { border-radius: 0 0 8px 8px !important; }
+.round-bold-l { border-radius: 8px 0 0 8px !important; }
+.round-bold-tl { border-top-left-radius: 8px !important; }
+.round-bold-tr { border-top-right-radius: 8px !important; }
+.round-bold-br { border-bottom-right-radius: 8px !important; }
+.round-bold-bl { border-bottom-left-radius: 8px !important; }
 
-.round-full { border-radius: 50%; }
-.round-full-t { border-radius: 50% 50% 0 0; }
-.round-full-r { border-radius: 0 50% 50% 0; }
-.round-full-b { border-radius: 0 0 50% 50%; }
-.round-full-l { border-radius: 50% 0 0 50%; }
-.round-full-tl { border-top-left-radius: 50%; }
-.round-full-tr { border-top-right-radius: 50%; }
-.round-full-br { border-bottom-right-radius: 50%; }
-.round-full-bl { border-bottom-left-radius: 50%; }
+.round-full { border-radius: 50% !important; }
+.round-full-t { border-radius: 50% 50% 0 0 !important; }
+.round-full-r { border-radius: 0 50% 50% 0 !important; }
+.round-full-b { border-radius: 0 0 50% 50% !important; }
+.round-full-l { border-radius: 50% 0 0 50% !important; }
+.round-full-tl { border-top-left-radius: 50% !important; }
+.round-full-tr { border-top-right-radius: 50% !important; }
+.round-full-br { border-bottom-right-radius: 50% !important; }
+.round-full-bl { border-bottom-left-radius: 50% !important; }
 
 /**
  * Border classes.
  */
-.border { border: 1px solid; }
-.border--2 { border-width: 2px; }
-.border--dash { border-style: dashed; }
+.border { border: 1px solid !important; }
+.border--2 { border-width: 2px !important; }
+.border--dash { border-style: dashed !important; }
 
-.border-l { border-left: 1px solid; }
-.border-t { border-top: 1px solid; }
-.border-r { border-right: 1px solid; }
-.border-b { border-bottom: 1px solid; }
+.border-l { border-left: 1px solid !important; }
+.border-t { border-top: 1px solid !important; }
+.border-r { border-right: 1px solid !important; }
+.border-b { border-bottom: 1px solid !important; }
 
-.border--gray { border-color: #acb4b9; }
-.border--blue { border-color: #0077cc; }
-.border--purple { border-color: #5500cc; }
-.border--pink { border-color: #cc0077; }
-.border--red { border-color: #cc0011; }
-.border--orange { border-color: #cc5500; }
-.border--mustard { border-color: #ffbf16; }
-.border--yellow { border-color: #ffeb3b; }
-.border--green { border-color: #11cc00; }
-.border--teal { border-color: #3fbfbc; }
-.border--cyan { border-color: #00ccbb; }
-.border--denim { border-color: #34607f; }
-.border--navy { border-color: #0a3a5c; }
-.border--white { border-color: #fff; }
-.border--light { border-color: #f2f2f2; }
-.border--transparent { border-color: rgba(0, 0, 0, 0); }
-.border--darken5 { border-color: var(--darken5); }
-.border--darken10 { border-color: var(--darken10); }
-.border--darken25 { border-color: var(--darken25); }
-.border--darken50 { border-color: var(--darken50); }
-.border--darken75 { border-color: var(--darken75); }
-.border--lighten5 { border-color: var(--lighten5); }
-.border--lighten10 { border-color: var(--lighten10); }
-.border--lighten25 { border-color: var(--lighten25); }
-.border--lighten50 { border-color: var(--lighten50); }
-.border--lighten75 { border-color: var(--lighten75); }
+.border--gray { border-color: #acb4b9 !important; }
+.border--blue { border-color: #0077cc !important; }
+.border--purple { border-color: #5500cc !important; }
+.border--pink { border-color: #cc0077 !important; }
+.border--red { border-color: #cc0011 !important; }
+.border--orange { border-color: #cc5500 !important; }
+.border--mustard { border-color: #ffbf16 !important; }
+.border--yellow { border-color: #ffeb3b !important; }
+.border--green { border-color: #11cc00 !important; }
+.border--teal { border-color: #3fbfbc !important; }
+.border--cyan { border-color: #00ccbb !important; }
+.border--denim { border-color: #34607f !important; }
+.border--navy { border-color: #0a3a5c !important; }
+.border--white { border-color: #fff !important; }
+.border--light { border-color: #f2f2f2 !important; }
+.border--transparent { border-color: rgba(0, 0, 0, 0) !important; }
+.border--darken5 { border-color: var(--darken5) !important; }
+.border--darken10 { border-color: var(--darken10) !important; }
+.border--darken25 { border-color: var(--darken25) !important; }
+.border--darken50 { border-color: var(--darken50) !important; }
+.border--darken75 { border-color: var(--darken75) !important; }
+.border--lighten5 { border-color: var(--lighten5) !important; }
+.border--lighten10 { border-color: var(--lighten10) !important; }
+.border--lighten25 { border-color: var(--lighten25) !important; }
+.border--lighten50 { border-color: var(--lighten50) !important; }
+.border--lighten75 { border-color: var(--lighten75) !important; }
 
 /**
  * Shadow classes.
  */
-.shadow5 { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3); }
-.shadow10 { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3); }
-.shadow20 { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.3); }
-.shadow30 { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3); }
-.shadow-bold5 { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.9); }
-.shadow-bold10 { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.9); }
-.shadow-bold20 { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.9); }
-.shadow-bold30 { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.9); }
+.shadow5 { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3) !important; }
+.shadow10 { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.3) !important; }
+.shadow20 { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.3) !important; }
+.shadow30 { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3) !important; }
+.shadow-bold5 { box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.9) !important; }
+.shadow-bold10 { box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.9) !important; }
+.shadow-bold20 { box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.9) !important; }
+.shadow-bold30 { box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.9) !important; }
 
-.txt-shadow5 { text-shadow: 0 0 5px rgba(0, 0, 0, 0.3); }
-.txt-shadow10 { text-shadow: 0 0 10px rgba(0, 0, 0, 0.3); }
-.txt-shadow20 { text-shadow: 0 0 20px rgba(0, 0, 0, 0.3); }
-.txt-shadow30 { text-shadow: 0 0 30px rgba(0, 0, 0, 0.3); }
-.txt-shadow-bold5 { text-shadow: 0 0 5px rgba(0, 0, 0, 0.9); }
-.txt-shadow-bold10 { text-shadow: 0 0 10px rgba(0, 0, 0, 0.9); }
-.txt-shadow-bold20 { text-shadow: 0 0 20px rgba(0, 0, 0, 0.9); }
-.txt-shadow-bold30 { text-shadow: 0 0 30px rgba(0, 0, 0, 0.9); }
+.txt-shadow5 { text-shadow: 0 0 5px rgba(0, 0, 0, 0.3) !important; }
+.txt-shadow10 { text-shadow: 0 0 10px rgba(0, 0, 0, 0.3) !important; }
+.txt-shadow20 { text-shadow: 0 0 20px rgba(0, 0, 0, 0.3) !important; }
+.txt-shadow30 { text-shadow: 0 0 30px rgba(0, 0, 0, 0.3) !important; }
+.txt-shadow-bold5 { text-shadow: 0 0 5px rgba(0, 0, 0, 0.9) !important; }
+.txt-shadow-bold10 { text-shadow: 0 0 10px rgba(0, 0, 0, 0.9) !important; }
+.txt-shadow-bold20 { text-shadow: 0 0 20px rgba(0, 0, 0, 0.9) !important; }
+.txt-shadow-bold30 { text-shadow: 0 0 30px rgba(0, 0, 0, 0.9) !important; }
 
 /**
  * Visibility classes.
  */
-.alpha0 { opacity: 0; }
-.alpha25 { opacity: 0.25; }
-.alpha50 { opacity: 0.5; }
-.alpha75 { opacity: 0.75; }
-.alpha100 { opacity: 1; }
+.alpha0 { opacity: 0 !important; }
+.alpha25 { opacity: 0.25 !important; }
+.alpha50 { opacity: 0.5 !important; }
+.alpha75 { opacity: 0.75 !important; }
+.alpha100 { opacity: 1 !important; }
 
-.clip { overflow: hidden; }
+.clip { overflow: hidden !important; }
 
 /**
  * Cursor classes.
  */
-.cursor-default { cursor: default; }
-.cursor-pointer { cursor: pointer; }
-.cursor-crosshair { cursor: crosshair; }
-.cursor-move { cursor: move; }
+.cursor-default { cursor: default !important; }
+.cursor-pointer { cursor: pointer !important; }
+.cursor-crosshair { cursor: crosshair !important; }
+.cursor-move { cursor: move !important; }
 
 /**
  * State classes.

--- a/src/triangles.css
+++ b/src/triangles.css
@@ -11,103 +11,103 @@
  * <div class='triangle triangle--u'></div>
  */
 .triangle {
-  width: 10px;
-  height: 10px;
-  font-size: 0;
-  line-height: 0;
+  width: 10px !important;
+  height: 10px !important;
+  font-size: 0 !important;
+  line-height: 0 !important;
 }
 
 /**
  * Small triangles
  */
 .triangle--u {
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-bottom: 7px solid currentColor;
+  border-left: 5px solid transparent !important;
+  border-right: 5px solid transparent !important;
+  border-bottom: 7px solid currentColor !important;
 }
 
 .triangle--r {
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  border-left: 7px solid currentColor;
+  border-top: 5px solid transparent !important;
+  border-bottom: 5px solid transparent !important;
+  border-left: 7px solid currentColor !important;
 }
 
 .triangle--d {
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 7px solid currentColor;
+  border-left: 5px solid transparent !important;
+  border-right: 5px solid transparent !important;
+  border-top: 7px solid currentColor !important;
 }
 
 .triangle--l {
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  border-right: 7px solid currentColor;
+  border-top: 5px solid transparent !important;
+  border-bottom: 5px solid transparent !important;
+  border-right: 7px solid currentColor !important;
 }
 
 /**
  * Medium sized triangles
  */
 .triangle-l {
-  width: 20px;
-  height: 20px;
-  font-size: 0;
-  line-height: 0;
+  width: 20px !important;
+  height: 20px !important;
+  font-size: 0 !important;
+  line-height: 0 !important;
 }
 
 .triangle-l--u {
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-bottom: 13px solid currentColor;
+  border-left: 10px solid transparent !important;
+  border-right: 10px solid transparent !important;
+  border-bottom: 13px solid currentColor !important;
 }
 
 .triangle-l--r {
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent;
-  border-left: 13px solid currentColor;
+  border-top: 10px solid transparent !important;
+  border-bottom: 10px solid transparent !important;
+  border-left: 13px solid currentColor !important;
 }
 
 .triangle-l--d {
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
-  border-top: 13px solid currentColor;
+  border-left: 10px solid transparent !important;
+  border-right: 10px solid transparent !important;
+  border-top: 13px solid currentColor !important;
 }
 
 .triangle-l--l {
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent;
-  border-right: 13px solid currentColor;
+  border-top: 10px solid transparent !important;
+  border-bottom: 10px solid transparent !important;
+  border-right: 13px solid currentColor !important;
 }
 
 /**
  * Extra large triangles
  */
 .triangle-xl {
-  width: 40px;
-  height: 40px;
-  font-size: 0;
-  line-height: 0;
+  width: 40px !important;
+  height: 40px !important;
+  font-size: 0 !important;
+  line-height: 0 !important;
 }
 
 .triangle-xl--u {
-  border-left: 20px solid transparent;
-  border-right: 20px solid transparent;
-  border-bottom: 25px solid currentColor;
+  border-left: 20px solid transparent !important;
+  border-right: 20px solid transparent !important;
+  border-bottom: 25px solid currentColor !important;
 }
 
 .triangle-xl--r {
-  border-top: 20px solid transparent;
-  border-bottom: 20px solid transparent;
-  border-left: 25px solid currentColor;
+  border-top: 20px solid transparent !important;
+  border-bottom: 20px solid transparent !important;
+  border-left: 25px solid currentColor !important;
 }
 
 .triangle-xl--d {
-  border-left: 20px solid transparent;
-  border-right: 20px solid transparent;
-  border-top: 25px solid currentColor;
+  border-left: 20px solid transparent !important;
+  border-right: 20px solid transparent !important;
+  border-top: 25px solid currentColor !important;
 }
 
 .triangle-xl--l {
-  border-top: 20px solid transparent;
-  border-bottom: 20px solid transparent;
-  border-right: 24px solid currentColor;
+  border-top: 20px solid transparent !important;
+  border-bottom: 20px solid transparent !important;
+  border-right: 24px solid currentColor !important;
 }

--- a/src/typography.css
+++ b/src/typography.css
@@ -206,7 +206,7 @@ textarea {
  * <div class='txt-weight-light'>light</div>
  */
 .txt-weight-light {
-  font-weight: lighter;
+  font-weight: lighter !important;
 }
 
 /**
@@ -215,7 +215,7 @@ textarea {
  * @example
  * <div class='strong'>strong</div>
  */
-.strong { font-weight: bold; }
+.strong { font-weight: bold !important; }
 
 /**
  * Italic text.
@@ -223,7 +223,7 @@ textarea {
  * @example
  * <div class='em'>em</div>
  */
-.em { font-style: italic; }
+.em { font-style: italic !important; }
 
 /**
  * Uppercase text.
@@ -231,7 +231,7 @@ textarea {
  * @example
  * <div class='uppercase'>uppercase</div>
  */
-.uppercase { text-transform: uppercase; }
+.uppercase { text-transform: uppercase !important; }
 
 /**
  * All caps.
@@ -239,7 +239,7 @@ textarea {
  * @example
  * <div class='capitalize'>capitalize</div>
  */
-.capitalize { text-transform: capitalize; }
+.capitalize { text-transform: capitalize !important; }
 
 /**
  * Sentence case.
@@ -248,8 +248,8 @@ textarea {
  * @example
  * <div class='sentence-case'>sentence-case</div>
  */
-.sentence-case { text-transform: lowercase; }
-.sentence-case::first-letter { text-transform: capitalize; }
+.sentence-case { text-transform: lowercase !important; }
+.sentence-case::first-letter { text-transform: capitalize !important; }
 /** @endgroup */
 
 /**
@@ -261,9 +261,9 @@ textarea {
  * <div class='txt-r'>txt-r</div>
  * <div class='txt-center'>txt-center</div>
  */
-.txt-l { text-align: left; }
-.txt-r { text-align: right; }
-.txt-center { text-align: center; }
+.txt-l { text-align: left !important; }
+.txt-r { text-align: right !important; }
+.txt-center { text-align: center !important; }
 /** @endgroup */
 
 /**
@@ -274,15 +274,15 @@ textarea {
  * <div class='txt-align-t'>txt-align-t</div>
  * <div class='txt-align-middle'>txt-align-middle</div>
  */
-.txt-align-t { vertical-align: top; }
-.txt-align-middle { vertical-align: middle; }
+.txt-align-t { vertical-align: top !important; }
+.txt-align-middle { vertical-align: middle !important; }
 /** @endgroup */
 
 /**
  * Text underline
  * @member of Typography utilities
  */
-.txt-underline { text-decoration: underline; }
+.txt-underline { text-decoration: underline !important; }
 
 /**
  * By default, the `txt-link` class does *nothing*. It should be
@@ -297,13 +297,13 @@ textarea {
  * <a href='#link' class='txt-link txt-underline color-red'>red underlined link</a>
  */
 .txt-link { /* empty */ }
-.txt-link.color-gray:hover { color: var(--gray-dark); }
-.txt-link.color-pink:hover { color: var(--pink-dark); }
-.txt-link.color-red:hover { color: var(--red-dark); }
-.txt-link.color-orange:hover { color: var(--orange-dark); }
-.txt-link.color-yellow:hover { color: var(--yellow-dark); }
-.txt-link.color-green:hover { color: var(--green-dark); }
-.txt-link.color-teal:hover { color: var(--teal-dark); }
-.txt-link.color-blue:hover { color: var(--blue-dark); }
-.txt-link.color-purple:hover { color: var(--purple-dark); }
-.txt-link.color-white:hover { color: var(--gray-faint); }
+.txt-link.color-gray:hover { color: var(--gray-dark) !important; }
+.txt-link.color-pink:hover { color: var(--pink-dark) !important; }
+.txt-link.color-red:hover { color: var(--red-dark) !important; }
+.txt-link.color-orange:hover { color: var(--orange-dark) !important; }
+.txt-link.color-yellow:hover { color: var(--yellow-dark) !important; }
+.txt-link.color-green:hover { color: var(--green-dark) !important; }
+.txt-link.color-teal:hover { color: var(--teal-dark) !important; }
+.txt-link.color-blue:hover { color: var(--blue-dark) !important; }
+.txt-link.color-purple:hover { color: var(--purple-dark) !important; }
+.txt-link.color-white:hover { color: var(--gray-faint) !important; }


### PR DESCRIPTION
Closes #123. See that issue for more discussion.

I tried to add `!important` to all the declarations that directly correspond to a class's name — the principle being that you should not use these classes unless you want the effect their name advertises.

Also applied it in at least one place (triangles) where the declaration does not correspond to a class's name but you shouldn't have any reason to modify those properties.

What do you think team assembly? @samanpwbb @katydecorah @tristen @dasulit @mayagao 