### PR TITLE
Add txt- prefix

### DIFF
--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -4,11 +4,15 @@
 require('babel-register');
 const renderSite = require('./render-site');
 const buildCss = require('./build-css');
+const buildJs = require('./build-js');
 const copySiteAssets = require('./copy-site-assets');
 
 function buildSite() {
-  return buildCss()
-    .then(() => Promise.all([renderSite(), copySiteAssets()]));
+  return Promise.all([
+    buildCss().then(renderSite()),
+    buildJs(),
+    copySiteAssets()
+  ]);
 }
 
 module.exports = buildSite;

--- a/site/debug/elements.js
+++ b/site/debug/elements.js
@@ -28,7 +28,7 @@ class Elements extends React.Component {
           </div>
           <div className='col col--4'>
             classes
-            <p>Lorem <sup className='txt-sup'>ipsum</sup> dolor <sub className='txt-sub'>sit</sub> amet, <abbr className='txt-abbr'>consectetur adipisicing elit</abbr>, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. <code className='code'>Cool code</code> Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut <kbd className='txt-kbd'>T</kbd> aliquip ex ea commodo consequat.</p>
+            <p>Lorem <sup className='txt-sup'>ipsum</sup> dolor <sub className='txt-sub'>sit</sub> amet, <abbr className='txt-abbr'>consectetur adipisicing elit</abbr>, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. <code className='txt-code'>Cool code</code> Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut <kbd className='txt-kbd'>T</kbd> aliquip ex ea commodo consequat.</p>
             <p><img src='http://placehold.it/800' alt='' /></p>
             <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             <hr className='txt-hr' />

--- a/site/debug/grids.js
+++ b/site/debug/grids.js
@@ -69,16 +69,16 @@ class Grids extends React.Component {
           Grid
         </h1>
 
-        <h2 className='mb12 mt24 txt-l uppercase txt-bold'>Standard grid</h2>
+        <h2 className='mb12 mt24 txt-l txt-uppercase txt-bold'>Standard grid</h2>
         {GridEls}
 
-        <h2 className='mb12 mt24 txt-l uppercase txt-bold'>Grid with gutters</h2>
+        <h2 className='mb12 mt24 txt-l txt-uppercase txt-bold'>Grid with gutters</h2>
         {GridElsWithGutters}
 
-        <h2 className='mb12 mt24 txt-l uppercase txt-bold'>Grid with left offset</h2>
+        <h2 className='mb12 mt24 txt-l txt-uppercase txt-bold'>Grid with left offset</h2>
         {GridElsWithLeftMargin}
 
-        <h2 className='mb12 mt24 txt-l uppercase txt-bold'>Grid with right offset</h2>
+        <h2 className='mb12 mt24 txt-l txt-uppercase txt-bold'>Grid with right offset</h2>
         {GridElsWithRightMargin}
       </div>
     );

--- a/site/debug/typography.js
+++ b/site/debug/typography.js
@@ -61,7 +61,7 @@ class Typography extends React.Component {
           <div className='txt-xl txt-bold mb18 mt24'>Sit Nullam Elit</div>
 
           {/* note there is no bottom margin here, on the final element in the container */}
-          <div className='txt-xl mb18 mt24 txt-bold em'>Sit Nullam Elit</div>
+          <div className='txt-xl mb18 mt24 txt-bold txt-em'>Sit Nullam Elit</div>
 
         </div>
       </div>

--- a/site/documentation/heading.js
+++ b/site/documentation/heading.js
@@ -17,7 +17,7 @@ class Heading extends React.Component {
     }
 
     const sectionClass = props.level === 1 ? 'pb18 border--gray' : 'pb12 mt12 border--gray-faint';
-    const levelClass = props.level === 1 ? 'txt-subhead mb12 pt24' : 'pt12 txt-l uppercase';
+    const levelClass = props.level === 1 ? 'txt-subhead mb12 pt24' : 'pt12 txt-l txt-uppercase';
 
     const example = !props.parsedComment.example ? null : (
       <HtmlExample code={props.parsedComment.example.description} />

--- a/site/home.js
+++ b/site/home.js
@@ -11,7 +11,7 @@ class Home extends React.Component {
     return (
       <div className='mt24 mb96 wmax960'>
         <div className='txt-headline'>
-          <h1 className='animation-rainbow animation--speed-8 color-teal txt-mono uppercase txt-headline txt-spacing2 pl6 pr6'>Assembly.css</h1>
+          <h1 className='animation-rainbow animation--speed-8 color-teal txt-mono txt-uppercase txt-headline txt-spacing2 pl6 pr6'>Assembly.css</h1>
         </div>
         <p className='txt-l mt24'>
           Assembly is a CSS framework that makes the hard parts of designing for the web easy.
@@ -25,7 +25,7 @@ class Home extends React.Component {
             <span className='ml6 align-middle'>View on GitHub</span>
           </a>
         </p>
-        <h2 className='border-b border--2 border--gray-faint pb6 mt72 mb24 txt-l uppercase txt-bold'>
+        <h2 className='border-b border--2 border--gray-faint pb6 mt72 mb24 txt-l txt-uppercase txt-bold'>
           Usage
         </h2>
         <p>
@@ -38,7 +38,7 @@ class Home extends React.Component {
           />
         </div>
         <p className='mt24'>
-          And include somewhere in your HTML, depending on your preferences, the Assembly JavaScript. It is safe to use the <code className='code'>async</code> and <code className='code'>defer</code> attributes.
+          And include somewhere in your HTML, depending on your preferences, the Assembly JavaScript. It is safe to use the <code className='txt-code'>async</code> and <code className='txt-code'>defer</code> attributes.
         </p>
         <div className='mt24 pre'>
           <Lowlight
@@ -46,7 +46,7 @@ class Home extends React.Component {
             value={'<script async defer src="https://www.mapbox.com/assembly/assembly.js"></script>'}
           />
         </div>
-        <h2 className='border-b border--2 border--gray-faint pb6 mt72 txt-l uppercase txt-bold'>
+        <h2 className='border-b border--2 border--gray-faint pb6 mt72 txt-l txt-uppercase txt-bold'>
           Philosophy
         </h2>
         <div className='grid grid--gut24'>
@@ -75,22 +75,22 @@ class Home extends React.Component {
             </p>
           </div>
         </div>
-        <h2 className='border-b border--2 border--gray-faint pb6 mt72 txt-l uppercase txt-bold'>
+        <h2 className='border-b border--2 border--gray-faint pb6 mt72 txt-l txt-uppercase txt-bold'>
           Overview
         </h2>
         <h3 className='mt24 txt-bold'>
-          <code className='code'>6px</code> baseline grid
+          <code className='txt-code'>6px</code> baseline grid
         </h3>
         <p className='mt12'>
-          Every element in Assembly is designed according to a <code className='code'>6px</code> baseline grid, even buttons and form components. Baseline grids don't just make your site look and feel better: they also make development more convenient. All the pieces naturally fit together without fiddling with line height or vertical alignment.
+          Every element in Assembly is designed according to a <code className='txt-code'>6px</code> baseline grid, even buttons and form components. Baseline grids don't just make your site look and feel better: they also make development more convenient. All the pieces naturally fit together without fiddling with line height or vertical alignment.
         </p>
         <h3 className='mt24 txt-bold'>
           No default styling for semantic elements
         </h3>
         <p className='mt12'>
-          You should use <code className='code'>{'<h3>'}</code> for third-level headings, not because you want a certain style.
-          Similarly, you should use <code className='code'>{'<button>'}</code> when a button is behaviorally and semantically appropriate,
-          instead of <code className='code'>href</code>-less <code className='code'>{'<a>'}</code> tags or other elements with click handlers.
+          You should use <code className='txt-code'>{'<h3>'}</code> for third-level headings, not because you want a certain style.
+          Similarly, you should use <code className='txt-code'>{'<button>'}</code> when a button is behaviorally and semantically appropriate,
+          instead of <code className='txt-code'>href</code>-less <code className='txt-code'>{'<a>'}</code> tags or other elements with click handlers.
         </p>
         <p className='mt12'>
           Assembly's reset allows you to use semantically appropriate HTML without battling browser-default styles.
@@ -98,11 +98,11 @@ class Home extends React.Component {
           A heading <em>style</em>, or a button <em>style</em>, can be applied to <em>any</em> element by applying the appropriate classes.
         </p>
         <h3 className='mt24 txt-bold'>
-          <code className='code'>box-sizing: border-box</code>
+          <code className='txt-code'>box-sizing: border-box</code>
         </h3>
         <p className='mt12'>
-          The <code className='code'>border-box</code> box model allows for more intuitive styling than the default <code className='code'>content-box</code> model.
-          For example, when you set a <code className='code'>w300</code> class, your element will always be 300 pixels wide, regardless of its padding and borders.
+          The <code className='txt-code'>border-box</code> box model allows for more intuitive styling than the default <code className='txt-code'>content-box</code> model.
+          For example, when you set a <code className='txt-code'>w300</code> class, your element will always be 300 pixels wide, regardless of its padding and borders.
         </p>
         <h3 className='mt24 txt-bold'>
           Customizable icons
@@ -118,25 +118,25 @@ class Home extends React.Component {
         </p>
         <div className='prose mt12'>
           <ul className='txt-ul'>
-            <li>Extra large screens: <code className='code'>{defaultMediaQueries['--xl-screen']}</code></li>
-            <li>Large screens: <code className='code'>{defaultMediaQueries['--l-screen']}</code></li>
-            <li>Medium screens: <code className='code'>{defaultMediaQueries['--m-screen']}</code></li>
+            <li>Extra large screens: <code className='txt-code'>{defaultMediaQueries['--xl-screen']}</code></li>
+            <li>Large screens: <code className='txt-code'>{defaultMediaQueries['--l-screen']}</code></li>
+            <li>Medium screens: <code className='txt-code'>{defaultMediaQueries['--m-screen']}</code></li>
           </ul>
         </div>
         <p className='mt12'>
-          Classes that take affect within certain media queries always end with a <code className='code'>{'-m<size>'}</code> suffix,
-          where "size" is <code className='code'>m</code>, <code className='code'>l</code>, or <code className='code'>xl</code>.
+          Classes that take affect within certain media queries always end with a <code className='txt-code'>{'-m<size>'}</code> suffix,
+          where "size" is <code className='txt-code'>m</code>, <code className='txt-code'>l</code>, or <code className='txt-code'>xl</code>.
         </p>
         <h3 className='mt24 txt-bold'>
-          Utility classes are <code className='code'>!important</code>
+          Utility classes are <code className='txt-code'>!important</code>
         </h3>
         <p className='mt12'>
-          Assembly uses <code className='code'>!important</code> on declarations whose effect directly corresponds to a class name.
+          Assembly uses <code className='txt-code'>!important</code> on declarations whose effect directly corresponds to a class name.
         </p>
         <p className='mt12'>
-          For example, in the <code className='code'>.bg-pink</code> rule, the <code className='code'>background-color</code> declaration is <code className='code'>!important</code>.
-          On the <code className='code'>.pl20</code> rule, the <code className='code'>padding-left</code> declaration is <code className='code'>!important</code>.
-          This ensures that such classes always behave the same. Whenever you see the class <code className='code'>bg-pink</code> on an element,
+          For example, in the <code className='txt-code'>.bg-pink</code> rule, the <code className='txt-code'>background-color</code> declaration is <code className='txt-code'>!important</code>.
+          On the <code className='txt-code'>.pl20</code> rule, the <code className='txt-code'>padding-left</code> declaration is <code className='txt-code'>!important</code>.
+          This ensures that such classes always behave the same. Whenever you see the class <code className='txt-code'>bg-pink</code> on an element,
           that element should have a pink background, regardless of its context and the other rules that apply to it.
         </p>
         <p className='mt12'>
@@ -144,14 +144,14 @@ class Home extends React.Component {
           But if you need even more, you should use custom CSS instead of a utility class.
         </p>
         <h3 className='mt24 txt-bold'>
-          <code className='code'>is-active</code> applies active states
+          <code className='txt-code'>is-active</code> applies active states
         </h3>
         <p className='mt12'>
-          Assembly uses the <code className='code'>is-active</code> state class to designate that an element is active and style it accordingly.
+          Assembly uses the <code className='txt-code'>is-active</code> state class to designate that an element is active and style it accordingly.
         </p>
         <p className='mt12'>
-          The <code className='code'>is-active</code> state on buttons and links darkens their color.
-          And the <code className='code'>*-on-active</code> state classes (e.g. only <code className='code'>color-red-on-active</code>) only take effect when combined with the <code className='code'>is-active</code> class.
+          The <code className='txt-code'>is-active</code> state on buttons and links darkens their color.
+          And the <code className='txt-code'>*-on-active</code> state classes (e.g. only <code className='txt-code'>color-red-on-active</code>) only take effect when combined with the <code className='txt-code'>is-active</code> class.
         </p>
       </div>
     );

--- a/site/icons.js
+++ b/site/icons.js
@@ -47,7 +47,7 @@ class Icons extends React.Component {
           {iconEls}
         </div>
 
-        <h2 className='pt24 txt-bold uppercase mb12 mt24'>
+        <h2 className='pt24 txt-bold txt-uppercase mb12 mt24'>
           Programmatically adding icons with JavaScript
         </h2>
         <div className='mb24'>

--- a/site/navigation.js
+++ b/site/navigation.js
@@ -59,7 +59,7 @@ class Navigation extends React.Component {
 
     return (
       <div className='flex-parent-mm flex-parent--column-mm w-full'>
-        <a href='/assembly/' className='mt24 mb12 mx24 txt-mono link txt-spacing2 uppercase block'>Assembly</a>
+        <a href='/assembly/' className='mt24 mb12 mx24 txt-mono link txt-spacing2 txt-uppercase block'>Assembly</a>
         <div className='flex-child-grow-mm scroll-auto pr18 pl24'>
           {navEls}
         </div>

--- a/src/typography.css
+++ b/src/typography.css
@@ -366,7 +366,7 @@ textarea {
   top: 0.5ex;
 }
 
-.code,
+.txt-code,
 .pre,
 .prose code,
 .prose pre {
@@ -388,9 +388,9 @@ textarea {
  *
  * @memberof Type basics
  * @example
- * Make sure you <code class='code'>git checkout</code> the repository.
+ * Make sure you <code class='txt-code'>git checkout</code> the repository.
  */
-.code,
+.txt-code,
 .prose code {
   padding: 2px 4px;
 }
@@ -475,80 +475,46 @@ textarea {
  *
  * @memberof Type utils
  * @example
- * <div class='em'>em</div>
+ * <div class='txt-em'>em</div>
  */
-.em { font-style: italic !important; }
+.txt-em { font-style: italic !important; }
 
 /**
  * Capitalize all letters in an element.
  *
  * @memberof Type utils
  * @example
- * <div class='uppercase'>UpPeRcAsE</div>
+ * <div class='txt-uppercase'>UpPeRcAsE</div>
  */
-.uppercase { text-transform: uppercase !important; }
+.txt-uppercase { text-transform: uppercase !important; }
 
 /**
  * Lowercase all letters in an element.
  *
  * @memberof Type utils
  * @example
- * <div class='lowercase'>LoWeRcAsE</div>
+ * <div class='txt-lowercase'>LoWeRcAsE</div>
  */
-.lowercase { text-transform: lowercase !important; }
+.txt-lowercase { text-transform: lowercase !important; }
 
 /**
  * Capitalize all words in an element.
  *
  * @memberof Type utils
  * @example
- * <div class='capitalize'>all words are capitalized</div>
+ * <div class='txt-capitalize'>all words are capitalized</div>
  */
-.capitalize { text-transform: capitalize !important; }
+.txt-capitalize { text-transform: capitalize !important; }
 
 /**
  * Capitalize the first letter in an element.
  *
  * @memberof Type utils
  * @example
- * <div class='capitalize-first'>first word only is capitalized</div>
+ * <div class='txt-capitalize-first'>first word only is capitalized</div>
  */
-.capitalize-first { text-transform: lowercase !important; }
-.capitalize-first::first-letter { text-transform: capitalize !important; }
-
-/**
- * Control the horizontal alignment of an element's inline children.
- *
- * @memberof Type utils
- * @group
- * @example
- * <div class='align-l'>.align-l</div>
- * <div class='align-r'>.align-r</div>
- * <div class='align-center'>.align-center</div>
- */
-.align-l { text-align: left !important; }
-.align-r { text-align: right !important; }
-.align-center { text-align: center !important; }
-/** @endgroup */
-
-/**
- * Control the vertical alignment of an inline or table-cell element.
- *
- * @memberof Type utils
- * @group
- * @example
- * <div>
- *   <span class='align-t inline-block h12 w12 border border--gray'></span>
- *   <span class='align-t inline-block h48 border border--gray'>align-top</span>
- * </div>
- * <div class='mt3'>
- *   <span class='align-middle inline-block h12 w12 border'></span>
- *   <span class='align-middle inline-block h48 border border--gray'>align-middle</span>
- * </div>
- */
-.align-t { vertical-align: top !important; }
-.align-middle { vertical-align: middle !important; }
-/** @endgroup */
+.txt-capitalize-first { text-transform: lowercase !important; }
+.txt-capitalize-first::first-letter { text-transform: capitalize !important; }
 
 /**
  * Underline text.
@@ -769,3 +735,37 @@ textarea {
 }
 /* stylelint-enable selector-no-universal */
 /* end prose-specific rules */
+
+/**
+ * Control the horizontal alignment of an element's inline children.
+ *
+ * @memberof Type utils
+ * @group
+ * @example
+ * <div class='align-l'>.align-l</div>
+ * <div class='align-r'>.align-r</div>
+ * <div class='align-center'>.align-center</div>
+ */
+.align-l { text-align: left !important; }
+.align-r { text-align: right !important; }
+.align-center { text-align: center !important; }
+/** @endgroup */
+
+/**
+ * Control the vertical alignment of an inline or table-cell element.
+ *
+ * @memberof Type utils
+ * @group
+ * @example
+ * <div>
+ *   <span class='align-t inline-block h12 w12 border border--gray'></span>
+ *   <span class='align-t inline-block h48 border border--gray'>align-top</span>
+ * </div>
+ * <div class='mt3'>
+ *   <span class='align-middle inline-block h12 w12 border'></span>
+ *   <span class='align-middle inline-block h48 border border--gray'>align-middle</span>
+ * </div>
+ */
+.align-t { vertical-align: top !important; }
+.align-middle { vertical-align: middle !important; }
+/** @endgroup */


### PR DESCRIPTION
Adds `txt-` prefix to
- `uppercase`
- `lowercase`
- `capitalize`
- `capitalize-first`
- `em`
- `code` (I thought this was appropriate because it's really only for code-within-text)

Tries to fix the places those classes were used in the site.

Moves `align-*` classes lower down in typography utils because they stand out for not having a `txt-` prefix.

Also fixes a small unrelated thing: ensures that JS is built during the `build-site` script that runs on CI.

@samanpwbb for review.