### PR TITLE
Wrap SVG script in IIFE

### DIFF
--- a/scripts/create-svg-sprite.js
+++ b/scripts/create-svg-sprite.js
@@ -21,10 +21,10 @@ const svgo = new SVGO({
 });
 
 const baseJsTemplate = _.template(
-`var svgDocument = (new DOMParser()).parseFromString('<%= svgSprite %>', 'text/xml');
+`(function() { var svgDocument = (new DOMParser()).parseFromString('<%= svgSprite %>', 'text/xml');
 document.addEventListener("DOMContentLoaded", function() {
   document.body.appendChild(svgDocument.getElementById("svg-symbols"));
-});`
+});}());`
 );
 
 function addFileToSprite(filename, sprite, callback) {


### PR DESCRIPTION
Wrap the SVG JS code in an immediately invoked function expression to, because there's no need to add global variable.

@tristen for review.