### PR TITLE
Async-defer the JS

### DIFF
--- a/scripts/build-js.js
+++ b/scripts/build-js.js
@@ -21,7 +21,8 @@ function buildJs(outfile) {
     concatJs()
   ])
     .then((data) => {
-      return UglifyJS.minify(data.join(''), { fromString: true }).code;
+      const allJs = data.join('');
+      return UglifyJS.minify(allJs, { fromString: true }).code;
     })
     .then((minifiedJs) => {
       return optimizeJs(minifiedJs);

--- a/scripts/build-svg-loader.js
+++ b/scripts/build-svg-loader.js
@@ -21,9 +21,14 @@ const baseJsTemplate = (options) => {
   return `
     (function () {
       var svgDocument = (new DOMParser()).parseFromString('${options.svgSprite}', 'text/xml');
-      document.addEventListener('DOMContentLoaded', function () {
+      var appendSvg = function () {
         document.body.appendChild(svgDocument.getElementById('svg-symbols'));
-      });
+      }
+      if (document.readyState !== 'loading') {
+        appendSvg();
+      } else {
+        document.addEventListener('DOMContentLoaded', appendSvg);
+      }
     }());
   `;
 };

--- a/site/home.js
+++ b/site/home.js
@@ -1,9 +1,6 @@
 import React from 'react';
 const defaultMediaQueries = require('../src/media-queries');
 
-const headIncludes = `<link href="https://www.mapbox.com/assembly/assembly.css" rel="stylesheet"
-<script src="https://www.mapbox.com/assembly/assembly.js"></script>`;
-
 class Home extends React.Component {
   render() {
     return (
@@ -18,11 +15,19 @@ class Home extends React.Component {
           Usage
         </h2>
         <p>
-          Include in the head of your HTML the Assembly stylesheet and icon-loading JavaScript.
+          Include in the head of your HTML the Assembly stylesheet.
         </p>
-        <pre className='mt12 pre'>
+        <pre className='mt6 pre'>
           <code>
-            {headIncludes}
+            {'<link href="https://www.mapbox.com/assembly/assembly.css" rel="stylesheet">'}
+          </code>
+        </pre>
+        <p className='mt6'>
+          And include somewhere in your HTML, depending on your preferences, the Assembly JavaScript. It is safe to use the `async` and `defer` attributes.
+        </p>
+        <pre className='mt6 pre'>
+          <code>
+            {'<script async defer src="https://www.mapbox.com/assembly/assembly.js"></script>'}
           </code>
         </pre>
         <h2 className='border-b border--2 border--gray-faint pb6 mt72 txt-l uppercase txt-bold'>

--- a/site/template.html
+++ b/site/template.html
@@ -7,7 +7,7 @@
   <link rel='shortcut icon' href='/img/favicon.ico' type='image/x-icon' />
   <link href='/assembly/hljs.css' rel='stylesheet' type='text/css'>
   <link href='/assembly/assembly.css' rel='stylesheet' type='text/css'>
-  <script src='/assembly/assembly.js'></script>
+  <script async defer src='/assembly/assembly.js'></script>
 </head>
 <body>
 {content}


### PR DESCRIPTION
We should be able to safely recommend that people use `async` and `defer` attributes when they load the Assembly JS. They could also put it at the bottom of the `<body>`. This PR documents that and uses the documentation pages as proof-of-concept.

@tristen for review.