### PR TITLE
Remove flex classes from buttons and recreate pills

### DIFF
--- a/site/catalog/pills.js
+++ b/site/catalog/pills.js
@@ -21,21 +21,17 @@ class Pills extends React.Component {
           <button className='btn btn--red btn--stroke btn--pill btn--pill-hr round'>Confirm</button>
         </div>
 
-        <div className='mb18'>
-          <div className='flex-parent-inline flex-parent--column'>
-            <button className='btn btn--orange btn--s btn--pill btn--pill-vt'>Confirm</button>
-            <button className='btn btn--orange btn--s btn--pill btn--pill-vc'>Confirm</button>
-            <button className='btn btn--orange btn--s btn--pill btn--pill-vb is-active'>Confirm</button>
-          </div>
+        <div className='mb18 flex-parent-inline flex-parent--column'>
+          <button className='btn btn--orange btn--s btn--pill btn--pill-vt'>Confirm</button>
+          <button className='btn btn--orange btn--s btn--pill btn--pill-vc'>Confirm</button>
+          <button className='btn btn--orange btn--s btn--pill btn--pill-vb is-active'>Confirm</button>
         </div>
 
-        <div className='mb18'>
-          <div className='flex-parent-inline flex-parent--column'>
-            <button className='btn btn--stroke btn--s btn--pill btn--pill-vt round'>Confirm</button>
-            <button className='btn btn--stroke btn--s btn--pill btn--pill-vc round'>Confirm</button>
-            <button className='btn btn--stroke btn--s btn--pill btn--pill-vc round'>Confirm</button>
-            <button className='btn btn--stroke btn--s btn--pill btn--pill-vb round is-active'>Confirm</button>
-          </div>
+        <div className='mb18 ml18 flex-parent-inline flex-parent--column'>
+          <button className='btn btn--stroke btn--s btn--pill btn--pill-vt round'>Confirm</button>
+          <button className='btn btn--stroke btn--s btn--pill btn--pill-vc round'>Confirm</button>
+          <button className='btn btn--stroke btn--s btn--pill btn--pill-vc round'>Confirm</button>
+          <button className='btn btn--stroke btn--s btn--pill btn--pill-vb round is-active'>Confirm</button>
         </div>
       </div>
     );

--- a/src/buttons.css
+++ b/src/buttons.css
@@ -34,9 +34,7 @@
   border-radius: 18px; /* fully round by default */
   padding: 4px 12px; /* Padding accommodates borders */
   font-weight: bold;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  text-align: center;
   text-decoration: none !important; /* prevent underline when inside .prose */
   transition: background-color var(--transition),
     border-color var(--transition),
@@ -129,7 +127,7 @@
 /**
  * Create pill button groups.
  * Pill groups must be wrapped in a `flex-parent-inline` container.
- * And every button in a pill group must have the `btn` and `btn--pill` classes, along with a modifier specifying its position.
+ * Every button in a pill group must have the `btn` and `btn--pill` classes, along with a modifier specifying its position.
  *
  * For *horizontal* pills, use
  * - `flex-parent-inline` on the container
@@ -147,18 +145,16 @@
  *
  * @memberof Buttons
  * @example
- * <div>
- *   <div class="mr12 flex-parent-inline">
- *     <button class="btn btn--pill btn--pill-hl">Left</button>
- *     <button class="btn btn--pill btn--pill-hc">Center</button>
- *     <button class="btn btn--pill btn--pill-hr">Right</button>
- *   </div>
+ * <div class="flex-parent-inline">
+ *   <button class="btn btn--pill btn--pill-hl">Left</button>
+ *   <button class="btn btn--pill btn--pill-hc">Center</button>
+ *   <button class="btn btn--pill btn--pill-hr">Right</button>
  * </div>
- *  <div class="flex-parent flex-parent-inline flex-parent--column mt12">
- *     <button class="btn btn--pill btn--pill-vt">Top</button>
- *     <button class="btn btn--pill btn--pill-vc is-active">Center</button>
- *     <button class="btn btn--pill btn--pill-vb">Bottom</button>
- *  </div>
+ * <div class="flex-parent-inline flex-parent--column">
+ *   <button class="btn btn--pill btn--pill-vt">Top</button>
+ *   <button class="btn btn--pill btn--pill-vc is-active">Center</button>
+ *   <button class="btn btn--pill btn--pill-vb">Bottom</button>
+ * </div>
  */
 .btn--pill {
   position: relative;
@@ -196,16 +192,22 @@ against .round class */
   border-radius: 0 !important;
   margin-top: 1px;
   margin-bottom: 1px;
+  display: block;
+  width: 100%;
 }
 
 .btn.btn--pill-vt {
   border-bottom-right-radius: 0 !important;
   border-bottom-left-radius: 0 !important;
+  display: block;
+  width: 100%;
 }
 
 .btn.btn--pill-vb {
   border-top-right-radius: 0 !important;
   border-top-left-radius: 0 !important;
+  display: block;
+  width: 100%;
 }
 
 .btn--stroke.btn--pill-hc {


### PR DESCRIPTION
@davidtheclark for review..

I'm concerned about two things:
1. that constructing vertical pills in an inline-block container will cause problems
2. that using margin-left to close the space between inline horizontal pills is too hacky

fixes https://github.com/mapbox/assembly/issues/533 and https://github.com/mapbox/assembly/issues/547