### PR TITLE
remove hover state from forms, closes #606

### DIFF
--- a/src/forms.css
+++ b/src/forms.css
@@ -37,8 +37,6 @@
   width: 100%;
 }
 
-.input:hover,
-.textarea:hover,
 .input:focus,
 .textarea:focus {
   border-color: var(--default-primary-interactive-color);


### PR DESCRIPTION
Nowhere else are there hover states on text inputs / textareas. This is what was bothering me when I opened https://github.com/mapbox/assembly/issues/606. 