### PR TITLE
Magic focus ring management

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "check-size": "node scripts/check-size",
     "build:site": "node scripts/build-site",
     "build:css": "node scripts/build-css",
-    "build:svg": "node scripts/build-svg-sprite",
-    "build": "rm -rf dist && npm-run-all --parallel build:css build:svg build:site",
+    "build:js": "node scripts/build-js",
+    "build": "rm -rf dist && npm-run-all --parallel build:css build:js build:site",
     "lint:css": "stylelint src/*.css",
     "lint:js": "eslint .",
     "lint": "npm run lint:css && npm run lint:js",
     "serve": "node scripts/serve",
-    "start": "npm run build:svg && npm run serve",
+    "start": "npm run build:js && npm run serve",
     "test:jest": "jest",
     "test:svgs": "tape test/test-icons.tape.js | tap-spec",
     "test": "npm run lint && npm run test:svgs && npm run test:jest && npm run build:site"
@@ -68,6 +68,7 @@
     "highlight.js": "^9.8.0",
     "nodemon": "^1.11.0",
     "npm-run-all": "^4.0.0",
+    "optimize-js": "^1.0.2",
     "pretty-bytes": "^4.0.2",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
@@ -77,6 +78,7 @@
     "stylelint": "^7.6.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.3",
+    "uglify-js": "^2.7.5",
     "xml2js": "^0.4.17"
   },
   "jest": {

--- a/scripts/build-css.js
+++ b/scripts/build-css.js
@@ -31,6 +31,7 @@ function handlePostcssError(error) {
 
 const assemblyCssFiles = [
   getCssPath('reset'),
+  getCssPath('focus'),
   getCssPath('fonts'),
   getCssPath('typography'),
   getCssPath('tables'),

--- a/scripts/build-js.js
+++ b/scripts/build-js.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+const pify = require('pify');
+const globby = require('globby');
+const UglifyJS = require('uglify-js');
+const optimizeJs = require('optimize-js');
+const timelog = require('./timelog');
+const buildSvgLoader = require('./build-svg-loader');
+
+const jsGlob = path.join(__dirname, '../src/js/*.js');
+
+function buildJs(outfile) {
+  timelog('Building JS');
+  outfile = outfile || path.join(__dirname, '../dist/assembly.js');
+
+  return Promise.all([
+    buildSvgLoader(),
+    concatJs()
+  ])
+    .then((data) => {
+      return UglifyJS.minify(data.join(''), { fromString: true }).code;
+    })
+    .then((minifiedJs) => {
+      return optimizeJs(minifiedJs);
+    })
+    .then((optimizedJs) => {
+      return pify(mkdirp)(path.join(__dirname, '../dist')).then(() => {
+        return pify(fs.writeFile)(outfile, optimizedJs);
+      });
+    }).then(() => {
+      timelog('Done building JS');
+    });
+}
+
+function concatJs() {
+  let result = '';
+  return globby(jsGlob).then((jsFiles) => {
+    return Promise.all(jsFiles.map((jsFile) => {
+      return pify(fs.readFile)(jsFile, 'utf8').then((jsFileContent) => {
+        result += jsFileContent;
+      });
+    }));
+  }).then(() => result);
+}
+
+module.exports = buildJs;
+
+if (require.main === module) {
+  buildJs().catch((err) => console.error(err.stack));
+}

--- a/scripts/build-user-assets.js
+++ b/scripts/build-user-assets.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const buildCss = require('./build-css');
-const buildSvgSprite = require('./build-svg-sprite');
+const buildJs = require('./build-js');
 const copyFonts = require('./copy-fonts');
 
 function buildUserAssets(outdir, options) {
@@ -12,11 +12,11 @@ function buildUserAssets(outdir, options) {
     outfile: path.join(outdir, 'assembly.css')
   }, options);
 
-  const svgOutfile = path.join(outdir, 'assembly-svg.js');
+  const jsOutfile = path.join(outdir, 'assembly.js');
 
   return Promise.all([
     buildCss(buildCssOptions),
-    buildSvgSprite(svgOutfile),
+    buildJs(jsOutfile),
     copyFonts(outdir)
   ]);
 }

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -7,19 +7,19 @@ const child_process = require('child_process');
 const prettyBytes = require('pretty-bytes');
 const gzipSize = require('gzip-size');
 
-child_process.execSync('node_modules/.bin/npm-run-all --parallel build:svg build:css');
+child_process.execSync('node_modules/.bin/npm-run-all --parallel build:js build:css');
 
 const readCss = pify(fs.readFile)(path.join(__dirname, '../dist/assembly.min.css'));
-const readSvg = pify(fs.readFile)(path.join(__dirname, '../dist/assembly-svg.js'));
+const readJs = pify(fs.readFile)(path.join(__dirname, '../dist/assembly.js'));
 
-Promise.all([readCss, readSvg]).then((data) => {
+Promise.all([readCss, readJs]).then((data) => {
   const cssBuffer = data[0];
-  const svgBuffer = data[1];
+  const jsBuffer = data[1];
   const cssSize = prettyBytes(Buffer.byteLength(cssBuffer, 'utf8'));
-  const svgSize = prettyBytes(Buffer.byteLength(svgBuffer, 'utf8'));
+  const jsSize = prettyBytes(Buffer.byteLength(jsBuffer, 'utf8'));
   const cssGzipSize = prettyBytes(gzipSize.sync(cssBuffer));
-  const svgGzipSize = prettyBytes(gzipSize.sync(svgBuffer));
+  const jsGzipSize = prettyBytes(gzipSize.sync(jsBuffer));
 
   console.log(`CSS: ${cssSize} (minified) => ${cssGzipSize} (gzipped)`);
-  console.log(`SVG: ${svgSize} => ${svgGzipSize} (gzipped)`);
+  console.log(`SVG: ${jsSize} => ${jsGzipSize} (gzipped)`);
 });

--- a/site/home.js
+++ b/site/home.js
@@ -2,7 +2,7 @@ import React from 'react';
 const defaultMediaQueries = require('../src/media-queries');
 
 const headIncludes = `<link href="https://www.mapbox.com/assembly/assembly.css" rel="stylesheet"
-<script src="https://www.mapbox.com/assembly/assembly-svg.js"></script>`;
+<script src="https://www.mapbox.com/assembly/assembly.js"></script>`;
 
 class Home extends React.Component {
   render() {

--- a/site/template.html
+++ b/site/template.html
@@ -7,7 +7,7 @@
   <link rel='shortcut icon' href='/img/favicon.ico' type='image/x-icon' />
   <link href='/assembly/hljs.css' rel='stylesheet' type='text/css'>
   <link href='/assembly/assembly.css' rel='stylesheet' type='text/css'>
-  <script src='/assembly/assembly-svg.js'></script>
+  <script src='/assembly/assembly.js'></script>
 </head>
 <body>
 {content}

--- a/src/buttons.css
+++ b/src/buttons.css
@@ -38,7 +38,9 @@
   align-items: center;
   justify-content: center;
   text-decoration: none !important; /* prevent underline when inside .prose */
-  transition: background-color var(--transition), box-shadow var(--transition), border-color var(--transition), color var(--transition);
+  transition: background-color var(--transition),
+    border-color var(--transition),
+    color var(--transition);
 }
 
 /**
@@ -222,11 +224,4 @@ against .round class */
 
 .btn--stroke.btn--pill-vb {
   margin-top: -2px;
-}
-
-/* focus states */
-
-.btn:focus {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--neutral45);
 }

--- a/src/focus.css
+++ b/src/focus.css
@@ -1,0 +1,40 @@
+/* stylelint-disable selector-no-universal, selector-no-combinator, selector-no-type */
+.focus-control *:focus {
+  outline: 0;
+}
+
+.focus-control.focus-control--visible *:focus {
+  box-shadow: var(--focus-shadow);
+  transition: box-shadow var(--transition);
+}
+
+/* Shared form component focus states */
+.focus-control.focus-control--visible input:focus + .checkbox,
+.focus-control.focus-control--visible input:focus + .radio,
+.focus-control.focus-control--visible input:focus + .switch,
+.focus-control.focus-control--visible input:focus + .toggle {
+  box-shadow: var(--focus-shadow);
+}
+
+/* Range focus */
+.focus-control.focus-control--visible .range {
+  box-shadow: none;
+}
+.focus-control.focus-control--visible .range:focus::-webkit-slider-thumb {
+  box-shadow: var(--focus-shadow);
+}
+.focus-control.focus-control--visible .range:focus::-ms-fill-upper {
+  box-shadow: var(--focus-shadow);
+}
+.focus-control.focus-control--visible .range:focus::-ms-fill-lower {
+  box-shadow: var(--focus-shadow);
+}
+.focus-control.focus-control--visible .range:focus::-ms-thumb {
+  box-shadow: var(--focus-shadow);
+}
+.focus-control.focus-control--visible .range:focus::-moz-range-thumb {
+  box-shadow: var(--focus-shadow);
+}
+
+.focus-control .range::-moz-focus-outer { border: 0; }
+/* stylelint-enable selector-no-universal, selector-no-combinator, selector-no-type */

--- a/src/forms.css
+++ b/src/forms.css
@@ -28,7 +28,8 @@
   border: 1px solid var(--blue);
   border-radius: var(--border-radius);
   display: inline-block;
-  transition: background-color var(--transition), box-shadow var(--transition), border-color var(--transition);
+  transition: background-color var(--transition),
+    border-color var(--transition);
 }
 
 .input:hover,
@@ -36,12 +37,6 @@
 .input:focus,
 .textarea:focus {
   border-color: var(--blue-dark);
-  outline: none;
-}
-
-.input:focus,
-.textarea:focus {
-  box-shadow: inset 0 0 0 2px var(--neutral25);
 }
 
 .input::placeholder,
@@ -201,7 +196,8 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   padding: 4px 30px 4px 12px; /* plus arrow, minus border */
   cursor: pointer;
   display: inline-block;
-  transition: box-shadow var(--transition), color var(--transition), background-color var(--transition);
+  transition: color var(--transition),
+    background-color var(--transition);
   border-width: 2px;
   border-style: solid;
   border-color: transparent;
@@ -415,7 +411,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /* range thumb */
 .range::-webkit-slider-thumb {
-  transition: box-shadow var(--transition), background var(--transition);
+  transition: background var(--transition);
   appearance: none;
   box-shadow: 0;
   width: 20px;
@@ -428,7 +424,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 }
 
 .range::-moz-range-thumb {
-  transition: box-shadow var(--transition), background var(--transition);
+  transition: background var(--transition);
   width: 17px;
   height: 17px;
   border-radius: 50%;
@@ -438,7 +434,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 }
 
 .range::-ms-thumb {
-  transition: box-shadow var(--transition), background var(--transition);
+  transition: background var(--transition);
   width: 20px;
   height: 20px;
   border-radius: 50%;
@@ -485,33 +481,6 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   height: 15px;
 }
 
-/* Range focus */
-.range:focus {
-  outline: none;
-}
-.range:focus::-webkit-slider-thumb {
-  transform: box-shadow var(--transition);
-  box-shadow: 0 0 0 3px var(--neutral45);
-}
-.range:focus::-ms-fill-upper {
-  transform: box-shadow var(--transition);
-  box-shadow: 0 0 0 3px var(--neutral45);
-}
-.range:focus::-ms-fill-lower {
-  transform: box-shadow var(--transition);
-  box-shadow: 0 0 0 3px var(--neutral45);
-}
-.range:focus::-ms-thumb {
-  transform: box-shadow var(--transition);
-  box-shadow: 0 0 0 3px var(--neutral45);
-}
-.range:focus::-moz-range-thumb {
-  transform: box-shadow var(--transition);
-  box-shadow: 0 0 0 3px var(--neutral45);
-}
-
-.range::-moz-focus-outer { border: 0; }
-
 /*
  * When a range element has the `disabled` attribute, it will be styled accordingly.
  *
@@ -557,7 +526,8 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-width: 2px;
   border-style: solid;
   border-color: transparent;
-  transition: box-shadow var(--transition), color var(--transition), background-color var(--transition);
+  transition: color var(--transition),
+    background-color var(--transition);
 }
 
 /**
@@ -710,7 +680,9 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-style: solid;
   border-color: currentColor;
   color: var(--blue);
-  transition: box-shadow var(--transition), color var(--transition), background-color var(--transition), border-color var(--transition);
+  transition: color var(--transition),
+    background-color var(--transition),
+    border-color var(--transition);
 }
 
 .switch::after {
@@ -783,7 +755,8 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-radius: 13px;
   text-decoration: none !important; /* prevent underline when inside .prose */
   background-color: transparent;
-  transition: color var(--transition), background-color var(--transition), box-shadow var(--transition);
+  transition: color var(--transition),
+    background-color var(--transition);
 }
 /** @endgroup */
 
@@ -826,16 +799,6 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 .checkbox--s-label,
 .radio--s-label {
   top: 0;
-}
-
-/* Shared focus states */
-input:focus + .checkbox,
-input:focus + .radio,
-input:focus + .switch,
-input:focus + .toggle,
-.select:focus {
-  outline: 0;
-  box-shadow: 0 0 0 3px var(--neutral45);
 }
 
 input:disabled {

--- a/src/icons.css
+++ b/src/icons.css
@@ -1,5 +1,5 @@
 /**
- * Assembly uses an SVG icon sprite. To load the sprite, you must must include [assembly-svg.js](https://www.mapbox.com/assembly/assembly-svg.js) on your page.
+ * Assembly uses an SVG icon sprite. To load the sprite, you must must include [assembly.js](https://www.mapbox.com/assembly/assembly.js) on your page.
  *
  * @section Icons
  */
@@ -7,7 +7,7 @@
 /**
  * The `icon` class must be appled to an `<svg>` element.
  * Inside the `<svg>`, insert a `<use>` element whose `xlink:href` attribute
- * points to an icon loaded by `assembly-svg.js`. All icons are referenced
+ * points to an icon loaded by `assembly.js`. All icons are referenced
  * by the string `#icon-{name}`.
  *
  * To see a list of all available icons, visit [the icons page](/assembly/icons).

--- a/src/js/focus-ring.js
+++ b/src/js/focus-ring.js
@@ -1,0 +1,17 @@
+/* eslint-disable */
+(function () {
+  document.documentElement.classList.add('focus-control');
+  var activeClass = 'focus-control--visible';
+  var on = false;
+  document.addEventListener('mousedown', function () {
+    if (on === false) return;
+    on = false;
+    document.documentElement.classList.remove(activeClass);
+  });
+  document.addEventListener('keydown', function (event) {
+    if (on === true) return;
+    if (event.key !== 'Tab' && event.keyCode !== 9) return;
+    on = true;
+    document.documentElement.classList.add(activeClass);
+  });
+}());

--- a/src/links.css
+++ b/src/links.css
@@ -35,8 +35,3 @@
 .link.is-active {
   color: var(--blue-dark);
 }
-
-.link:focus {
-  outline: 0;
-  text-decoration: underline;
-}

--- a/src/miscellaneous.css
+++ b/src/miscellaneous.css
@@ -136,22 +136,3 @@
 .clip {
   overflow: hidden !important;
 }
-
-/**
- * Apply Assembly's default focus outline when an element is focused.
- *
- * Inputs, selects, buttons, and links already handle focus states.
- * You'll only need to apply this class to other things that you make focusable
- * (e.g. by adding a `tabindex`). If you do not use this class on a focusable
- * element, that element will receive the browser's default focus outline.
- *
- * @memberof Miscellaneous
- * @example
- * <div tabindex='0' class='focusable inline-block bg-blue-light p6'>
- *   I am a div but focusable
- * </div>
- */
-.focusable:focus {
-  outline: 0 !important;
-  box-shadow: var(--focus-shadow) !important;
-}

--- a/src/reset.css
+++ b/src/reset.css
@@ -74,11 +74,6 @@ button {
   cursor: pointer;
 }
 
-*:hover,
-*:active {
-  outline: 0;
-}
-
 a:hover {
   box-shadow: none;
 }

--- a/src/variables.json
+++ b/src/variables.json
@@ -60,9 +60,9 @@
   "white": "#fff",
   "transparent": "transparent",
 
-  "neutral10": "rgba(127, 127, 127, .10)",
-  "neutral25": "rgba(127, 127, 127, .25)",
-  "neutral45": "rgba(127, 127, 127, .45)",
+  "neutral10": "rgba(127, 127, 127, 0.10)",
+  "neutral25": "rgba(127, 127, 127, 0.25)",
+  "neutral45": "rgba(127, 127, 127, 0.45)",
 
   "text-color": "rgba(0, 0, 0, 0.75)",
 
@@ -72,7 +72,7 @@
 
   "transition": "0.125s",
 
-  "focus-shadow": "0 0 5px 0 rgba(0, 0, 0, 0.75)",
+  "focus-shadow": "0 0 0 3px rgba(137, 199, 216, 0.65)",
 
   "font-stack-base": "'Open Sans', sans-serif",
   "font-stack-mono": "'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace"

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,7 +46,7 @@ acorn@^2.1.0, acorn@^2.4.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
 
-acorn@^3.0.4, acorn@^3.1.0:
+acorn@^3.0.4, acorn@^3.1.0, acorn@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
@@ -1271,7 +1271,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6:
+concat-stream@^1.4.6, concat-stream@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1964,6 +1964,10 @@ estraverse@^4.1.1, estraverse@^4.2.0:
 estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
+
+estree-walker@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.0.tgz#f67ca8f57b9ed66d886af816c099c779b315d4db"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -3407,7 +3411,7 @@ lodash.assign@^3.0.0:
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
 
-lodash.assign@^4.2.0:
+lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
@@ -3560,6 +3564,12 @@ macaddress@^0.2.8:
 magic-string@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.14.0.tgz#57224aef1701caeed273b17a39a956e72b172462"
+  dependencies:
+    vlq "^0.2.1"
+
+magic-string@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.16.0.tgz#970ebb0da7193301285fb1aa650f39bdd81eb45a"
   dependencies:
     vlq "^0.2.1"
 
@@ -3991,6 +4001,16 @@ optimist@^0.6.1:
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
+
+optimize-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/optimize-js/-/optimize-js-1.0.2.tgz#1c5b8fd33ea9bd7fa3e4ecc0a9efa7e95f372907"
+  dependencies:
+    acorn "^3.3.0"
+    concat-stream "^1.5.1"
+    estree-walker "^0.3.0"
+    magic-string "^0.16.0"
+    yargs "^4.8.1"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
@@ -5689,7 +5709,7 @@ ua-parser-js@0.7.12, ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.6:
+uglify-js@^2.6, uglify-js@^2.7.5:
   version "2.7.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
   dependencies:
@@ -5954,13 +5974,9 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
-wordwrap@0.0.2:
+wordwrap@0.0.2, wordwrap@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wordwrap@~1.0.0:
   version "1.0.0"
@@ -6064,6 +6080,13 @@ yallist@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.0.0.tgz#306c543835f09ee1a4cb23b7bce9ab341c91cdd4"
 
+yargs-parser@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
+  dependencies:
+    camelcase "^3.0.0"
+    lodash.assign "^4.0.6"
+
 yargs-parser@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
@@ -6103,6 +6126,25 @@ yargs@6.4.0, yargs@^6.3.0:
 yargs@^1.2.6:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.3.3.tgz#054de8b61f22eefdb7207059eaef9d6b83fb931a"
+
+yargs@^4.8.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
+  dependencies:
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    lodash.assign "^4.0.3"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.1"
+    which-module "^1.0.0"
+    window-size "^0.2.0"
+    y18n "^3.2.1"
+    yargs-parser "^2.4.1"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Closes #493.

I had to modify the build process some for this. Instead of `assembly-svg.js`, we now have `assembly.js`, which concatenates the SVG-loading JS with any scripts in `src/js`. I also added uglification and silly optimization (via [optimize-js](https://github.com/nolanlawson/optimize-js)) to that concatenated script.

`focus-ring.js` is the simple little script that manages the focus ring.

I added `focus.css`, where the focus management nastiness is congregated and contained. After `focus-ring.js` runs, nothing gets its browser-default focus outline. Instead, once you press tab our special focus outline is added to everything. I made it a bright, mostly opaque blue. If anybody wants to tinker with that, it's the `--focus-shadow` variable.

This seems to be working nicely!

@samanpwbb and @mayagao for review. If you like how this works, I'll add some documentation to the homepage before merging.