### PR TITLE
Add GitHub links and more

### DIFF
--- a/site/home.js
+++ b/site/home.js
@@ -1,4 +1,9 @@
 import React from 'react';
+import Lowlight from 'react-lowlight';
+import xmlLanguage from 'highlight.js/lib/languages/xml';
+
+Lowlight.registerLanguage('html', xmlLanguage);
+
 const defaultMediaQueries = require('../src/media-queries');
 
 class Home extends React.Component {
@@ -8,8 +13,17 @@ class Home extends React.Component {
         <div className='txt-headline'>
           <h1 className='animation-rainbow animation--speed-8 color-teal txt-mono uppercase txt-headline txt-spacing2 pl6 pr6'>Assembly.css</h1>
         </div>
-        <p className='txt-l mt12'>
+        <p className='txt-l mt24'>
           Assembly is a CSS framework that makes the hard parts of designing for the web easy.
+        </p>
+        <p className='mt24'>
+          <a className='link' href='https://github.com/mapbox/assembly/'>
+            <svg
+              className='icon'
+              dangerouslySetInnerHTML={{ __html: '<use xlink:href="#icon-github"></use>' }}
+            />
+            <span className='ml6 align-middle'>View on GitHub</span>
+          </a>
         </p>
         <h2 className='border-b border--2 border--gray-faint pb6 mt72 mb24 txt-l uppercase txt-bold'>
           Usage
@@ -17,19 +31,21 @@ class Home extends React.Component {
         <p>
           Include in the head of your HTML the Assembly stylesheet.
         </p>
-        <pre className='mt6 pre'>
-          <code>
-            {'<link href="https://www.mapbox.com/assembly/assembly.css" rel="stylesheet">'}
-          </code>
-        </pre>
-        <p className='mt6'>
-          And include somewhere in your HTML, depending on your preferences, the Assembly JavaScript. It is safe to use the `async` and `defer` attributes.
+        <div className='mt24 pre'>
+          <Lowlight
+            language='html'
+            value={'<link href="https://www.mapbox.com/assembly/assembly.css" rel="stylesheet">'}
+          />
+        </div>
+        <p className='mt24'>
+          And include somewhere in your HTML, depending on your preferences, the Assembly JavaScript. It is safe to use the <code className='code'>async</code> and <code className='code'>defer</code> attributes.
         </p>
-        <pre className='mt6 pre'>
-          <code>
-            {'<script async defer src="https://www.mapbox.com/assembly/assembly.js"></script>'}
-          </code>
-        </pre>
+        <div className='mt24 pre'>
+          <Lowlight
+            language='html'
+            value={'<script async defer src="https://www.mapbox.com/assembly/assembly.js"></script>'}
+          />
+        </div>
         <h2 className='border-b border--2 border--gray-faint pb6 mt72 txt-l uppercase txt-bold'>
           Philosophy
         </h2>
@@ -65,75 +81,75 @@ class Home extends React.Component {
         <h3 className='mt24 txt-bold'>
           <code className='code'>6px</code> baseline grid
         </h3>
-        <p className='mt6'>
+        <p className='mt12'>
           Every element in Assembly is designed according to a <code className='code'>6px</code> baseline grid, even buttons and form components. Baseline grids don't just make your site look and feel better: they also make development more convenient. All the pieces naturally fit together without fiddling with line height or vertical alignment.
         </p>
         <h3 className='mt24 txt-bold'>
           No default styling for semantic elements
         </h3>
-        <p className='mt6'>
+        <p className='mt12'>
           You should use <code className='code'>{'<h3>'}</code> for third-level headings, not because you want a certain style.
           Similarly, you should use <code className='code'>{'<button>'}</code> when a button is behaviorally and semantically appropriate,
           instead of <code className='code'>href</code>-less <code className='code'>{'<a>'}</code> tags or other elements with click handlers.
         </p>
-        <p className='mt6'>
+        <p className='mt12'>
           Assembly's reset allows you to use semantically appropriate HTML without battling browser-default styles.
           And its CSS rules are built to behave the same regardless of which element they're applied to.
           A heading <em>style</em>, or a button <em>style</em>, can be applied to <em>any</em> element by applying the appropriate classes.
         </p>
         <h3 className='mt24 txt-bold'>
-          box-sizing: border-box
+          <code className='code'>box-sizing: border-box</code>
         </h3>
-        <p className='mt6'>
+        <p className='mt12'>
           The <code className='code'>border-box</code> box model allows for more intuitive styling than the default <code className='code'>content-box</code> model.
           For example, when you set a <code className='code'>w300</code> class, your element will always be 300 pixels wide, regardless of its padding and borders.
         </p>
         <h3 className='mt24 txt-bold'>
           Customizable icons
         </h3>
-        <p className='mt6'>
+        <p className='mt12'>
           Assembly comes with <a className='txt-underline' href='icons/'>more than 150 icons</a>, intended to be used as inline SVGs. Inline SVGs are easy to resize and color.
         </p>
         <h3 className='mt24 txt-bold'>
           Media queries are mobile-first
         </h3>
-        <p className='mt6'>
+        <p className='mt12'>
           Mobile-first media queries lead to cleaner code because there are fewer overrides. Start with a simple mobile layout, then add complexity with additional media-constrained rules. Assembly uses the following media queries:
         </p>
-        <div className='prose mt6'>
+        <div className='prose mt12'>
           <ul className='txt-ul'>
             <li>Extra large screens: <code className='code'>{defaultMediaQueries['--xl-screen']}</code></li>
             <li>Large screens: <code className='code'>{defaultMediaQueries['--l-screen']}</code></li>
             <li>Medium screens: <code className='code'>{defaultMediaQueries['--m-screen']}</code></li>
           </ul>
         </div>
-        <p className='mt6'>
+        <p className='mt12'>
           Classes that take affect within certain media queries always end with a <code className='code'>{'-m<size>'}</code> suffix,
           where "size" is <code className='code'>m</code>, <code className='code'>l</code>, or <code className='code'>xl</code>.
         </p>
         <h3 className='mt24 txt-bold'>
-          <code className='code'>!important</code> all utility classes behavior
+          Utility classes are <code className='code'>!important</code>
         </h3>
-        <p className='mt6'>
+        <p className='mt12'>
           Assembly uses <code className='code'>!important</code> on declarations whose effect directly corresponds to a class name.
         </p>
-        <p className='mt6'>
+        <p className='mt12'>
           For example, in the <code className='code'>.bg-pink</code> rule, the <code className='code'>background-color</code> declaration is <code className='code'>!important</code>.
           On the <code className='code'>.pl20</code> rule, the <code className='code'>padding-left</code> declaration is <code className='code'>!important</code>.
           This ensures that such classes always behave the same. Whenever you see the class <code className='code'>bg-pink</code> on an element,
           that element should have a pink background, regardless of its context and the other rules that apply to it.
         </p>
-        <p className='mt6'>
+        <p className='mt12'>
           For dynamic styles, responsive classes (described above) provide some additional flexibility.
           But if you need even more, you should use custom CSS instead of a utility class.
         </p>
         <h3 className='mt24 txt-bold'>
           <code className='code'>is-active</code> applies active states
         </h3>
-        <p className='mt6'>
+        <p className='mt12'>
           Assembly uses the <code className='code'>is-active</code> state class to designate that an element is active and style it accordingly.
         </p>
-        <p className='mt6'>
+        <p className='mt12'>
           The <code className='code'>is-active</code> state on buttons and links darkens their color.
           And the <code className='code'>*-on-active</code> state classes (e.g. only <code className='code'>color-red-on-active</code>) only take effect when combined with the <code className='code'>is-active</code> class.
         </p>

--- a/site/navigation.js
+++ b/site/navigation.js
@@ -57,10 +57,23 @@ class Navigation extends React.Component {
       );
     });
 
-    return (<div>
-      <a href='/assembly/' className='mb24 txt-mono link txt-spacing2 uppercase block'>Assembly</a>
-      {navEls}
-    </div>);
+    return (
+      <div className='flex-parent-mm flex-parent--column-mm w-full'>
+        <a href='/assembly/' className='mt24 mb12 mx24 txt-mono link txt-spacing2 uppercase block'>Assembly</a>
+        <div className='flex-child-grow-mm scroll-auto pr18 pl24'>
+          {navEls}
+        </div>
+        <div className='mt12 mb24 mx24 flex-child-noshrink-mm'>
+          <a className='link txt-s' href='https://github.com/mapbox/assembly/'>
+            <svg
+              className='icon'
+              dangerouslySetInnerHTML={{ __html: '<use xlink:href="#icon-github"></use>' }}
+            />
+            <span className='ml6 align-middle'>View on GitHub</span>
+          </a>
+        </div>
+      </div>
+    );
   }
 }
 

--- a/site/page.js
+++ b/site/page.js
@@ -5,7 +5,7 @@ class Page extends React.Component {
   render() {
     return (
       <div>
-        <div className='bg-darken5 scroll-auto viewport-full-mm w180-mm fixed-mm top left pt24 pr18 pb24 pl24'>
+        <div className='bg-darken5 scroll-auto viewport-full-mm w180-mm fixed-mm top left flex-parent-mm flex-parent--stretch-cross-mm'>
           <Navigation navData={this.props.navData} />
         </div>
         <div className='ml180-mm wmax1200 pl24 pr24 pl48-mm pr48-mm mb24'>

--- a/src/layout.css
+++ b/src/layout.css
@@ -1384,7 +1384,7 @@
 }
 
 /**
- * All sizing classes fit the following pattern: `<w|h><min|max><size>`.
+ * All sizing classes fit the following pattern: `<w|h><min|max><size>` or `<w|h><min|max>-full` for `100%`.
  * And all sizing class sets include `*-mm`, `*-ml`, and `*-mxl` variations to target screen sizes.
  *
  * @section Sizing
@@ -1413,6 +1413,7 @@
 .w480 { width: 480px !important; }
 .w720 { width: 720px !important; }
 .w960 { width: 960px !important; }
+.w-full { width: 100% !important; }
 /** @endgroup */
 
 @media (--m-screen) {
@@ -1430,6 +1431,7 @@
   .w480-mm { width: 480px !important; }
   .w720-mm { width: 720px !important; }
   .w960-mm { width: 960px !important; }
+  .w-full-mm { width: 100% !important; }
 }
 
 @media (--l-screen) {
@@ -1447,6 +1449,7 @@
   .w480-ml { width: 480px !important; }
   .w720-ml { width: 720px !important; }
   .w960-ml { width: 960px !important; }
+  .w-full-ml { width: 100% !important; }
 }
 
 @media (--xl-screen) {
@@ -1464,6 +1467,7 @@
   .w480-mxl { width: 480px !important; }
   .w720-mxl { width: 720px !important; }
   .w960-mxl { width: 960px !important; }
+  .w-full-mxl { width: 100% !important; }
 }
 
 /**
@@ -1490,6 +1494,7 @@
 .wmax960 { max-width: 960px !important; }
 .wmax1200 { max-width: 1200px !important; }
 .wmax1500 { max-width: 1500px !important; }
+.wmax-full { max-width: 100% !important; }
 /** @endgroup */
 
 @media (--m-screen) {
@@ -1507,6 +1512,7 @@
   .wmax480-mm { max-width: 480px !important; }
   .wmax720-mm { max-width: 720px !important; }
   .wmax960-mm { max-width: 960px !important; }
+  .wmax-full-mm { max-width: 100% !important; }
 }
 
 @media (--l-screen) {
@@ -1524,6 +1530,7 @@
   .wmax480-ml { max-width: 480px !important; }
   .wmax720-ml { max-width: 720px !important; }
   .wmax960-ml { max-width: 960px !important; }
+  .wmax-full-ml { max-width: 100% !important; }
 }
 
 @media (--xl-screen) {
@@ -1543,6 +1550,7 @@
   .wmax960-mxl { max-width: 960px !important; }
   .wmax1200-mxl { max-width: 1200px !important; }
   .wmax1500-mxl { max-width: 1500px !important; }
+  .wmax-full-mxl { max-width: 100% !important; }
 }
 
 /**
@@ -1565,21 +1573,23 @@
 .wmin180 { min-width: 180px !important; }
 .wmin240 { min-width: 240px !important; }
 .wmin480 { min-width: 480px !important; }
+.wmin-full { min-width: 100% !important; }
 /** @endgroup */
 
 @media (--m-screen) {
-  .wmin-mm { min-width: 0 !important; }
-  .wmin-mm { min-width: 6px !important; }
-  .wmin-mm { min-width: 12px !important; }
-  .wmin-mm { min-width: 18px !important; }
-  .wmin-mm { min-width: 24px !important; }
-  .wmin-mm { min-width: 48px !important; }
-  .wmin-mm { min-width: 72px !important; }
-  .wmin-mm { min-width: 96px !important; }
-  .wmin-mm { min-width: 120px !important; }
-  .wmin-mm { min-width: 180px !important; }
-  .wmin-mm { min-width: 240px !important; }
-  .wmin-mm { min-width: 480px !important; }
+  .wmin0-mm { min-width: 0 !important; }
+  .wmin6-mm { min-width: 6px !important; }
+  .wmin12-mm { min-width: 12px !important; }
+  .wmin18-mm { min-width: 18px !important; }
+  .wmin24-mm { min-width: 24px !important; }
+  .wmin48-mm { min-width: 48px !important; }
+  .wmin72-mm { min-width: 72px !important; }
+  .wmin96-mm { min-width: 96px !important; }
+  .wmin120-mm { min-width: 120px !important; }
+  .wmin180-mm { min-width: 180px !important; }
+  .wmin240-mm { min-width: 240px !important; }
+  .wmin480-mm { min-width: 480px !important; }
+  .wmin-full-mm { min-width: 100% !important; }
 }
 
 @media (--l-screen) {
@@ -1595,6 +1605,7 @@
   .wmin180-ml { min-width: 180px !important; }
   .wmin240-ml { min-width: 240px !important; }
   .wmin480-ml { min-width: 480px !important; }
+  .wmin-full-ml { min-width: 100% !important; }
 }
 
 @media (--xl-screen) {
@@ -1610,6 +1621,7 @@
   .wmin180-mxl { min-width: 180px !important; }
   .wmin240-mxl { min-width: 240px !important; }
   .wmin480-mxl { min-width: 480px !important; }
+  .wmin-full-mxl { min-width: 100% !important; }
 }
 
 /**
@@ -1632,6 +1644,7 @@
 .h180 { height: 180px !important; }
 .h240 { height: 240px !important; }
 .h480 { height: 480px !important; }
+.h-full { height: 100% !important; }
 /** @endgroup */
 
 @media (--m-screen) {
@@ -1647,6 +1660,7 @@
   .h180-mm { height: 180px !important; }
   .h240-mm { height: 240px !important; }
   .h480-mm { height: 480px !important; }
+  .h-full-mm { height: 100% !important; }
 }
 
 @media (--l-screen) {
@@ -1662,6 +1676,7 @@
   .h180-ml { height: 180px !important; }
   .h240-ml { height: 240px !important; }
   .h480-ml { height: 480px !important; }
+  .h-full-ml { height: 100% !important; }
 }
 
 @media (--xl-screen) {
@@ -1677,6 +1692,7 @@
   .h180-mxl { height: 180px !important; }
   .h240-mxl { height: 240px !important; }
   .h480-mxl { height: 480px !important; }
+  .h-full-mxl { height: 100% !important; }
 }
 
 /**
@@ -1699,6 +1715,7 @@
 .hmax180 { max-height: 180px !important; }
 .hmax240 { max-height: 240px !important; }
 .hmax480 { max-height: 480px !important; }
+.hmax-full { max-height: 100% !important; }
 /** @endgroup */
 
 @media (--m-screen) {
@@ -1714,6 +1731,7 @@
   .hmax180-mm { max-height: 180px !important; }
   .hmax240-mm { max-height: 240px !important; }
   .hmax480-mm { max-height: 480px !important; }
+  .hmax-full-mm { max-height: 100% !important; }
 }
 
 @media (--l-screen) {
@@ -1729,6 +1747,7 @@
   .hmax180-ml { max-height: 180px !important; }
   .hmax240-ml { max-height: 240px !important; }
   .hmax480-ml { max-height: 480px !important; }
+  .hmax-full-ml { max-height: 100% !important; }
 }
 
 @media (--xl-screen) {
@@ -1744,6 +1763,7 @@
   .hmax180-mxl { max-height: 180px !important; }
   .hmax240-mxl { max-height: 240px !important; }
   .hmax480-mxl { max-height: 480px !important; }
+  .hmax-full-mxl { max-height: 100% !important; }
 }
 
 /**
@@ -1766,6 +1786,7 @@
 .hmin180 { min-height: 180px !important; }
 .hmin240 { min-height: 240px !important; }
 .hmin480 { min-height: 480px !important; }
+.hmin-full { min-height: 100% !important; }
 /** @endgroup */
 
 @media (--m-screen) {
@@ -1781,6 +1802,7 @@
   .hmin180-mm { min-height: 180px !important; }
   .hmin240-mm { min-height: 240px !important; }
   .hmin480-mm { min-height: 480px !important; }
+  .hmin-full-mm { min-height: 100% !important; }
 }
 
 @media (--l-screen) {
@@ -1796,6 +1818,7 @@
   .hmin180-ml { min-height: 180px !important; }
   .hmin240-ml { min-height: 240px !important; }
   .hmin480-ml { min-height: 480px !important; }
+  .hmin-full-ml { min-height: 100% !important; }
 }
 
 @media (--xl-screen) {
@@ -1811,6 +1834,7 @@
   .hmin180-mxl { min-height: 180px !important; }
   .hmin240-mxl { min-height: 240px !important; }
   .hmin480-mxl { min-height: 480px !important; }
+  .hmin-full-mxl { min-height: 100% !important; }
 }
 
 /**


### PR DESCRIPTION
Closes #508 by adding GitHub links on the homepage and in the nav.

Cleans up a couple of things on the homepage.

Modifies the nav for flexbox fun. 

Also adds `*-full` classes for width, height, max-width, max-height, because it became apparent that those were missing.

Finally, fixes the min-width on medium screen class set, which was entirely bunk.

@samanpwbb for review.