### PR TITLE
Fix appearance of search inputs on mobile Safari

### DIFF
--- a/src/forms.css
+++ b/src/forms.css
@@ -58,7 +58,7 @@
   height: 0;
 }
 .input[type='search'] {
-  appearance: textfield;
+  appearance: none;
 }
 .input[type='search']::-webkit-search-decoration,
 .input[type='search']::-webkit-search-cancel-button {


### PR DESCRIPTION
adding `-webkit-appearance: none` to search inputs fixes https://github.com/mapbox/assembly/issues/541

I'm continuing to investigate other Safari bugs, but we can merge for beta if we want.