### PR TITLE
Full width on inputs and textareas, no special search

### DIFF
--- a/site/catalog/inputs.js
+++ b/site/catalog/inputs.js
@@ -29,7 +29,7 @@ const colors = [
 ];
 
 function InputEl(props) {
-  let inputClasses = 'input';
+  let inputClasses = 'input w180';
   if (props.border) inputClasses += ` input--border-${props.border}`;
   if (props.color) inputClasses += ` color-${props.color}`;
   return (
@@ -78,34 +78,34 @@ class Inputs extends React.Component {
         <div className='mb24'>
           <div className='mr6 mb6 inline-block'>
             <input
-              className='input'
+              className='input w180'
               placeholder='date'
               type='date'
             />
           </div>
           <div className='mr6 mb6 inline-block'>
             <input
-              className='input'
+              className='input w180'
               placeholder='number'
               type='number'
             />
           </div>
           <div className='mr6 mb6 inline-block'>
             <input
-              className='input'
+              className='input w180'
               placeholder='search'
               type='search'
             />
           </div>
           <div className='mr6 mb6 inline-block align-t'>
             <input
-              className='input'
+              className='input w180'
               type='color'
             />
           </div>
           <div className='mr6 mb6 inline-block'>
             <input
-              className='input'
+              className='input w180'
               placeholder='datetime'
               type='datetime'
             />

--- a/site/catalog/textareas.js
+++ b/site/catalog/textareas.js
@@ -29,7 +29,7 @@ const colors = [
 ];
 
 function TextareaEl(props) {
-  let textareaClasses = 'textarea';
+  let textareaClasses = 'textarea w180';
   if (props.border) textareaClasses += ` textarea--border-${props.border}`;
   if (props.color) textareaClasses += ` color-${props.color}`;
   return (

--- a/src/forms.css
+++ b/src/forms.css
@@ -20,6 +20,10 @@
  * The `input` class styles input types `text`, `password`, `email`,
  * `datetime`, `search`, `tel`, `url`, and `number`. The `textarea` class styles the `<textarea>` element.
  *
+ * Both form elements fill the width of their container, by default.
+ * You should adjust the widths of inputs and textareas by adding [`w*` width classes](http://localhost:3000/assembly/documentation/#Sizing)
+ * or controlling the widths of their containers, e.g. with [`grid` classes](http://localhost:3000/assembly/documentation/#Grid).
+ *
  * @section Inputs & textareas
  * @memberof Forms
  */
@@ -27,9 +31,10 @@
 .textarea {
   border: 1px solid var(--gray-light);
   border-radius: var(--border-radius);
-  display: inline-block;
   transition: background-color var(--transition),
     border-color var(--transition);
+  display: block;
+  width: 100%;
 }
 
 .input:hover,
@@ -58,7 +63,7 @@
   height: 0;
 }
 .input[type='search'] {
-  appearance: textfield;
+  appearance: none;
 }
 .input[type='search']::-webkit-search-decoration,
 .input[type='search']::-webkit-search-cancel-button {
@@ -72,7 +77,7 @@
  * @memberof Inputs & textareas
  * @example
  * <input class='input' placeholder='default' />
- * <input class='input input--border-teal' placeholder='teal' />
+ * <input class='input input--border-teal w180' placeholder='teal' />
  */
 .input {
   height: 36px;
@@ -99,7 +104,7 @@
  * @memberof Inputs & textareas
  * @example
  * <textarea placeholder='default' class='textarea'></textarea>
- * <textarea placeholder='pink' class='textarea textarea--border-pink'></textarea>
+ * <textarea placeholder='pink' class='textarea textarea--border-pink w180'></textarea>
  */
 .textarea {
   resize: vertical;


### PR DESCRIPTION
Closes #540, closes #541.

@samanpwbb for review. Here's what I see now for those HTML5 typed inputs on mobile Safari:

![screen shot 2017-01-06 at 4 04 24 pm](https://cloud.githubusercontent.com/assets/628431/21735911/51926e94-d42a-11e6-8847-e46f20a98767.png)

Beautiful uniformity.