### PR TITLE
Use the word default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ buildUserAssets('path/to/my/outdir', myOptions)
 
 If the `colorVariants` value is an array, it must be an array of color names corresponding to variables. All components will have color variants generated for all colors in the array.
 
-The following configuration specifies an array of universal colors. All components will have these (and *only these*) color variants.
+The following configuration specifies an array of default colors. All components will have these (and *only these*) color variants.
 
 ```json
 [
@@ -55,7 +55,7 @@ The following configuration specifies an array of universal colors. All componen
 ```
 
 If the `colorVariants` value is an object, each property value must be an array of color names corresponding to variables. The property names designate which component each color array applies to:
-  - `universal`: These colors apply to all components that are not otherwise specified.
+  - `default`: These colors apply to all components that are not otherwise specified.
   - `buttonFill`: `*-dark` colors will not be used.
   - `buttonStroke`: `*-dark` colors will not be used.
   - `inputTextarea`: `*-dark` colors will not be used.
@@ -75,11 +75,11 @@ If the `colorVariants` value is an object, each property value must be an array 
   - `hoverColor`
   - `hoverBorder`
 
-The following configuration specifies colors for individual components. In this configuration, every component not specified will have the `universal` color variants; specified components will have their specified color variants; and `switch` and `range` components will have no color variants (only the default will be available).
+The following configuration specifies colors for individual components. In this configuration, every component not specified will have the `default` color variants; specified components will have their specified color variants; and `switch` and `range` components will have no color variants (only the default will be available).
 
 ```json
 {
-  "universal": ["lighten50", "lighten25", "gray"],
+  "default": ["lighten50", "lighten25", "gray"],
   "buttonFill": ["green", "purple"],
   "selectFill": ["green"],
   "background": ["orange", "yellow", "pink"],

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -77,8 +77,8 @@ function isDark(color) {
 function buildColorVariants(variables, config) {
   variables = Object.assign({}, defaultVariables, variables);
   const colorVariants = (Array.isArray(config))
-    ? { universal: config }
-    : Object.assign({ universal: allColors }, config);
+    ? { default: config }
+    : Object.assign({ default: allColors }, config);
 
   function getDarkerShade(color) {
     if (color === 'white') return variables['gray-faint'];
@@ -568,7 +568,7 @@ function buildColorVariants(variables, config) {
   let result = '\n/* Color variants */\n';
 
   Object.keys(variantGenerators).forEach((coloredThing) => {
-    const colors = colorVariants[coloredThing] || colorVariants.universal;
+    const colors = colorVariants[coloredThing] || colorVariants.default;
     if (colors === null || colors === undefined) return;
     result += variantGenerators[coloredThing](colors);
   });

--- a/src/buttons.css
+++ b/src/buttons.css
@@ -26,7 +26,7 @@
  * </div>
  */
 .btn {
-  background-color: var(--blue);
+  background-color: var(--default-interactive-color);
   color: var(--white);
   border-width: 2px;
   border-style: solid;
@@ -60,7 +60,7 @@
 .btn--stroke {
   background-color: transparent;
   border-color: currentColor;
-  color: var(--blue);
+  color: var(--default-interactive-color);
 }
 
 /**
@@ -103,13 +103,13 @@
  */
 .btn:hover,
 .btn.is-active {
-  background-color: var(--blue-dark);
+  background-color: var(--default-interactive-color-dark);
 }
 
 .btn--stroke:hover,
 .btn--stroke.is-active {
   background-color: transparent;
-  color: var(--blue-dark);
+  color: var(--default-interactive-color-dark);
 }
 
 /**

--- a/src/forms.css
+++ b/src/forms.css
@@ -25,7 +25,7 @@
  */
 .input,
 .textarea {
-  border: 1px solid var(--blue);
+  border: 1px solid var(--default-interactive-color);
   border-radius: var(--border-radius);
   display: inline-block;
   transition: background-color var(--transition),
@@ -36,7 +36,7 @@
 .textarea:hover,
 .input:focus,
 .textarea:focus {
-  border-color: var(--blue-dark);
+  border-color: var(--default-interactive-color-dark);
 }
 
 .input::placeholder,
@@ -202,7 +202,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-style: solid;
   border-color: transparent;
   border-radius: var(--border-radius);
-  background-color: var(--blue); /* match btn default state */
+  background-color: var(--default-interactive-color); /* match btn default state */
 }
 
 .select-arrow {
@@ -223,7 +223,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /* default hover state */
 .select:hover {
-  background-color: var(--blue-dark);
+  background-color: var(--default-interactive-color-dark);
 }
 
 /* Some browsers color the option text and background, so reset that */
@@ -267,22 +267,22 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  * </div>
  */
 .select--stroke {
-  color: var(--blue);
+  color: var(--default-interactive-color);
   background-color: transparent;
   border-color: currentColor;
 }
 
 .select--stroke + .select-arrow {
-  border-top-color: var(--blue);
+  border-top-color: var(--default-interactive-color);
 }
 
 .select--stroke:hover {
   background-color: transparent;
-  color: var(--blue-dark);
+  color: var(--default-interactive-color-dark);
 }
 
 .select--stroke:hover + .select-arrow {
-  border-top-color: var(--blue-dark);
+  border-top-color: var(--default-interactive-color-dark);
 }
 
 /**
@@ -363,7 +363,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   padding: 0;
   border: 0;
   border-radius: 2px;
-  background: var(--blue);
+  background: var(--default-interactive-color);
   vertical-align: middle;
   cursor: pointer;
   box-shadow: 0;
@@ -375,7 +375,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   padding: 0;
   border: 0;
   border-radius: 2px;
-  background: var(--blue);
+  background: var(--default-interactive-color);
   vertical-align: middle;
   cursor: pointer;
   box-shadow: 0;
@@ -392,22 +392,22 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 }
 
 .range::-ms-fill-lower {
-  background: var(--blue);
+  background: var(--default-interactive-color);
   border: 0;
   box-shadow: 0;
 }
 
 .range::-ms-fill-upper {
-  background: var(--blue);
+  background: var(--default-interactive-color);
   border: 0;
   box-shadow: 0;
 }
 
 /* range track:hover */
-.range:hover::-webkit-slider-runnable-track { background: var(--blue-dark); }
-.range:hover::-moz-range-track { background: var(--blue-dark); }
-.range:hover::-ms-fill-upper { background: var(--blue-dark); }
-.range:hover::-ms-fill-lower { background: var(--blue-dark); }
+.range:hover::-webkit-slider-runnable-track { background: var(--default-interactive-color-dark); }
+.range:hover::-moz-range-track { background: var(--default-interactive-color-dark); }
+.range:hover::-ms-fill-upper { background: var(--default-interactive-color-dark); }
+.range:hover::-ms-fill-lower { background: var(--default-interactive-color-dark); }
 
 /* range thumb */
 .range::-webkit-slider-thumb {
@@ -418,7 +418,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   height: 20px;
   border-radius: 50%;
   background: var(--white);
-  border: 2px solid var(--blue);
+  border: 2px solid var(--default-interactive-color);
   cursor: pointer;
   margin-top: -8px;
 }
@@ -429,7 +429,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   height: 17px;
   border-radius: 50%;
   background: var(--white);
-  border: 2px solid var(--blue);
+  border: 2px solid var(--default-interactive-color);
   cursor: pointer;
 }
 
@@ -439,14 +439,14 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   height: 20px;
   border-radius: 50%;
   background: var(--white);
-  border: 2px solid var(--blue);
+  border: 2px solid var(--default-interactive-color);
   cursor: pointer;
 }
 
 /* range thumb:hover */
-.range:hover::-webkit-slider-thumb { border-color: var(--blue-dark); }
-.range:hover::-ms-thumb { border-color: var(--blue-dark); }
-.range:hover::-moz-range-thumb { border-color: var(--blue-dark); }
+.range:hover::-webkit-slider-thumb { border-color: var(--default-interactive-color-dark); }
+.range:hover::-ms-thumb { border-color: var(--default-interactive-color-dark); }
+.range:hover::-moz-range-thumb { border-color: var(--default-interactive-color-dark); }
 
 /*
  * Make a range element small.
@@ -565,12 +565,12 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .checkbox {
   background-color: #fff;
-  color: var(--blue);
+  color: var(--default-interactive-color);
   border-color: currentColor;
 }
 
 .checkbox-container:hover > .checkbox {
-  color: var(--blue-dark);
+  color: var(--default-interactive-color-dark);
 }
 
 /* Ensure checkboxes inside buttons look nice */
@@ -619,12 +619,12 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .radio {
   border-radius: 50%;
-  color: var(--blue);
+  color: var(--default-interactive-color);
   border-color: currentColor;
 }
 
 .radio-container:hover > .radio {
-  color: var(--blue-dark);
+  color: var(--default-interactive-color-dark);
 }
 
 .radio::before {
@@ -679,7 +679,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-width: 2px;
   border-style: solid;
   border-color: currentColor;
-  color: var(--blue);
+  color: var(--default-interactive-color);
   transition: color var(--transition),
     background-color var(--transition),
     border-color var(--transition);
@@ -749,7 +749,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 .toggle {
   flex-shrink: 0;
   cursor: pointer;
-  color: var(--blue);
+  color: var(--default-interactive-color);
   font-weight: bold;
   padding: 0 12px;
   border-radius: 13px;
@@ -780,7 +780,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   padding: 4px;
   border-width: 2px;
   border-style: solid;
-  border-color: var(--blue);
+  border-color: var(--default-interactive-color);
 }
 
 /* Adjust border radiuses with small text – only necessary for vertical toggle groups */
@@ -876,12 +876,12 @@ input:checked + .radio::before {
 
 input:checked + .checkbox,
 input:checked + .radio {
-  color: var(--blue-dark);
+  color: var(--default-interactive-color-dark);
 }
 
 /* state management for switches */
 .switch:hover {
-  color: var(--blue-dark);
+  color: var(--default-interactive-color-dark);
 }
 
 input:checked + .switch::after {
@@ -891,16 +891,16 @@ input:checked + .switch::after {
 
 input:checked + .switch {
   border-color: transparent;
-  background-color: var(--blue-dark);
+  background-color: var(--default-interactive-color-dark);
 }
 
 /* state management for toggles */
 .toggle:hover {
-  color: var(--blue-dark);
+  color: var(--default-interactive-color-dark);
 }
 
 input:checked + .toggle {
-  background: var(--blue);
+  background: var(--default-interactive-color);
   color: var(--white);
 }
 

--- a/src/links.css
+++ b/src/links.css
@@ -18,7 +18,7 @@
  */
 .link {
   cursor: pointer;
-  color: var(--blue);
+  color: var(--default-interactive-color);
   transition: color var(--transition);
 }
 
@@ -33,5 +33,5 @@
  */
 .link:hover,
 .link.is-active {
-  color: var(--blue-dark);
+  color: var(--default-interactive-color-dark);
 }

--- a/src/variables.json
+++ b/src/variables.json
@@ -65,6 +65,8 @@
   "neutral45": "rgba(127, 127, 127, 0.45)",
 
   "text-color": "rgba(0, 0, 0, 0.75)",
+  "default-interactive-color-dark": "#0014AA",
+  "default-interactive-color": "#0065fb",
 
   "border-radius": "4px",
   "border-radius-bold": "8px",

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -13960,453 +13960,7 @@ input:checked + .toggle--active-transparent {
       /** @endgroup */"
 `;
 
-exports[`buildColorVariants with granular colors 1`] = `
-"
-/* Color variants */
-
-.btn--green {
-  background-color: #01aa46;
-}
-
-.btn--green:hover,
-.btn--green.is-active {
-  background-color: #007532;
-}
-      
-.btn--purple {
-  background-color: #8c50c7;
-}
-
-.btn--purple:hover,
-.btn--purple.is-active {
-  background-color: #500078;
-}
-      
-.btn--stroke.btn--lighten50 {
-  background-color: transparent;
-  color: rgba(255, 255, 255, 0.50);
-}
-
-.btn--stroke.btn--lighten50:hover,
-.btn--stroke.btn--lighten50.is-active {
-  color: rgba(255, 255, 255, 0.75);
-}
-      
-.btn--stroke.btn--lighten25 {
-  background-color: transparent;
-  color: rgba(255, 255, 255, 0.25);
-}
-
-.btn--stroke.btn--lighten25:hover,
-.btn--stroke.btn--lighten25.is-active {
-  color: rgba(255, 255, 255, 0.50);
-}
-      
-.btn--stroke.btn--gray {
-  background-color: transparent;
-  color: #666;
-}
-
-.btn--stroke.btn--gray:hover,
-.btn--stroke.btn--gray.is-active {
-  color: #333;
-}
-      
-.textarea--border-lighten50,
-.input--border-lighten50,
-.textarea--border-lighten50,
-.input--border-lighten50 {
-  border-color: rgba(255, 255, 255, 0.50);
-}
-
-.textarea--border-lighten50:hover,
-.input--border-lighten50:hover,
-.textarea--border-lighten50:focus,
-.input--border-lighten50:focus {
-  border-color: rgba(255, 255, 255, 0.75);
-}
-      
-.textarea--border-lighten25,
-.input--border-lighten25,
-.textarea--border-lighten25,
-.input--border-lighten25 {
-  border-color: rgba(255, 255, 255, 0.25);
-}
-
-.textarea--border-lighten25:hover,
-.input--border-lighten25:hover,
-.textarea--border-lighten25:focus,
-.input--border-lighten25:focus {
-  border-color: rgba(255, 255, 255, 0.50);
-}
-      
-.textarea--border-gray,
-.input--border-gray,
-.textarea--border-gray,
-.input--border-gray {
-  border-color: #666;
-}
-
-.textarea--border-gray:hover,
-.input--border-gray:hover,
-.textarea--border-gray:focus,
-.input--border-gray:focus {
-  border-color: #333;
-}
-      
-.select--green {
-  background-color: #01aa46;
-}
-
-.select--green:hover {
-  background-color: #007532;
-}
-      
-.select--stroke-lighten50 {
-  color: rgba(255, 255, 255, 0.50);
-}
-.select--stroke-lighten50 + .select-arrow {
-  border-top-color: rgba(255, 255, 255, 0.50);
-}
-.select--stroke-lighten50:hover {
-  color: rgba(255, 255, 255, 0.75);
-}
-.select--stroke-lighten50:hover + .select-arrow {
-  border-top-color: rgba(255, 255, 255, 0.75);
-}
-      
-.select--stroke-lighten25 {
-  color: rgba(255, 255, 255, 0.25);
-}
-.select--stroke-lighten25 + .select-arrow {
-  border-top-color: rgba(255, 255, 255, 0.25);
-}
-.select--stroke-lighten25:hover {
-  color: rgba(255, 255, 255, 0.50);
-}
-.select--stroke-lighten25:hover + .select-arrow {
-  border-top-color: rgba(255, 255, 255, 0.50);
-}
-      
-.select--stroke-gray {
-  color: #666;
-}
-.select--stroke-gray + .select-arrow {
-  border-top-color: #666;
-}
-.select--stroke-gray:hover {
-  color: #333;
-}
-.select--stroke-gray:hover + .select-arrow {
-  border-top-color: #333;
-}
-      
-.checkbox--lighten50 {
-  color: rgba(255, 255, 255, 0.50);
-}
-
-.checkbox-container:hover > .checkbox--lighten50,
-input:checked + .checkbox--lighten50 {
-  color: rgba(255, 255, 255, 0.75);
-}
-      
-.checkbox--lighten25 {
-  color: rgba(255, 255, 255, 0.25);
-}
-
-.checkbox-container:hover > .checkbox--lighten25,
-input:checked + .checkbox--lighten25 {
-  color: rgba(255, 255, 255, 0.50);
-}
-      
-.checkbox--gray {
-  color: #666;
-}
-
-.checkbox-container:hover > .checkbox--gray,
-input:checked + .checkbox--gray {
-  color: #333;
-}
-      
-.radio--lighten50 {
-  color: rgba(255, 255, 255, 0.50);
-}
-
-.radio-container:hover > .radio--lighten50,
-input:checked + .radio--lighten50 {
-  color: rgba(255, 255, 255, 0.75);
-}
-      
-.radio--lighten25 {
-  color: rgba(255, 255, 255, 0.25);
-}
-
-.radio-container:hover > .radio--lighten25,
-input:checked + .radio--lighten25 {
-  color: rgba(255, 255, 255, 0.50);
-}
-      
-.radio--gray {
-  color: #666;
-}
-
-.radio-container:hover > .radio--gray,
-input:checked + .radio--gray {
-  color: #333;
-}
-      
-.toggle--lighten50 {
-  color: rgba(255, 255, 255, 0.50);
-}
-
-.toggle--lighten50:hover {
-  color: rgba(255, 255, 255, 0.75);
-}
-
-input:checked + .toggle--lighten50 {
-  background: rgba(255, 255, 255, 0.50);
-  color: #fff;
-}
-
-input:checked + .toggle--active-lighten50 {
-  color: rgba(255, 255, 255, 0.50);
-}
-      
-.toggle--lighten25 {
-  color: rgba(255, 255, 255, 0.25);
-}
-
-.toggle--lighten25:hover {
-  color: rgba(255, 255, 255, 0.50);
-}
-
-input:checked + .toggle--lighten25 {
-  background: rgba(255, 255, 255, 0.25);
-  color: #fff;
-}
-
-input:checked + .toggle--active-lighten25 {
-  color: rgba(255, 255, 255, 0.25);
-}
-      
-.toggle--gray {
-  color: #666;
-}
-
-.toggle--gray:hover {
-  color: #333;
-}
-
-input:checked + .toggle--gray {
-  background: #666;
-  color: #fff;
-}
-
-input:checked + .toggle--active-gray {
-  color: #666;
-}
-      
-input:checked + .toggle--active-lighten50 {
-  color: rgba(255, 255, 255, 0.50);
-}
-      
-input:checked + .toggle--active-lighten25 {
-  color: rgba(255, 255, 255, 0.25);
-}
-      
-input:checked + .toggle--active-gray {
-  color: #666;
-}
-      
-/**
- * @section Text colors
- * @memberof Colors
- */
-
-/**
- * Apply a text color.
- *
- * @group
- * @memberof Text colors
- * @example
- * <div class=\'grid\'>
- *   <div class=\'col col--3 color-lighten50\'>color-lighten50</div>
- *   <div class=\'col col--3 color-lighten25\'>color-lighten25</div>
- *   <div class=\'col col--3 color-gray\'>color-gray</div>
- *   <div class=\'col col--3 color-text\'>.color-text</div>
- * </div>
- */
-.color-lighten50 {
-  color: rgba(255, 255, 255, 0.50) !important;
-}
-      
-.color-lighten25 {
-  color: rgba(255, 255, 255, 0.25) !important;
-}
-      
-.color-gray {
-  color: #666 !important;
-}
-      
-.color-text {
-  color: rgba(0, 0, 0, 0.75) !important;
-}
-    /** @endgroup */
-/**
- * @section Background colors
- * @memberof Colors
- */
-
-/**
- * Apply a background color.
- *
- * @group
- * @memberof Background colors
- * @example
- * <div class=\'grid\'>
- *   <div class=\'col col--3 bg-orange p6\'>bg-orange</div>
- *   <div class=\'col col--3 bg-yellow p6\'>bg-yellow</div>
- *   <div class=\'col col--3 bg-pink p6\'>bg-pink</div>
- * </div>
- */
-.bg-orange {
-  background-color: #ff6e00 !important;
-}
-      
-.bg-yellow {
-  background-color: #f0dc00 !important;
-}
-      
-.bg-pink {
-  background-color: #ff3c96 !important;
-}
-      /** @endgroup */
-.link--orange {
-  color: #ff6e00;
-}
-
-.link--orange:hover,
-.link--orange.is-active {
-  color: #DC4600;
-}
-      
-/**
- * Apply a [color](#Colors) to a border.
- *
- * @group
- * @memberof Borders
- * @example
- * <div class=\'border border--red\'>border--red</div>
- */
-.border--lighten50 {
-  border-color: rgba(255, 255, 255, 0.50) !important;
-}
-      
-.border--lighten25 {
-  border-color: rgba(255, 255, 255, 0.25) !important;
-}
-      
-.border--gray {
-  border-color: #666 !important;
-}
-      /** @endgroup */
-/**
- * Apply a box shadow on hover and active states.
- *
- * @group
- * @memberof Shadows
- * @example
- * <div class=\'shadow-darken25-on-hover\'>shadow-darken25-on-hover</div>
- * <div class=\'shadow-darken25-on-active\'>shadow-darken25-on-active (not active)</div>
- * <div class=\'shadow-darken25-on-active is-active\'>shadow-darken25-on-active (active)</div>
- */
-.shadow-lighten50-on-hover:hover,
-.shadow-lighten50-on-active.is-active {
-  box-shadow: 0 0 10px 2px rgba(255, 255, 255, 0.50) !important;
-}
-.shadow-bold-lighten50-on-hover:hover,
-.shadow-bold-lighten50-on-active.is-active {
-  box-shadow: 0 0 30px 6px rgba(255, 255, 255, 0.50) !important;
-}
-      /** @endgroup */
-/**
- * Apply a background color on hover and active states.
- *
- * @group
- * @memberof Background colors
- * @example
- * <div class=\'bg-darken25-on-hover\'>bg-darken25-on-hover</div>
- * <div class=\'bg-darken25-on-active\'>bg-darken25-on-active (not active)</div>
- * <div class=\'bg-darken25-on-active is-active\'>bg-darken25-on-active (active)</div>
- */
-.bg-lighten50-on-hover:hover,
-.bg-lighten50-on-active.is-active {
-  background-color: rgba(255, 255, 255, 0.50) !important;
-}
-      
-.bg-lighten25-on-hover:hover,
-.bg-lighten25-on-active.is-active {
-  background-color: rgba(255, 255, 255, 0.25) !important;
-}
-      
-.bg-gray-on-hover:hover,
-.bg-gray-on-active.is-active {
-  background-color: #666 !important;
-}
-      /** @endgroup */
-/**
- * Apply a text color on hover and active states.
- *
- * @group
- * @memberof Text colors
- * @example
- * <div class=\'color-red-on-hover\'>color-red-on-hover</div>
- * <div class=\'color-red-on-active\'>color-red-on-active (not active)</div>
- * <div class=\'color-red-on-active is-active\'>color-red-on-active (active)</div>
- */
-.color-lighten50-on-hover:hover,
-.color-lighten50-on-active.is-active {
-  color: rgba(255, 255, 255, 0.50) !important;
-}
-      
-.color-lighten25-on-hover:hover,
-.color-lighten25-on-active.is-active {
-  color: rgba(255, 255, 255, 0.25) !important;
-}
-      
-.color-gray-on-hover:hover,
-.color-gray-on-active.is-active {
-  color: #666 !important;
-}
-      /** @endgroup */
-/**
- * Apply a border color on hover and active states.
- *
- * @group
- * @memberof Borders
- * @example
- * <div class=\'border border--red-on-hover\'>border--red-on-hover</div>
- * <div class=\'border border--red-on-active\'>border--red-on-active (not active)</div>
- * <div class=\'border border--red-on-active is-active\'>border--red-on-active (active)</div>
- */
-.border--lighten50-on-hover:hover,
-.border--lighten50-on-active.is-active {
-  border-color: rgba(255, 255, 255, 0.50) !important;
-}
-      
-.border--lighten25-on-hover:hover,
-.border--lighten25-on-active.is-active {
-  border-color: rgba(255, 255, 255, 0.25) !important;
-}
-      
-.border--gray-on-hover:hover,
-.border--gray-on-active.is-active {
-  border-color: #666 !important;
-}
-      /** @endgroup */"
-`;
-
-exports[`buildColorVariants with universal colors 1`] = `
+exports[`buildColorVariants with default colors array 1`] = `
 "
 /* Color variants */
 
@@ -15020,6 +14574,452 @@ input:checked + .toggle--active-green-light {
 .border--green-light-on-hover:hover,
 .border--green-light-on-active.is-active {
   border-color: #72C781 !important;
+}
+      /** @endgroup */"
+`;
+
+exports[`buildColorVariants with granular colors 1`] = `
+"
+/* Color variants */
+
+.btn--green {
+  background-color: #01aa46;
+}
+
+.btn--green:hover,
+.btn--green.is-active {
+  background-color: #007532;
+}
+      
+.btn--purple {
+  background-color: #8c50c7;
+}
+
+.btn--purple:hover,
+.btn--purple.is-active {
+  background-color: #500078;
+}
+      
+.btn--stroke.btn--lighten50 {
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.50);
+}
+
+.btn--stroke.btn--lighten50:hover,
+.btn--stroke.btn--lighten50.is-active {
+  color: rgba(255, 255, 255, 0.75);
+}
+      
+.btn--stroke.btn--lighten25 {
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.btn--stroke.btn--lighten25:hover,
+.btn--stroke.btn--lighten25.is-active {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+.btn--stroke.btn--gray {
+  background-color: transparent;
+  color: #666;
+}
+
+.btn--stroke.btn--gray:hover,
+.btn--stroke.btn--gray.is-active {
+  color: #333;
+}
+      
+.textarea--border-lighten50,
+.input--border-lighten50,
+.textarea--border-lighten50,
+.input--border-lighten50 {
+  border-color: rgba(255, 255, 255, 0.50);
+}
+
+.textarea--border-lighten50:hover,
+.input--border-lighten50:hover,
+.textarea--border-lighten50:focus,
+.input--border-lighten50:focus {
+  border-color: rgba(255, 255, 255, 0.75);
+}
+      
+.textarea--border-lighten25,
+.input--border-lighten25,
+.textarea--border-lighten25,
+.input--border-lighten25 {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.textarea--border-lighten25:hover,
+.input--border-lighten25:hover,
+.textarea--border-lighten25:focus,
+.input--border-lighten25:focus {
+  border-color: rgba(255, 255, 255, 0.50);
+}
+      
+.textarea--border-gray,
+.input--border-gray,
+.textarea--border-gray,
+.input--border-gray {
+  border-color: #666;
+}
+
+.textarea--border-gray:hover,
+.input--border-gray:hover,
+.textarea--border-gray:focus,
+.input--border-gray:focus {
+  border-color: #333;
+}
+      
+.select--green {
+  background-color: #01aa46;
+}
+
+.select--green:hover {
+  background-color: #007532;
+}
+      
+.select--stroke-lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+.select--stroke-lighten50 + .select-arrow {
+  border-top-color: rgba(255, 255, 255, 0.50);
+}
+.select--stroke-lighten50:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+.select--stroke-lighten50:hover + .select-arrow {
+  border-top-color: rgba(255, 255, 255, 0.75);
+}
+      
+.select--stroke-lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+.select--stroke-lighten25 + .select-arrow {
+  border-top-color: rgba(255, 255, 255, 0.25);
+}
+.select--stroke-lighten25:hover {
+  color: rgba(255, 255, 255, 0.50);
+}
+.select--stroke-lighten25:hover + .select-arrow {
+  border-top-color: rgba(255, 255, 255, 0.50);
+}
+      
+.select--stroke-gray {
+  color: #666;
+}
+.select--stroke-gray + .select-arrow {
+  border-top-color: #666;
+}
+.select--stroke-gray:hover {
+  color: #333;
+}
+.select--stroke-gray:hover + .select-arrow {
+  border-top-color: #333;
+}
+      
+.checkbox--lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+
+.checkbox-container:hover > .checkbox--lighten50,
+input:checked + .checkbox--lighten50 {
+  color: rgba(255, 255, 255, 0.75);
+}
+      
+.checkbox--lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.checkbox-container:hover > .checkbox--lighten25,
+input:checked + .checkbox--lighten25 {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+.checkbox--gray {
+  color: #666;
+}
+
+.checkbox-container:hover > .checkbox--gray,
+input:checked + .checkbox--gray {
+  color: #333;
+}
+      
+.radio--lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+
+.radio-container:hover > .radio--lighten50,
+input:checked + .radio--lighten50 {
+  color: rgba(255, 255, 255, 0.75);
+}
+      
+.radio--lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.radio-container:hover > .radio--lighten25,
+input:checked + .radio--lighten25 {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+.radio--gray {
+  color: #666;
+}
+
+.radio-container:hover > .radio--gray,
+input:checked + .radio--gray {
+  color: #333;
+}
+      
+.toggle--lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+
+.toggle--lighten50:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+input:checked + .toggle--lighten50 {
+  background: rgba(255, 255, 255, 0.50);
+  color: #fff;
+}
+
+input:checked + .toggle--active-lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+.toggle--lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.toggle--lighten25:hover {
+  color: rgba(255, 255, 255, 0.50);
+}
+
+input:checked + .toggle--lighten25 {
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+input:checked + .toggle--active-lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+      
+.toggle--gray {
+  color: #666;
+}
+
+.toggle--gray:hover {
+  color: #333;
+}
+
+input:checked + .toggle--gray {
+  background: #666;
+  color: #fff;
+}
+
+input:checked + .toggle--active-gray {
+  color: #666;
+}
+      
+input:checked + .toggle--active-lighten50 {
+  color: rgba(255, 255, 255, 0.50);
+}
+      
+input:checked + .toggle--active-lighten25 {
+  color: rgba(255, 255, 255, 0.25);
+}
+      
+input:checked + .toggle--active-gray {
+  color: #666;
+}
+      
+/**
+ * @section Text colors
+ * @memberof Colors
+ */
+
+/**
+ * Apply a text color.
+ *
+ * @group
+ * @memberof Text colors
+ * @example
+ * <div class=\'grid\'>
+ *   <div class=\'col col--3 color-lighten50\'>color-lighten50</div>
+ *   <div class=\'col col--3 color-lighten25\'>color-lighten25</div>
+ *   <div class=\'col col--3 color-gray\'>color-gray</div>
+ *   <div class=\'col col--3 color-text\'>.color-text</div>
+ * </div>
+ */
+.color-lighten50 {
+  color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.color-lighten25 {
+  color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.color-gray {
+  color: #666 !important;
+}
+      
+.color-text {
+  color: rgba(0, 0, 0, 0.75) !important;
+}
+    /** @endgroup */
+/**
+ * @section Background colors
+ * @memberof Colors
+ */
+
+/**
+ * Apply a background color.
+ *
+ * @group
+ * @memberof Background colors
+ * @example
+ * <div class=\'grid\'>
+ *   <div class=\'col col--3 bg-orange p6\'>bg-orange</div>
+ *   <div class=\'col col--3 bg-yellow p6\'>bg-yellow</div>
+ *   <div class=\'col col--3 bg-pink p6\'>bg-pink</div>
+ * </div>
+ */
+.bg-orange {
+  background-color: #ff6e00 !important;
+}
+      
+.bg-yellow {
+  background-color: #f0dc00 !important;
+}
+      
+.bg-pink {
+  background-color: #ff3c96 !important;
+}
+      /** @endgroup */
+.link--orange {
+  color: #ff6e00;
+}
+
+.link--orange:hover,
+.link--orange.is-active {
+  color: #DC4600;
+}
+      
+/**
+ * Apply a [color](#Colors) to a border.
+ *
+ * @group
+ * @memberof Borders
+ * @example
+ * <div class=\'border border--red\'>border--red</div>
+ */
+.border--lighten50 {
+  border-color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.border--lighten25 {
+  border-color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.border--gray {
+  border-color: #666 !important;
+}
+      /** @endgroup */
+/**
+ * Apply a box shadow on hover and active states.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class=\'shadow-darken25-on-hover\'>shadow-darken25-on-hover</div>
+ * <div class=\'shadow-darken25-on-active\'>shadow-darken25-on-active (not active)</div>
+ * <div class=\'shadow-darken25-on-active is-active\'>shadow-darken25-on-active (active)</div>
+ */
+.shadow-lighten50-on-hover:hover,
+.shadow-lighten50-on-active.is-active {
+  box-shadow: 0 0 10px 2px rgba(255, 255, 255, 0.50) !important;
+}
+.shadow-bold-lighten50-on-hover:hover,
+.shadow-bold-lighten50-on-active.is-active {
+  box-shadow: 0 0 30px 6px rgba(255, 255, 255, 0.50) !important;
+}
+      /** @endgroup */
+/**
+ * Apply a background color on hover and active states.
+ *
+ * @group
+ * @memberof Background colors
+ * @example
+ * <div class=\'bg-darken25-on-hover\'>bg-darken25-on-hover</div>
+ * <div class=\'bg-darken25-on-active\'>bg-darken25-on-active (not active)</div>
+ * <div class=\'bg-darken25-on-active is-active\'>bg-darken25-on-active (active)</div>
+ */
+.bg-lighten50-on-hover:hover,
+.bg-lighten50-on-active.is-active {
+  background-color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.bg-lighten25-on-hover:hover,
+.bg-lighten25-on-active.is-active {
+  background-color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.bg-gray-on-hover:hover,
+.bg-gray-on-active.is-active {
+  background-color: #666 !important;
+}
+      /** @endgroup */
+/**
+ * Apply a text color on hover and active states.
+ *
+ * @group
+ * @memberof Text colors
+ * @example
+ * <div class=\'color-red-on-hover\'>color-red-on-hover</div>
+ * <div class=\'color-red-on-active\'>color-red-on-active (not active)</div>
+ * <div class=\'color-red-on-active is-active\'>color-red-on-active (active)</div>
+ */
+.color-lighten50-on-hover:hover,
+.color-lighten50-on-active.is-active {
+  color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.color-lighten25-on-hover:hover,
+.color-lighten25-on-active.is-active {
+  color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.color-gray-on-hover:hover,
+.color-gray-on-active.is-active {
+  color: #666 !important;
+}
+      /** @endgroup */
+/**
+ * Apply a border color on hover and active states.
+ *
+ * @group
+ * @memberof Borders
+ * @example
+ * <div class=\'border border--red-on-hover\'>border--red-on-hover</div>
+ * <div class=\'border border--red-on-active\'>border--red-on-active (not active)</div>
+ * <div class=\'border border--red-on-active is-active\'>border--red-on-active (active)</div>
+ */
+.border--lighten50-on-hover:hover,
+.border--lighten50-on-active.is-active {
+  border-color: rgba(255, 255, 255, 0.50) !important;
+}
+      
+.border--lighten25-on-hover:hover,
+.border--lighten25-on-active.is-active {
+  border-color: rgba(255, 255, 255, 0.25) !important;
+}
+      
+.border--gray-on-hover:hover,
+.border--gray-on-active.is-active {
+  border-color: #666 !important;
 }
       /** @endgroup */"
 `;

--- a/test/build-color-variants.jest.js
+++ b/test/build-color-variants.jest.js
@@ -15,7 +15,7 @@ describe('buildColorVariants', () => {
     })).toMatchSnapshot();
   });
 
-  it('with universal colors', () => {
+  it('with default colors array', () => {
     expect(buildColorVariants(null, [
       'red',
       'teal',
@@ -26,7 +26,7 @@ describe('buildColorVariants', () => {
 
   it('with granular colors', () => {
     expect(buildColorVariants(null, {
-      universal: ['lighten50', 'lighten25', 'gray'],
+      default: ['lighten50', 'lighten25', 'gray'],
       buttonFill: ['green', 'purple'],
       selectFill: ['green'],
       background: ['orange', 'yellow', 'pink'],


### PR DESCRIPTION
- Uses `default-interactive-color` and `default-interactive-color-dark` variables throughout, instead of `blue` and `blue-dark`, closing #513.
- Changes "universal" to "default" in color variants. A breaking change for the Mapbox custom build.

@samanpwbb for review.