### PR TITLE
Punch up focus opacity, remove shadow from link hover.

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -83,6 +83,10 @@ a:focus {
   box-shadow: var(--focus-shadow) !important;
 }
 
+a:hover {
+  box-shadow: none !important;
+}
+
 button::-moz-focus-inner {
   padding: 0;
   border: 0;

--- a/src/variables.json
+++ b/src/variables.json
@@ -72,5 +72,5 @@
 
   "transition": "0.125s",
 
-  "focus-shadow": "0 0 12px 0 rgba(0, 0, 0, 0.25)"
+  "focus-shadow": "0 0 5px 0 rgba(0, 0, 0, 0.75)"
 }


### PR DESCRIPTION
1. Fixes https://github.com/mapbox/assembly/issues/416
2. Removes shadow from `a:hover` in reset to avoid this:

![screen shot 2016-12-20 at 10 49 34](https://cloud.githubusercontent.com/assets/8495845/21431706/5f1761d2-c836-11e6-94a8-9949c8295d5c.png)

@davidtheclark for review