### PR TITLE
mobile first media queries, closes #336

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Assembly targets IE 11+ and other modern browsers.
 
 - Many classes have media query variants. The media query variants follow a naming convention: suffix `-media-{size}` to end of the rule. For example, for the class `.p6`, the variations are: `.p6-ms`, `.p6-ml`, `.p6-mxl`,
 - If a class has a media query variant for one breakpoint, it must also have a variant for all breakpoints.
-- Order in stylesheet of media query rules is consistent: first the default rule, followed by the `-mxl` rule, followed by the `-ml` rule, followed by the `-ms` rule. We do this to guarantee that small rules override medium rules, etc.
+- Order in stylesheet of media query rules is consistent: first the default rule, followed by the `-mm` rule, followed by the `-ml` rule, followed by the `-mxl` rule. We do this to guarantee that as page size gets larger, rules that target larger screens override rules that target small screens, etc.
 
 ## Development
 

--- a/site/documentation/heading.js
+++ b/site/documentation/heading.js
@@ -15,14 +15,14 @@ class Heading extends React.Component {
       </div>;
     }
 
-    const sectionClass = props.level === 1 ? 'bg-blue-faint pl24 pr24 pb24 mb48 mt72 round' : 'mt24';
-    const levelClass = props.level === 1 ? 'txt-subhead mb6' : 'txt-xl mb6';
+    const sectionClass = props.level === 1 ? 'mt24 pb18 border--gray' : 'pt12 pb12 mt12 border--gray-faint';
+    const levelClass = props.level === 1 ? 'txt-subhead mb12' : 'txt-xl mb6';
 
     return (
-      <div className={sectionClass}>
+      <div className={`mb48 border-b border--2 ${sectionClass}`}>
         <div
           id={id}
-          className={`${levelClass}`}
+          className={levelClass}
         >
           <a className='block pt24' href={`#${id}`}>
             {props.title}

--- a/site/navigation.js
+++ b/site/navigation.js
@@ -7,7 +7,7 @@ class Navigation extends React.Component {
     let secondaryEls;
     if (props.navItems.secondary) {
       secondaryEls = <div className='border-l border--2 border--gray-faint mt6 mb6 pl12'>{props.navItems.secondary.map((r) =>
-        <a key={r.name} className='txt-link color-blue block txt-s' href={r.route}>{r.name}</a>)}
+        <a key={r.name} className='inline-block mr6 mr0-mm block-mm txt-link color-blue txt-s' href={r.route}>{r.name}</a>)}
       </div>;
     }
 
@@ -18,7 +18,7 @@ class Navigation extends React.Component {
       </div>
     );
 
-    return (<div className='pt48 viewport-full scroll-auto pl24 pr18 w240 fixed top left'>
+    return (<div className='pt48 viewport-full-mm scroll-auto pl24 pr18 w240-mm fixed-mm top left'>
       <div className='txt-m mb12'>Assembly</div>
       {navEls}
     </div>);

--- a/site/page.js
+++ b/site/page.js
@@ -4,9 +4,9 @@ import { Navigation } from './navigation';
 class Page extends React.Component {
   render() {
     return (
-      <div>
+      <div className='flex-parent-mm flex-parent--center-main-mm'>
         <Navigation navItems={this.props.navItems} />
-        <div className='mb24 ml240 pl18 pr18 wmax960'>{this.props.children}</div>
+        <div className='mb24 ml240-mm pl24 pr24 wmax960'>{this.props.children}</div>
       </div>
     );
   }

--- a/src/layout.css
+++ b/src/layout.css
@@ -24,7 +24,7 @@
 
 /**
  * Flexbox utilities. Check out ["A Complete Guide to Flexbox"](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
- * to learn how the system works. Class set includes `-ms`, `-ml`, and `-mxl` variations to target screen sizes.
+ * to learn how the system works. Class set includes `-mm`, `-ml`, and `-mxl` variations to target screen sizes.
  *
  * @memberof Layout
  * @group
@@ -374,7 +374,7 @@
 /** @endgroup */
 
 /**
- * Use display classes to control the display property of elements. Class set includes `-ms`, `-ml`, and `-mxl` variations to target screen sizes.
+ * Use display classes to control the display property of elements. Class set includes `-mm`, `-ml`, and `-mxl` variations to target screen sizes.
  *
  * @section Display
  * @memberof Layout
@@ -434,7 +434,7 @@
  */
 
 /**
- * Set an element's `position`. Class set includes `-ms`, `-ml`, and `-mxl` variations to target screen sizes.
+ * Set an element's `position`. Class set includes `-mm`, `-ml`, and `-mxl` variations to target screen sizes.
  *
  * @group
  * @memberof Positioning
@@ -467,7 +467,7 @@
 }
 
 /**
- * Set positioned elements flush against a side of their container. Class set includes `-ms`, `-ml`, and `-mxl` variations to target screen sizes.
+ * Set positioned elements flush against a side of their container. Class set includes `-mm`, `-ml`, and `-mxl` variations to target screen sizes.
  *
  * @group
  * @memberof Positioning
@@ -501,7 +501,7 @@
 
 /**
  * Override default stacking order with z-index classes. Whenever possible, rely on
- * built-in stacking order and avoid these rules. Class set includes `-ms`, `-ml`, and `-mxl` variations to target screen sizes.
+ * built-in stacking order and avoid these rules. Class set includes `-mm`, `-ml`, and `-mxl` variations to target screen sizes.
  *
  * @group
  * @memberof Positioning
@@ -547,7 +547,7 @@
 
 /**
  * All margin classes follow the following pattern:
- * `m<side><margin-size>-<screen-size>`. Screen sizes are *optional* and are `-ms`, `-ml`, and `-mxl`.
+ * `m<side><margin-size>-<screen-size>`. Screen sizes are *optional* and are `-mm`, `-ml`, and `-mxl`.
  *
  * @section Margins
  * @memberof Layout
@@ -652,51 +652,51 @@
 /** @endgroup */
 
 @media (--m-screen) {
-  .mr0-l { margin-right: 0 !important; }
-  .mr3-l { margin-right: 3px !important; }
-  .mr6-l { margin-right: 6px !important; }
-  .mr12-l { margin-right: 12px !important; }
-  .mr18-l { margin-right: 18px !important; }
-  .mr24-l { margin-right: 24px !important; }
-  .mr48-l { margin-right: 48px !important; }
-  .mr72-l { margin-right: 72px !important; }
-  .mr96-l { margin-right: 96px !important; }
-  .mr120-l { margin-right: 120px !important; }
-  .mr180-l { margin-right: 180px !important; }
-  .mr240-l { margin-right: 240px !important; }
-  .mr480-l { margin-right: 480px !important; }
+  .mr0-ml { margin-right: 0 !important; }
+  .mr3-ml { margin-right: 3px !important; }
+  .mr6-ml { margin-right: 6px !important; }
+  .mr12-ml { margin-right: 12px !important; }
+  .mr18-ml { margin-right: 18px !important; }
+  .mr24-ml { margin-right: 24px !important; }
+  .mr48-ml { margin-right: 48px !important; }
+  .mr72-ml { margin-right: 72px !important; }
+  .mr96-ml { margin-right: 96px !important; }
+  .mr120-ml { margin-right: 120px !important; }
+  .mr180-ml { margin-right: 180px !important; }
+  .mr240-ml { margin-right: 240px !important; }
+  .mr480-ml { margin-right: 480px !important; }
 }
 
 @media (--l-screen) {
-  .mr0-m { margin-right: 0 !important; }
-  .mr3-m { margin-right: 3px !important; }
-  .mr6-m { margin-right: 6px !important; }
-  .mr12-m { margin-right: 12px !important; }
-  .mr18-m { margin-right: 18px !important; }
-  .mr24-m { margin-right: 24px !important; }
-  .mr48-m { margin-right: 48px !important; }
-  .mr72-m { margin-right: 72px !important; }
-  .mr96-m { margin-right: 96px !important; }
-  .mr120-m { margin-right: 120px !important; }
-  .mr180-m { margin-right: 180px !important; }
-  .mr240-m { margin-right: 240px !important; }
-  .mr480-m { margin-right: 480px !important; }
+  .mr0-ml { margin-right: 0 !important; }
+  .mr3-ml { margin-right: 3px !important; }
+  .mr6-ml { margin-right: 6px !important; }
+  .mr12-ml { margin-right: 12px !important; }
+  .mr18-ml { margin-right: 18px !important; }
+  .mr24-ml { margin-right: 24px !important; }
+  .mr48-ml { margin-right: 48px !important; }
+  .mr72-ml { margin-right: 72px !important; }
+  .mr96-ml { margin-right: 96px !important; }
+  .mr120-ml { margin-right: 120px !important; }
+  .mr180-ml { margin-right: 180px !important; }
+  .mr240-ml { margin-right: 240px !important; }
+  .mr480-ml { margin-right: 480px !important; }
 }
 
 @media (--xl-screen) {
-  .mr0-s { margin-right: 0 !important; }
-  .mr3-s { margin-right: 3px !important; }
-  .mr6-s { margin-right: 6px !important; }
-  .mr12-s { margin-right: 12px !important; }
-  .mr18-s { margin-right: 18px !important; }
-  .mr24-s { margin-right: 24px !important; }
-  .mr48-s { margin-right: 48px !important; }
-  .mr72-s { margin-right: 72px !important; }
-  .mr96-s { margin-right: 96px !important; }
-  .mr120-s { margin-right: 120px !important; }
-  .mr180-s { margin-right: 180px !important; }
-  .mr240-s { margin-right: 240px !important; }
-  .mr480-s { margin-right: 480px !important; }
+  .mr0-mxl { margin-right: 0 !important; }
+  .mr3-mxl { margin-right: 3px !important; }
+  .mr6-mxl { margin-right: 6px !important; }
+  .mr12-mxl { margin-right: 12px !important; }
+  .mr18-mxl { margin-right: 18px !important; }
+  .mr24-mxl { margin-right: 24px !important; }
+  .mr48-mxl { margin-right: 48px !important; }
+  .mr72-mxl { margin-right: 72px !important; }
+  .mr96-mxl { margin-right: 96px !important; }
+  .mr120-mxl { margin-right: 120px !important; }
+  .mr180-mxl { margin-right: 180px !important; }
+  .mr240-mxl { margin-right: 240px !important; }
+  .mr480-mxl { margin-right: 480px !important; }
 }
 
 /**
@@ -845,7 +845,7 @@
 
 /**
  * All padding classes follow the following pattern:
- * `m<side><padding-size>-<screen-size>`. Screen sizes are *optional* and are `-ms`, `-ml`, and `-mxl`.
+ * `m<side><padding-size>-<screen-size>`. Screen sizes are *optional* and are `-mm`, `-ml`, and `-mxl`.
  *
  * @section Padding
  * @memberof Layout
@@ -1123,7 +1123,7 @@
 
 /**
  * All sizing classes follow the following pattern:
- * `<w|h><min|max><dimension-size>-<screen-size>`. Min/max values are optional. Screen sizes are *optional* and are `-ms`, `-ml`, and `-mxl`.
+ * `<w|h><min|max><dimension-size>-<screen-size>`. Min/max values are optional. Screen sizes are *optional* and are `-mm`, `-ml`, and `-mxl`.
  *
  * @section Sizing
  * @memberof Layout
@@ -1538,7 +1538,7 @@
 }
 
 /**
- * Set the height of an element relative to the viewport. Class set includes `-ms`, `-ml`, and `-mxl` variations to target screen sizes.
+ * Set the height of an element relative to the viewport. Class set includes `-mm`, `-ml`, and `-mxl` variations to target screen sizes.
  *
  * @group
  * @memberof Sizing

--- a/src/media-queries.json
+++ b/src/media-queries.json
@@ -1,5 +1,5 @@
 {
-  "--xl-screen": "only screen and (min-width: 1600px)",
-  "--l-screen": "only screen and (min-width: 800px), screen and (min-height: 640px)",
-  "--m-screen": "only screen and (min-width: 640px), screen and (min-height: 420px)"
+  "--xl-screen": "screen and (min-width: 1600px)",
+  "--l-screen": "screen and (min-width: 800px) and (min-height: 640px)",
+  "--m-screen": "screen and (min-width: 640px) and (min-height: 420px)"
 }

--- a/src/typography.css
+++ b/src/typography.css
@@ -18,7 +18,7 @@ textarea {
 }
 
 /**
- * Standard text scale. All text size classes include `-ms`, `-ml`, and `-mxl` variations to target screen sizes.
+ * Standard text scale. All text size classes include `-mm`, `-ml`, and `-mxl` variations to target screen sizes.
  *
  * @memberof Typography
  * @group
@@ -68,37 +68,37 @@ textarea {
 /** @endgroup */
 
 @media (--m-screen) {
-  .txt-headline-ms {
+  .txt-headline-mm {
     font-size: 32px;
     line-height: 42px;
   }
 
-  .txt-subhead-ms {
+  .txt-subhead-mm {
     font-size: 28px;
     line-height: 36px;
   }
 
-  .txt-xl-ms {
+  .txt-xl-mm {
     font-size: 22px;
     line-height: 30px;
   }
 
-  .txt-l-ms {
+  .txt-l-mm {
     font-size: 18px;
     line-height: 30px;
   }
 
-  .txt-m-ms {
+  .txt-m-mm {
     font-size: 15px;
     line-height: 24px;
   }
 
-  .txt-s-ms {
+  .txt-s-mm {
     font-size: 12px;
     line-height: 18px;
   }
 
-  .txt-xs-ms {
+  .txt-xs-mm {
     font-size: 12px;
     line-height: 15px;
   }


### PR DESCRIPTION
This PR also saves us some KB by renaming media query rules:

`mxl`, `ml` and `mm` instead of `media-l`, `media-m`, `media-s`.