### PR TITLE
Clarify and document custom builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,92 @@
-Assembly
----
+# Assembly
 
 A CSS framework that makes the hard parts of building anything on the web easy. We define the hard parts as: managing class specificity, designing cross-browser form components that work well with each other, creating a harmonious typographic scale, maintaining a baseline grid, and keeping responsive designs simple.
 
 [![Build Status](https://travis-ci.com/mapbox/assembly.svg?token=FB2dZNVWaGo68KZnwz9M&branch=mb-pages)](https://travis-ci.com/mapbox/assembly)
 
-Browser support
----
+## Browser support
 
 Assembly targets IE 11+ and other modern browsers.
+
+## Custom Builds
+
+Assembly exposes a JS module for creating custom builds. Why might you want to create a custom build?
+
+- You want to customize variables (like colors and font stacks) or media queries.
+- You want to append extra stylesheets that also use Assembly's variables and media queries.
+- You want to reduce file-size by picking and choosing the color variants you need.
+
+### buildUserAssets(outdir[, options])
+
+Returns a Promise that resolves when all assets have been written to `outdir`.
+
+```js
+const Assembly = require('assembly');
+buildUserAssets('path/to/my/outdir', myOptions)
+  .then(() => /* something */)
+  .catch((err) => /* handle error */);
+```
+
+**Options**, all of which are optional:
+
+- **`files`**: An array of file paths to stylesheets you would like to append to `assembly.css`. These will be processed through Assembly's PostCSS pipeline.
+- **`variables`**: An object whose properties will override and add to `src/variables.json`. Use this option to change or add variables.
+  These variables are accessible in any stylesheets you append via the CSS custom properties syntax, e.g. `var(--property-name)`.
+- **`mediaQueries`**: An object whose properties will override and add to `src/mediaQueries.json`. Use this option to change or add media queries.
+  These media queries are accessible in any stylesheets you append via the CSS custom media query syntax, e.g. `@media --media-query-name`.
+- **`colorVariants`**: An object or array specifying the color variants you would like added to `assembly.css`. This is documented in detail below.
+- **`quiet`**: Suppress logs.
+
+### `colorVariants` option
+
+If the `colorVariants` value is an array, it must be an array of color names corresponding to variables. All components will have color variants generated for all colors in the array.
+
+The following configuration specifies an array of universal colors. All components will have these (and *only these*) color variants.
+
+```json
+[
+  "red",
+  "teal",
+  "teal-dark",
+  "green-light"
+]
+```
+
+If the `colorVariants` value is an object, each property value must be an array of color names corresponding to variables. The property names designate which component each color array applies to:
+  - `universal`: These colors apply to all components that are not otherwise specified.
+  - `buttonFill`: `*-dark` colors will not be used.
+  - `buttonStroke`: `*-dark` colors will not be used.
+  - `inputTextarea`: `*-dark` colors will not be used.
+  - `selectFill`: `*-dark` colors will not be used.
+  - `selectStroke`: `*-dark` colors will not be used.
+  - `checkbox`: `*-dark` colors will not be used.
+  - `radio`: `*-dark` colors will not be used.
+  - `switch`: `*-dark` colors will not be used.
+  - `toggle`: `*-dark` colors will not be used.
+  - `range`: `*-dark` colors will not be used.
+  - `color`
+  - `background`
+  - `link`: `*-dark` colors will not be used.
+  - `border`
+  - `hoverShadow`: Only `lighten*` and `darken*` colors will be used.
+  - `hoverBackground`
+  - `hoverColor`
+  - `hoverBorder`
+
+The following configuration specifies colors for individual components. In this configuration, every component not specified will have the `universal` color variants; specified components will have their specified color variants; and `switch` and `range` components will have no color variants (only the default will be available).
+
+```json
+{
+  "universal": ["lighten50", "lighten25", "gray"],
+  "buttonFill": ["green", "purple"],
+  "selectFill": ["green"],
+  "background": ["orange", "yellow", "pink"],
+  "link": ["orange"],
+  "hoverShadow": ["lighten50"],
+  "switch": [],
+  "range": []
+}
+```
 
 ## Development principles
 

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -3,7 +3,7 @@
 const stripIndent = require('strip-indent');
 const defaultVariables = require('../src/variables');
 
-const allConfig = [
+const allColors = [
   'gray-dark',
   'gray',
   'gray-light',
@@ -76,10 +76,9 @@ function isDark(color) {
 
 function buildColorVariants(variables, config) {
   variables = Object.assign({}, defaultVariables, variables);
-  config = config || allConfig;
-  const universalColors = (Array.isArray(config))
-    ? config
-    : null;
+  const colorVariants = (Array.isArray(config))
+    ? { universal: config }
+    : Object.assign({ universal: allColors }, config);
 
   function getDarkerShade(color) {
     if (color === 'white') return variables['gray-faint'];
@@ -163,7 +162,7 @@ function buildColorVariants(variables, config) {
     }, '');
   };
 
-  variantGenerators.inputStroke = function (colors) {
+  variantGenerators.inputTextarea = function (colors) {
     return colors.reduce((result, color) => {
       if (isDark(color)) return result;
       const colorValue = variables[color];
@@ -296,8 +295,8 @@ function buildColorVariants(variables, config) {
       const darkerShade = getDarkerShade(color);
       // Set the text color to regular when inactive.
       // Set the text color to dark when inactive on hover.
-      // Set the background color to dark and text color to white
-      // when active.
+      // Set the background color to regular and text color to white when active.
+      // Set the text color of toggle label when active.
       return result += stripIndent(`
         .toggle--${color} {
           color: ${colorValue};
@@ -311,6 +310,10 @@ function buildColorVariants(variables, config) {
           background: ${colorValue};
           color: #fff;
         }
+
+        input:checked + .toggle--active-${color} {
+          color: ${colorValue};
+        }
       `);
     }, '');
   };
@@ -318,8 +321,8 @@ function buildColorVariants(variables, config) {
   variantGenerators.toggleActive = function (colors) {
     return colors.reduce((result, color) => {
       const colorValue = variables[color];
-      // Set the text color of toggle label when active.
-      // Must be below .toggle group in  stylesheet
+
+      // Must be below .toggle group in stylesheet
       return result += stripIndent(`
         input:checked + .toggle--active-${color} {
           color: ${colorValue};
@@ -449,14 +452,14 @@ function buildColorVariants(variables, config) {
        * @example
        * <div class='border border--red'>border--red</div>
        */`);
-    css +=  colors.reduce((result, color) => {
+    css += colors.reduce((result, color) => {
       return result += stripIndent(`
         .border--${color} {
           border-color: ${variables[color]} !important;
         }
       `);
     }, '');
-    css +=  '/** @endgroup */';
+    css += '/** @endgroup */';
     return css;
   };
 
@@ -486,7 +489,7 @@ function buildColorVariants(variables, config) {
         }
       `);
     }, '');
-    css +=  '/** @endgroup */';
+    css += '/** @endgroup */';
     return css;
   };
 
@@ -510,7 +513,7 @@ function buildColorVariants(variables, config) {
         }
       `);
     }, '');
-    css +=  '/** @endgroup */';
+    css += '/** @endgroup */';
     return css;
   };
 
@@ -534,7 +537,7 @@ function buildColorVariants(variables, config) {
         }
       `);
     }, '');
-    css +=  '/** @endgroup */';
+    css += '/** @endgroup */';
     return css;
   };
 
@@ -558,14 +561,14 @@ function buildColorVariants(variables, config) {
         }
       `);
     }, '');
-    css +=  '/** @endgroup */';
+    css += '/** @endgroup */';
     return css;
   };
 
   let result = '\n/* Color variants */\n';
 
   Object.keys(variantGenerators).forEach((coloredThing) => {
-    const colors = universalColors || config[coloredThing];
+    const colors = colorVariants[coloredThing] || colorVariants.universal;
     if (colors === null || colors === undefined) return;
     result += variantGenerators[coloredThing](colors);
   });

--- a/scripts/build-css.js
+++ b/scripts/build-css.js
@@ -51,11 +51,12 @@ const assemblyCssFiles = [
  *
  * @param {Object} options
  * @param {string} [options.outfile] - Path to which built CSS should be written.
+ * @param {Array<string>} [options.files] - Paths to stylesheets that should be
+ *   processed and appended.
  * @param {Object} [options.variables] - Variables to override the defaults.
  * @param {Object} [options.mediaQueries] - Media queries to override the defaults.
- * @param {Object} [options.colorVariants] - Color variant config to override
- * @param {Object} [options.quiet] - Suppress logs
- *   the defaults. See `build-color-variants.js` for details.
+ * @param {Object} [options.colorVariants] - Color variant config to override.
+ * @param {Object} [options.quiet] - Suppress logs.
  * @return {Promise<void>}
  */
 function buildCss(options) {

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -3485,6 +3485,10 @@ input:checked + .toggle--gray {
   background: #666;
   color: #fff;
 }
+
+input:checked + .toggle--active-gray {
+  color: #666;
+}
       
 .toggle--gray-light {
   color: #ccc;
@@ -3497,6 +3501,10 @@ input:checked + .toggle--gray {
 input:checked + .toggle--gray-light {
   background: #ccc;
   color: #fff;
+}
+
+input:checked + .toggle--active-gray-light {
+  color: #ccc;
 }
       
 .toggle--gray-faint {
@@ -3511,6 +3519,10 @@ input:checked + .toggle--gray-faint {
   background: #f7f7f7;
   color: #fff;
 }
+
+input:checked + .toggle--active-gray-faint {
+  color: #f7f7f7;
+}
       
 .toggle--pink {
   color: #ff3c96;
@@ -3523,6 +3535,10 @@ input:checked + .toggle--gray-faint {
 input:checked + .toggle--pink {
   background: #ff3c96;
   color: #fff;
+}
+
+input:checked + .toggle--active-pink {
+  color: #ff3c96;
 }
       
 .toggle--pink-light {
@@ -3537,6 +3553,10 @@ input:checked + .toggle--pink-light {
   background: #FF88C0;
   color: #fff;
 }
+
+input:checked + .toggle--active-pink-light {
+  color: #FF88C0;
+}
       
 .toggle--pink-faint {
   color: #ffdbed;
@@ -3549,6 +3569,10 @@ input:checked + .toggle--pink-light {
 input:checked + .toggle--pink-faint {
   background: #ffdbed;
   color: #fff;
+}
+
+input:checked + .toggle--active-pink-faint {
+  color: #ffdbed;
 }
       
 .toggle--red {
@@ -3563,6 +3587,10 @@ input:checked + .toggle--red {
   background: #dc2b28;
   color: #fff;
 }
+
+input:checked + .toggle--active-red {
+  color: #dc2b28;
+}
       
 .toggle--red-light {
   color: #FF8280;
@@ -3575,6 +3603,10 @@ input:checked + .toggle--red {
 input:checked + .toggle--red-light {
   background: #FF8280;
   color: #fff;
+}
+
+input:checked + .toggle--active-red-light {
+  color: #FF8280;
 }
       
 .toggle--red-faint {
@@ -3589,6 +3621,10 @@ input:checked + .toggle--red-faint {
   background: #ffdad9;
   color: #fff;
 }
+
+input:checked + .toggle--active-red-faint {
+  color: #ffdad9;
+}
       
 .toggle--orange {
   color: #ff6e00;
@@ -3601,6 +3637,10 @@ input:checked + .toggle--red-faint {
 input:checked + .toggle--orange {
   background: #ff6e00;
   color: #fff;
+}
+
+input:checked + .toggle--active-orange {
+  color: #ff6e00;
 }
       
 .toggle--orange-light {
@@ -3615,6 +3655,10 @@ input:checked + .toggle--orange-light {
   background: #FFA950;
   color: #fff;
 }
+
+input:checked + .toggle--active-orange-light {
+  color: #FFA950;
+}
       
 .toggle--orange-faint {
   color: #FFE5CB;
@@ -3627,6 +3671,10 @@ input:checked + .toggle--orange-light {
 input:checked + .toggle--orange-faint {
   background: #FFE5CB;
   color: #fff;
+}
+
+input:checked + .toggle--active-orange-faint {
+  color: #FFE5CB;
 }
       
 .toggle--yellow {
@@ -3641,6 +3689,10 @@ input:checked + .toggle--yellow {
   background: #f0dc00;
   color: #fff;
 }
+
+input:checked + .toggle--active-yellow {
+  color: #f0dc00;
+}
       
 .toggle--yellow-light {
   color: #F0F062;
@@ -3653,6 +3705,10 @@ input:checked + .toggle--yellow {
 input:checked + .toggle--yellow-light {
   background: #F0F062;
   color: #fff;
+}
+
+input:checked + .toggle--active-yellow-light {
+  color: #F0F062;
 }
       
 .toggle--yellow-faint {
@@ -3667,6 +3723,10 @@ input:checked + .toggle--yellow-faint {
   background: #fafbd1;
   color: #fff;
 }
+
+input:checked + .toggle--active-yellow-faint {
+  color: #fafbd1;
+}
       
 .toggle--green {
   color: #01aa46;
@@ -3679,6 +3739,10 @@ input:checked + .toggle--yellow-faint {
 input:checked + .toggle--green {
   background: #01aa46;
   color: #fff;
+}
+
+input:checked + .toggle--active-green {
+  color: #01aa46;
 }
       
 .toggle--green-light {
@@ -3693,6 +3757,10 @@ input:checked + .toggle--green-light {
   background: #72C781;
   color: #fff;
 }
+
+input:checked + .toggle--active-green-light {
+  color: #72C781;
+}
       
 .toggle--green-faint {
   color: #d4edda;
@@ -3705,6 +3773,10 @@ input:checked + .toggle--green-light {
 input:checked + .toggle--green-faint {
   background: #d4edda;
   color: #fff;
+}
+
+input:checked + .toggle--active-green-faint {
+  color: #d4edda;
 }
       
 .toggle--teal {
@@ -3719,6 +3791,10 @@ input:checked + .toggle--teal {
   background: #01b5b4;
   color: #fff;
 }
+
+input:checked + .toggle--active-teal {
+  color: #01b5b4;
+}
       
 .toggle--teal-light {
   color: #50D2D2;
@@ -3731,6 +3807,10 @@ input:checked + .toggle--teal {
 input:checked + .toggle--teal-light {
   background: #50D2D2;
   color: #fff;
+}
+
+input:checked + .toggle--active-teal-light {
+  color: #50D2D2;
 }
       
 .toggle--teal-faint {
@@ -3745,6 +3825,10 @@ input:checked + .toggle--teal-faint {
   background: #cbf2f1;
   color: #fff;
 }
+
+input:checked + .toggle--active-teal-faint {
+  color: #cbf2f1;
+}
       
 .toggle--blue {
   color: #0065fb;
@@ -3757,6 +3841,10 @@ input:checked + .toggle--teal-faint {
 input:checked + .toggle--blue {
   background: #0065fb;
   color: #fff;
+}
+
+input:checked + .toggle--active-blue {
+  color: #0065fb;
 }
       
 .toggle--blue-light {
@@ -3771,6 +3859,10 @@ input:checked + .toggle--blue-light {
   background: #00B1FF;
   color: #fff;
 }
+
+input:checked + .toggle--active-blue-light {
+  color: #00B1FF;
+}
       
 .toggle--blue-faint {
   color: #bae8ff;
@@ -3783,6 +3875,10 @@ input:checked + .toggle--blue-light {
 input:checked + .toggle--blue-faint {
   background: #bae8ff;
   color: #fff;
+}
+
+input:checked + .toggle--active-blue-faint {
+  color: #bae8ff;
 }
       
 .toggle--purple {
@@ -3797,6 +3893,10 @@ input:checked + .toggle--purple {
   background: #8c50c7;
   color: #fff;
 }
+
+input:checked + .toggle--active-purple {
+  color: #8c50c7;
+}
       
 .toggle--purple-light {
   color: #C299E3;
@@ -3809,6 +3909,10 @@ input:checked + .toggle--purple {
 input:checked + .toggle--purple-light {
   background: #C299E3;
   color: #fff;
+}
+
+input:checked + .toggle--active-purple-light {
+  color: #C299E3;
 }
       
 .toggle--purple-faint {
@@ -3823,6 +3927,10 @@ input:checked + .toggle--purple-faint {
   background: #ede1f6;
   color: #fff;
 }
+
+input:checked + .toggle--active-purple-faint {
+  color: #ede1f6;
+}
       
 .toggle--darken5 {
   color: rgba(0, 0, 0, 0.05);
@@ -3835,6 +3943,10 @@ input:checked + .toggle--purple-faint {
 input:checked + .toggle--darken5 {
   background: rgba(0, 0, 0, 0.05);
   color: #fff;
+}
+
+input:checked + .toggle--active-darken5 {
+  color: rgba(0, 0, 0, 0.05);
 }
       
 .toggle--darken10 {
@@ -3849,6 +3961,10 @@ input:checked + .toggle--darken10 {
   background: rgba(0, 0, 0, 0.10);
   color: #fff;
 }
+
+input:checked + .toggle--active-darken10 {
+  color: rgba(0, 0, 0, 0.10);
+}
       
 .toggle--darken25 {
   color: rgba(0, 0, 0, 0.25);
@@ -3861,6 +3977,10 @@ input:checked + .toggle--darken10 {
 input:checked + .toggle--darken25 {
   background: rgba(0, 0, 0, 0.25);
   color: #fff;
+}
+
+input:checked + .toggle--active-darken25 {
+  color: rgba(0, 0, 0, 0.25);
 }
       
 .toggle--darken50 {
@@ -3875,6 +3995,10 @@ input:checked + .toggle--darken50 {
   background: rgba(0, 0, 0, 0.50);
   color: #fff;
 }
+
+input:checked + .toggle--active-darken50 {
+  color: rgba(0, 0, 0, 0.50);
+}
       
 .toggle--darken75 {
   color: rgba(0, 0, 0, 0.75);
@@ -3887,6 +4011,10 @@ input:checked + .toggle--darken50 {
 input:checked + .toggle--darken75 {
   background: rgba(0, 0, 0, 0.75);
   color: #fff;
+}
+
+input:checked + .toggle--active-darken75 {
+  color: rgba(0, 0, 0, 0.75);
 }
       
 .toggle--lighten5 {
@@ -3901,6 +4029,10 @@ input:checked + .toggle--lighten5 {
   background: rgba(255, 255, 255, 0.05);
   color: #fff;
 }
+
+input:checked + .toggle--active-lighten5 {
+  color: rgba(255, 255, 255, 0.05);
+}
       
 .toggle--lighten10 {
   color: rgba(255, 255, 255, 0.1);
@@ -3913,6 +4045,10 @@ input:checked + .toggle--lighten5 {
 input:checked + .toggle--lighten10 {
   background: rgba(255, 255, 255, 0.1);
   color: #fff;
+}
+
+input:checked + .toggle--active-lighten10 {
+  color: rgba(255, 255, 255, 0.1);
 }
       
 .toggle--lighten25 {
@@ -3927,6 +4063,10 @@ input:checked + .toggle--lighten25 {
   background: rgba(255, 255, 255, 0.25);
   color: #fff;
 }
+
+input:checked + .toggle--active-lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
       
 .toggle--lighten50 {
   color: rgba(255, 255, 255, 0.50);
@@ -3939,6 +4079,10 @@ input:checked + .toggle--lighten25 {
 input:checked + .toggle--lighten50 {
   background: rgba(255, 255, 255, 0.50);
   color: #fff;
+}
+
+input:checked + .toggle--active-lighten50 {
+  color: rgba(255, 255, 255, 0.50);
 }
       
 .toggle--lighten75 {
@@ -3953,6 +4097,10 @@ input:checked + .toggle--lighten75 {
   background: rgba(255, 255, 255, 0.75);
   color: #fff;
 }
+
+input:checked + .toggle--active-lighten75 {
+  color: rgba(255, 255, 255, 0.75);
+}
       
 .toggle--white {
   color: #fff;
@@ -3964,6 +4112,10 @@ input:checked + .toggle--lighten75 {
 
 input:checked + .toggle--white {
   background: #fff;
+  color: #fff;
+}
+
+input:checked + .toggle--active-white {
   color: #fff;
 }
       
@@ -3978,6 +4130,10 @@ input:checked + .toggle--white {
 input:checked + .toggle--transparent {
   background: transparent;
   color: #fff;
+}
+
+input:checked + .toggle--active-transparent {
+  color: transparent;
 }
       
 input:checked + .toggle--active-gray-dark {
@@ -10310,6 +10466,10 @@ input:checked + .toggle--gray {
   background: #666;
   color: #fff;
 }
+
+input:checked + .toggle--active-gray {
+  color: #666;
+}
       
 .toggle--gray-light {
   color: #ccc;
@@ -10322,6 +10482,10 @@ input:checked + .toggle--gray {
 input:checked + .toggle--gray-light {
   background: #ccc;
   color: #fff;
+}
+
+input:checked + .toggle--active-gray-light {
+  color: #ccc;
 }
       
 .toggle--gray-faint {
@@ -10336,6 +10500,10 @@ input:checked + .toggle--gray-faint {
   background: #f7f7f7;
   color: #fff;
 }
+
+input:checked + .toggle--active-gray-faint {
+  color: #f7f7f7;
+}
       
 .toggle--pink {
   color: pink;
@@ -10348,6 +10516,10 @@ input:checked + .toggle--gray-faint {
 input:checked + .toggle--pink {
   background: pink;
   color: #fff;
+}
+
+input:checked + .toggle--active-pink {
+  color: pink;
 }
       
 .toggle--pink-light {
@@ -10362,6 +10534,10 @@ input:checked + .toggle--pink-light {
   background: #FF88C0;
   color: #fff;
 }
+
+input:checked + .toggle--active-pink-light {
+  color: #FF88C0;
+}
       
 .toggle--pink-faint {
   color: #ffdbed;
@@ -10375,6 +10551,10 @@ input:checked + .toggle--pink-faint {
   background: #ffdbed;
   color: #fff;
 }
+
+input:checked + .toggle--active-pink-faint {
+  color: #ffdbed;
+}
       
 .toggle--red {
   color: #fff;
@@ -10386,6 +10566,10 @@ input:checked + .toggle--pink-faint {
 
 input:checked + .toggle--red {
   background: #fff;
+  color: #fff;
+}
+
+input:checked + .toggle--active-red {
   color: #fff;
 }
       
@@ -10401,6 +10585,10 @@ input:checked + .toggle--red-light {
   background: #FF8280;
   color: #fff;
 }
+
+input:checked + .toggle--active-red-light {
+  color: #FF8280;
+}
       
 .toggle--red-faint {
   color: #ffdad9;
@@ -10413,6 +10601,10 @@ input:checked + .toggle--red-light {
 input:checked + .toggle--red-faint {
   background: #ffdad9;
   color: #fff;
+}
+
+input:checked + .toggle--active-red-faint {
+  color: #ffdad9;
 }
       
 .toggle--orange {
@@ -10427,6 +10619,10 @@ input:checked + .toggle--orange {
   background: #ff6e00;
   color: #fff;
 }
+
+input:checked + .toggle--active-orange {
+  color: #ff6e00;
+}
       
 .toggle--orange-light {
   color: #FFA950;
@@ -10439,6 +10635,10 @@ input:checked + .toggle--orange {
 input:checked + .toggle--orange-light {
   background: #FFA950;
   color: #fff;
+}
+
+input:checked + .toggle--active-orange-light {
+  color: #FFA950;
 }
       
 .toggle--orange-faint {
@@ -10453,6 +10653,10 @@ input:checked + .toggle--orange-faint {
   background: #FFE5CB;
   color: #fff;
 }
+
+input:checked + .toggle--active-orange-faint {
+  color: #FFE5CB;
+}
       
 .toggle--yellow {
   color: #f0dc00;
@@ -10465,6 +10669,10 @@ input:checked + .toggle--orange-faint {
 input:checked + .toggle--yellow {
   background: #f0dc00;
   color: #fff;
+}
+
+input:checked + .toggle--active-yellow {
+  color: #f0dc00;
 }
       
 .toggle--yellow-light {
@@ -10479,6 +10687,10 @@ input:checked + .toggle--yellow-light {
   background: #F0F062;
   color: #fff;
 }
+
+input:checked + .toggle--active-yellow-light {
+  color: #F0F062;
+}
       
 .toggle--yellow-faint {
   color: #fafbd1;
@@ -10491,6 +10703,10 @@ input:checked + .toggle--yellow-light {
 input:checked + .toggle--yellow-faint {
   background: #fafbd1;
   color: #fff;
+}
+
+input:checked + .toggle--active-yellow-faint {
+  color: #fafbd1;
 }
       
 .toggle--green {
@@ -10505,6 +10721,10 @@ input:checked + .toggle--green {
   background: #01aa46;
   color: #fff;
 }
+
+input:checked + .toggle--active-green {
+  color: #01aa46;
+}
       
 .toggle--green-light {
   color: #72C781;
@@ -10517,6 +10737,10 @@ input:checked + .toggle--green {
 input:checked + .toggle--green-light {
   background: #72C781;
   color: #fff;
+}
+
+input:checked + .toggle--active-green-light {
+  color: #72C781;
 }
       
 .toggle--green-faint {
@@ -10531,6 +10755,10 @@ input:checked + .toggle--green-faint {
   background: #d4edda;
   color: #fff;
 }
+
+input:checked + .toggle--active-green-faint {
+  color: #d4edda;
+}
       
 .toggle--teal {
   color: #01b5b4;
@@ -10543,6 +10771,10 @@ input:checked + .toggle--green-faint {
 input:checked + .toggle--teal {
   background: #01b5b4;
   color: #fff;
+}
+
+input:checked + .toggle--active-teal {
+  color: #01b5b4;
 }
       
 .toggle--teal-light {
@@ -10557,6 +10789,10 @@ input:checked + .toggle--teal-light {
   background: #50D2D2;
   color: #fff;
 }
+
+input:checked + .toggle--active-teal-light {
+  color: #50D2D2;
+}
       
 .toggle--teal-faint {
   color: #cbf2f1;
@@ -10569,6 +10805,10 @@ input:checked + .toggle--teal-light {
 input:checked + .toggle--teal-faint {
   background: #cbf2f1;
   color: #fff;
+}
+
+input:checked + .toggle--active-teal-faint {
+  color: #cbf2f1;
 }
       
 .toggle--blue {
@@ -10583,6 +10823,10 @@ input:checked + .toggle--blue {
   background: #0065fb;
   color: #fff;
 }
+
+input:checked + .toggle--active-blue {
+  color: #0065fb;
+}
       
 .toggle--blue-light {
   color: #00B1FF;
@@ -10595,6 +10839,10 @@ input:checked + .toggle--blue {
 input:checked + .toggle--blue-light {
   background: #00B1FF;
   color: #fff;
+}
+
+input:checked + .toggle--active-blue-light {
+  color: #00B1FF;
 }
       
 .toggle--blue-faint {
@@ -10609,6 +10857,10 @@ input:checked + .toggle--blue-faint {
   background: #bae8ff;
   color: #fff;
 }
+
+input:checked + .toggle--active-blue-faint {
+  color: #bae8ff;
+}
       
 .toggle--purple {
   color: #8c50c7;
@@ -10621,6 +10873,10 @@ input:checked + .toggle--blue-faint {
 input:checked + .toggle--purple {
   background: #8c50c7;
   color: #fff;
+}
+
+input:checked + .toggle--active-purple {
+  color: #8c50c7;
 }
       
 .toggle--purple-light {
@@ -10635,6 +10891,10 @@ input:checked + .toggle--purple-light {
   background: #C299E3;
   color: #fff;
 }
+
+input:checked + .toggle--active-purple-light {
+  color: #C299E3;
+}
       
 .toggle--purple-faint {
   color: #ede1f6;
@@ -10647,6 +10907,10 @@ input:checked + .toggle--purple-light {
 input:checked + .toggle--purple-faint {
   background: #ede1f6;
   color: #fff;
+}
+
+input:checked + .toggle--active-purple-faint {
+  color: #ede1f6;
 }
       
 .toggle--darken5 {
@@ -10661,6 +10925,10 @@ input:checked + .toggle--darken5 {
   background: rgba(0, 0, 0, 0.05);
   color: #fff;
 }
+
+input:checked + .toggle--active-darken5 {
+  color: rgba(0, 0, 0, 0.05);
+}
       
 .toggle--darken10 {
   color: rgba(0, 0, 0, 0.10);
@@ -10673,6 +10941,10 @@ input:checked + .toggle--darken5 {
 input:checked + .toggle--darken10 {
   background: rgba(0, 0, 0, 0.10);
   color: #fff;
+}
+
+input:checked + .toggle--active-darken10 {
+  color: rgba(0, 0, 0, 0.10);
 }
       
 .toggle--darken25 {
@@ -10687,6 +10959,10 @@ input:checked + .toggle--darken25 {
   background: rgba(0, 0, 0, 0.25);
   color: #fff;
 }
+
+input:checked + .toggle--active-darken25 {
+  color: rgba(0, 0, 0, 0.25);
+}
       
 .toggle--darken50 {
   color: rgba(0, 0, 0, 0.50);
@@ -10699,6 +10975,10 @@ input:checked + .toggle--darken25 {
 input:checked + .toggle--darken50 {
   background: rgba(0, 0, 0, 0.50);
   color: #fff;
+}
+
+input:checked + .toggle--active-darken50 {
+  color: rgba(0, 0, 0, 0.50);
 }
       
 .toggle--darken75 {
@@ -10713,6 +10993,10 @@ input:checked + .toggle--darken75 {
   background: rgba(0, 0, 0, 0.75);
   color: #fff;
 }
+
+input:checked + .toggle--active-darken75 {
+  color: rgba(0, 0, 0, 0.75);
+}
       
 .toggle--lighten5 {
   color: rgba(255, 255, 255, 0.05);
@@ -10725,6 +11009,10 @@ input:checked + .toggle--darken75 {
 input:checked + .toggle--lighten5 {
   background: rgba(255, 255, 255, 0.05);
   color: #fff;
+}
+
+input:checked + .toggle--active-lighten5 {
+  color: rgba(255, 255, 255, 0.05);
 }
       
 .toggle--lighten10 {
@@ -10739,6 +11027,10 @@ input:checked + .toggle--lighten10 {
   background: rgba(255, 255, 255, 0.1);
   color: #fff;
 }
+
+input:checked + .toggle--active-lighten10 {
+  color: rgba(255, 255, 255, 0.1);
+}
       
 .toggle--lighten25 {
   color: rgba(255, 255, 255, 0.25);
@@ -10751,6 +11043,10 @@ input:checked + .toggle--lighten10 {
 input:checked + .toggle--lighten25 {
   background: rgba(255, 255, 255, 0.25);
   color: #fff;
+}
+
+input:checked + .toggle--active-lighten25 {
+  color: rgba(255, 255, 255, 0.25);
 }
       
 .toggle--lighten50 {
@@ -10765,6 +11061,10 @@ input:checked + .toggle--lighten50 {
   background: rgba(255, 255, 255, 0.50);
   color: #fff;
 }
+
+input:checked + .toggle--active-lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
       
 .toggle--lighten75 {
   color: rgba(255, 255, 255, 0.75);
@@ -10777,6 +11077,10 @@ input:checked + .toggle--lighten50 {
 input:checked + .toggle--lighten75 {
   background: rgba(255, 255, 255, 0.75);
   color: #fff;
+}
+
+input:checked + .toggle--active-lighten75 {
+  color: rgba(255, 255, 255, 0.75);
 }
       
 .toggle--white {
@@ -10791,6 +11095,10 @@ input:checked + .toggle--white {
   background: #fff;
   color: #fff;
 }
+
+input:checked + .toggle--active-white {
+  color: #fff;
+}
       
 .toggle--transparent {
   color: transparent;
@@ -10803,6 +11111,10 @@ input:checked + .toggle--white {
 input:checked + .toggle--transparent {
   background: transparent;
   color: #fff;
+}
+
+input:checked + .toggle--active-transparent {
+  color: transparent;
 }
       
 input:checked + .toggle--active-gray-dark {
@@ -13670,6 +13982,78 @@ exports[`buildColorVariants with granular colors 1`] = `
   background-color: #500078;
 }
       
+.btn--stroke.btn--lighten50 {
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.50);
+}
+
+.btn--stroke.btn--lighten50:hover,
+.btn--stroke.btn--lighten50.is-active {
+  color: rgba(255, 255, 255, 0.75);
+}
+      
+.btn--stroke.btn--lighten25 {
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.btn--stroke.btn--lighten25:hover,
+.btn--stroke.btn--lighten25.is-active {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+.btn--stroke.btn--gray {
+  background-color: transparent;
+  color: #666;
+}
+
+.btn--stroke.btn--gray:hover,
+.btn--stroke.btn--gray.is-active {
+  color: #333;
+}
+      
+.textarea--border-lighten50,
+.input--border-lighten50,
+.textarea--border-lighten50,
+.input--border-lighten50 {
+  border-color: rgba(255, 255, 255, 0.50);
+}
+
+.textarea--border-lighten50:hover,
+.input--border-lighten50:hover,
+.textarea--border-lighten50:focus,
+.input--border-lighten50:focus {
+  border-color: rgba(255, 255, 255, 0.75);
+}
+      
+.textarea--border-lighten25,
+.input--border-lighten25,
+.textarea--border-lighten25,
+.input--border-lighten25 {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.textarea--border-lighten25:hover,
+.input--border-lighten25:hover,
+.textarea--border-lighten25:focus,
+.input--border-lighten25:focus {
+  border-color: rgba(255, 255, 255, 0.50);
+}
+      
+.textarea--border-gray,
+.input--border-gray,
+.textarea--border-gray,
+.input--border-gray {
+  border-color: #666;
+}
+
+.textarea--border-gray:hover,
+.input--border-gray:hover,
+.textarea--border-gray:focus,
+.input--border-gray:focus {
+  border-color: #333;
+}
+      
 .select--green {
   background-color: #01aa46;
 }
@@ -13678,6 +14062,196 @@ exports[`buildColorVariants with granular colors 1`] = `
   background-color: #007532;
 }
       
+.select--stroke-lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+.select--stroke-lighten50 + .select-arrow {
+  border-top-color: rgba(255, 255, 255, 0.50);
+}
+.select--stroke-lighten50:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+.select--stroke-lighten50:hover + .select-arrow {
+  border-top-color: rgba(255, 255, 255, 0.75);
+}
+      
+.select--stroke-lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+.select--stroke-lighten25 + .select-arrow {
+  border-top-color: rgba(255, 255, 255, 0.25);
+}
+.select--stroke-lighten25:hover {
+  color: rgba(255, 255, 255, 0.50);
+}
+.select--stroke-lighten25:hover + .select-arrow {
+  border-top-color: rgba(255, 255, 255, 0.50);
+}
+      
+.select--stroke-gray {
+  color: #666;
+}
+.select--stroke-gray + .select-arrow {
+  border-top-color: #666;
+}
+.select--stroke-gray:hover {
+  color: #333;
+}
+.select--stroke-gray:hover + .select-arrow {
+  border-top-color: #333;
+}
+      
+.checkbox--lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+
+.checkbox-container:hover > .checkbox--lighten50,
+input:checked + .checkbox--lighten50 {
+  color: rgba(255, 255, 255, 0.75);
+}
+      
+.checkbox--lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.checkbox-container:hover > .checkbox--lighten25,
+input:checked + .checkbox--lighten25 {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+.checkbox--gray {
+  color: #666;
+}
+
+.checkbox-container:hover > .checkbox--gray,
+input:checked + .checkbox--gray {
+  color: #333;
+}
+      
+.radio--lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+
+.radio-container:hover > .radio--lighten50,
+input:checked + .radio--lighten50 {
+  color: rgba(255, 255, 255, 0.75);
+}
+      
+.radio--lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.radio-container:hover > .radio--lighten25,
+input:checked + .radio--lighten25 {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+.radio--gray {
+  color: #666;
+}
+
+.radio-container:hover > .radio--gray,
+input:checked + .radio--gray {
+  color: #333;
+}
+      
+.toggle--lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+
+.toggle--lighten50:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+input:checked + .toggle--lighten50 {
+  background: rgba(255, 255, 255, 0.50);
+  color: #fff;
+}
+
+input:checked + .toggle--active-lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+.toggle--lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.toggle--lighten25:hover {
+  color: rgba(255, 255, 255, 0.50);
+}
+
+input:checked + .toggle--lighten25 {
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+input:checked + .toggle--active-lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+      
+.toggle--gray {
+  color: #666;
+}
+
+.toggle--gray:hover {
+  color: #333;
+}
+
+input:checked + .toggle--gray {
+  background: #666;
+  color: #fff;
+}
+
+input:checked + .toggle--active-gray {
+  color: #666;
+}
+      
+input:checked + .toggle--active-lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+input:checked + .toggle--active-lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+      
+input:checked + .toggle--active-gray {
+  color: #666;
+}
+      
+/**
+ * @section Text colors
+ * @memberof Colors
+ */
+
+/**
+ * Apply a text color.
+ *
+ * @group
+ * @memberof Text colors
+ * @example
+ * <div class=\'grid\'>
+ *   <div class=\'col col--3 color-lighten50\'>color-lighten50</div>
+ *   <div class=\'col col--3 color-lighten25\'>color-lighten25</div>
+ *   <div class=\'col col--3 color-gray\'>color-gray</div>
+ *   <div class=\'col col--3 color-text\'>.color-text</div>
+ * </div>
+ */
+.color-lighten50 {
+  color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.color-lighten25 {
+  color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.color-gray {
+  color: #666 !important;
+}
+      
+.color-text {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+    /** @endgroup */
 /**
  * @section Background colors
  * @memberof Colors
@@ -13717,6 +14291,26 @@ exports[`buildColorVariants with granular colors 1`] = `
 }
       
 /**
+ * Apply a [color](#Colors) to a border.
+ *
+ * @group
+ * @memberof Borders
+ * @example
+ * <div class=\'border border--red\'>border--red</div>
+ */
+.border--lighten50 {
+  border-color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.border--lighten25 {
+  border-color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.border--gray {
+  border-color: #666 !important;
+}
+      /** @endgroup */
+/**
  * Apply a box shadow on hover and active states.
  *
  * @group
@@ -13733,6 +14327,81 @@ exports[`buildColorVariants with granular colors 1`] = `
 .shadow-bold-lighten50-on-hover:hover,
 .shadow-bold-lighten50-on-active.is-active {
   box-shadow: 0 0 30px 6px rgba(255, 255, 255, 0.50) !important;
+}
+      /** @endgroup */
+/**
+ * Apply a background color on hover and active states.
+ *
+ * @group
+ * @memberof Background colors
+ * @example
+ * <div class=\'bg-darken25-on-hover\'>bg-darken25-on-hover</div>
+ * <div class=\'bg-darken25-on-active\'>bg-darken25-on-active (not active)</div>
+ * <div class=\'bg-darken25-on-active is-active\'>bg-darken25-on-active (active)</div>
+ */
+.bg-lighten50-on-hover:hover,
+.bg-lighten50-on-active.is-active {
+  background-color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.bg-lighten25-on-hover:hover,
+.bg-lighten25-on-active.is-active {
+  background-color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.bg-gray-on-hover:hover,
+.bg-gray-on-active.is-active {
+  background-color: #666 !important;
+}
+      /** @endgroup */
+/**
+ * Apply a text color on hover and active states.
+ *
+ * @group
+ * @memberof Text colors
+ * @example
+ * <div class=\'color-red-on-hover\'>color-red-on-hover</div>
+ * <div class=\'color-red-on-active\'>color-red-on-active (not active)</div>
+ * <div class=\'color-red-on-active is-active\'>color-red-on-active (active)</div>
+ */
+.color-lighten50-on-hover:hover,
+.color-lighten50-on-active.is-active {
+  color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.color-lighten25-on-hover:hover,
+.color-lighten25-on-active.is-active {
+  color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.color-gray-on-hover:hover,
+.color-gray-on-active.is-active {
+  color: #666 !important;
+}
+      /** @endgroup */
+/**
+ * Apply a border color on hover and active states.
+ *
+ * @group
+ * @memberof Borders
+ * @example
+ * <div class=\'border border--red-on-hover\'>border--red-on-hover</div>
+ * <div class=\'border border--red-on-active\'>border--red-on-active (not active)</div>
+ * <div class=\'border border--red-on-active is-active\'>border--red-on-active (active)</div>
+ */
+.border--lighten50-on-hover:hover,
+.border--lighten50-on-active.is-active {
+  border-color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.border--lighten25-on-hover:hover,
+.border--lighten25-on-active.is-active {
+  border-color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.border--gray-on-hover:hover,
+.border--gray-on-active.is-active {
+  border-color: #666 !important;
 }
       /** @endgroup */"
 `;
@@ -14020,6 +14689,10 @@ input:checked + .toggle--red {
   background: #dc2b28;
   color: #fff;
 }
+
+input:checked + .toggle--active-red {
+  color: #dc2b28;
+}
       
 .toggle--teal {
   color: #01b5b4;
@@ -14033,6 +14706,10 @@ input:checked + .toggle--teal {
   background: #01b5b4;
   color: #fff;
 }
+
+input:checked + .toggle--active-teal {
+  color: #01b5b4;
+}
       
 .toggle--green-light {
   color: #72C781;
@@ -14045,6 +14722,10 @@ input:checked + .toggle--teal {
 input:checked + .toggle--green-light {
   background: #72C781;
   color: #fff;
+}
+
+input:checked + .toggle--active-green-light {
+  color: #72C781;
 }
       
 input:checked + .toggle--active-red {

--- a/test/build-color-variants.jest.js
+++ b/test/build-color-variants.jest.js
@@ -26,11 +26,14 @@ describe('buildColorVariants', () => {
 
   it('with granular colors', () => {
     expect(buildColorVariants(null, {
+      universal: ['lighten50', 'lighten25', 'gray'],
       buttonFill: ['green', 'purple'],
       selectFill: ['green'],
       background: ['orange', 'yellow', 'pink'],
       link: ['orange'],
-      hoverShadow: ['lighten50']
+      hoverShadow: ['lighten50'],
+      switch: [],
+      range: [],
     })).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Refines a few points in `build-color-variants.js` (e.g. changing `inputStroke` to `inputTextarea`) and documents the custom build functionality.

Closes #478 by demonstrating how you can exclude all color variants for a given component.

@samanpwbb for review.
