### PR TITLE
Fix mobile view by removing flex-parent--center-main

### DIFF
--- a/site/page.js
+++ b/site/page.js
@@ -5,13 +5,11 @@ class Page extends React.Component {
   render() {
     return (
       <div>
-        <div className='bg-darken5 pt24 pr18 pb24 pl24 viewport-full-mm scroll-auto w180-mm fixed-mm top left'>
+        <div className='bg-darken5 scroll-auto viewport-full-mm w180-mm fixed-mm top left pt24 pr18 pb24 pl24'>
           <Navigation navData={this.props.navData} />
         </div>
-        <div className='mb24 ml180-mm flex-parent flex-parent--center-main'>
-          <div className='pl48 pr48 wmax1200 mb48'>
-            {this.props.children}
-          </div>
+        <div className='ml180-mm wmax1200 pl24 pr24 pl48-mm pr48-mm mb24'>
+          {this.props.children}
         </div>
       </div>
     );

--- a/src/layout.css
+++ b/src/layout.css
@@ -1664,10 +1664,10 @@
  * Prevent the child from shrinking below its width value.
  * @memberof Flexbox
  * @example
- * <div class='bg-darken10 w480 flex-parent'>
- *  <div class='border w240 flex-child-noshrink'>child</div>
- *  <div class='border w240'>child</div>
- *  <div class='border w240'>child</div>
+ * <div class='bg-darken10 w240 flex-parent'>
+ *  <div class='border w120 flex-child-noshrink'>child</div>
+ *  <div class='border w120'>child</div>
+ *  <div class='border w120'>child</div>
  * </div>
  */
 .flex-child-noshrink { flex-shrink: 0 !important; }


### PR DESCRIPTION
Fixes https://github.com/mapbox/assembly/issues/457 so the site is no longer broken on narrow screens:

<img width="465" alt="screen shot 2017-01-02 at 1 19 43" src="https://cloud.githubusercontent.com/assets/8495845/21594230/290609a2-d0ee-11e6-96ee-465a15423730.png">

Also fixes a flexbox example that looked bad on mobile.

<hr>

Note that centering the main documentation content with `flex-parent--center-main` wasn't playing so nicely with the fixed sidebar; when resizing the page, the left margin rule is disobeyed, causing overlap with the sidebar.

I removed centering altogether, and I actually think this looks better than centering anyway! Left alignment keeps the content connected to the sidebar rather than floating in space on large screen widths.

<img width="1262" alt="screen shot 2017-01-02 at 1 18 07" src="https://cloud.githubusercontent.com/assets/8495845/21594221/ffeba6bc-d0ed-11e6-8d7e-57cae1718506.png">

*versus*

<img width="1274" alt="screen shot 2017-01-02 at 1 18 28" src="https://cloud.githubusercontent.com/assets/8495845/21594222/044bfef0-d0ee-11e6-82d8-91303c601c70.png">

@samanpwbb for review