### PR TITLE
Add hide-visually

### DIFF
--- a/src/forms.css
+++ b/src/forms.css
@@ -517,12 +517,20 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   display: inline-flex;
 }
 
+/* Same as the hide-visually class */
 .toggle-container > input,
 .checkbox-container > input,
 .switch-container > input,
 .radio-container > input {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
   position: absolute;
-  left: -9999px;
+  width: 1px;
+  white-space: nowrap;
 }
 
 .checkbox,

--- a/src/miscellaneous.css
+++ b/src/miscellaneous.css
@@ -143,3 +143,23 @@
 .clip {
   overflow: hidden !important;
 }
+
+/**
+ * Hide an element *visually*, but keep it available to screen readers.
+ *
+ * @memberof Miscellaneous
+ * @example
+ *   <div class='hide-visually'>You cannot see this with your eyes.</div>
+ *   <div>There is a sentence above this that you cannot see.</div>
+ */
+.hide-visually {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Use the same technique to hide toggly input elements.

Closes #594.

I ended up deciding to use the same technique [as in HTML5 boilerplate](https://github.com/h5bp/html5-boilerplate/blob/master/dist/css/main.css#L135), since that's at least semi-authoritative, probably well tested.

I *could* reduce a little CSS by making people add the `hide-visually` class to their `<input>` elements for these components. But that would be a bigger change, more of a hassle generally, and this is some very short repetition.

@samanpwbb for review.