### PR TITLE
Fix flex-child--grow so element does not overflow

### DIFF
--- a/site/catalog/flexbox.js
+++ b/site/catalog/flexbox.js
@@ -1,0 +1,63 @@
+import React from 'react';
+
+class Flexbox extends React.Component {
+  render() {
+    return (
+      <div>
+        <h2 className='border-b border--2 border--gray-faint pb6 mt72 mb24 txt-l txt-uppercase txt-bold'>
+          Flexbox
+        </h2>
+
+        <div className='mb24'>
+          <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>Standard flex children</div>
+          <div className='border flex-parent'>
+            <div className='flex-child bg-gray-light'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+            <div className='flex-child bg-gray-faint'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+          </div>
+        </div>
+
+        <div className='mb24'>
+          <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>Set-width flex children</div>
+          <div className='border flex-parent'>
+            <div className='flex-child w300 bg-gray-light'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+            <div className='flex-child w420 bg-gray-faint'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+          </div>
+        </div>
+
+        <div className='mb24'>
+          <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>One set-width flex child, the other with long text</div>
+          <div className='border flex-parent'>
+            <div className='flex-child w300 bg-gray-light'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+            <div className='flex-child bg-gray-faint'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+          </div>
+        </div>
+
+        <div className='mb24'>
+          <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>One set-width flex child, the other with short text</div>
+          <div className='border flex-parent'>
+            <div className='flex-child w300 bg-gray-light'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+            <div className='flex-child bg-gray-faint'>Duis mollis.</div>
+          </div>
+        </div>
+
+        <div className='mb24'>
+          <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>One set-width flex child and a growing child with long text</div>
+          <div className='border flex-parent'>
+            <div className='flex-child w300 bg-gray-light'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+            <div className='flex-child flex-child--grow bg-gray-faint'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+          </div>
+        </div>
+
+        <div className='mb24'>
+          <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>One set-width flex child and a growing child with short text</div>
+          <div className='border flex-parent'>
+            <div className='flex-child w300 bg-gray-light'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec ullamcorper nulla non metus auctor fringilla. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.</div>
+            <div className='flex-child flex-child--grow bg-gray-faint'>Duis mollis.</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export { Flexbox };

--- a/site/catalog/index.js
+++ b/site/catalog/index.js
@@ -15,6 +15,7 @@ import { Textareas } from './textareas';
 import { Ranges } from './ranges';
 import { Links } from './links';
 import { Grids } from './grids';
+import { Flexbox } from './flexbox';
 
 class Catalog extends React.Component {
   render() {
@@ -29,6 +30,9 @@ class Catalog extends React.Component {
         </div>
         <div id='Grids' className='mb48'>
           <Grids />
+        </div>
+        <div id='Flexbox' className='mb48'>
+          <Flexbox />
         </div>
         <div id='Tables' className='mb48'>
           <Tables />

--- a/site/routes.js
+++ b/site/routes.js
@@ -155,6 +155,7 @@ function buildRoutes() {
         const sections = [
           'Typography',
           'Grids',
+          'Flexbox',
           'Tables',
           'Lists',
           'Links',

--- a/src/layout.css
+++ b/src/layout.css
@@ -633,8 +633,6 @@
 .flex-child {
   display: block;
   max-width: 100%;
-  flex-shrink: 0;
-  flex-basis: auto;
 }
 /* Specifically, the above addresses #1, #2, and #12 in https://github.com/philipwalton/flexbugs */
 
@@ -652,7 +650,6 @@
  */
 .flex-child--grow {
   flex-grow: 1 !important;
-  flex-shrink: 1;
   min-width: 0;
 }
 
@@ -668,12 +665,9 @@
   .flex-child-mm {
     display: block;
     max-width: 100%;
-    flex-shrink: 0;
-    flex-basis: auto;
   }
   .flex-child--grow-mm {
     flex-grow: 1 !important;
-    flex-shrink: 1;
     min-width: 0;
   }
 }
@@ -690,12 +684,9 @@
   .flex-child-ml {
     display: block;
     max-width: 100%;
-    flex-shrink: 0;
-    flex-basis: auto;
   }
   .flex-child--grow-ml {
     flex-grow: 1 !important;
-    flex-shrink: 1;
     min-width: 0;
   }
 }
@@ -712,12 +703,9 @@
   .flex-child-mxl {
     display: block;
     max-width: 100%;
-    flex-shrink: 0;
-    flex-basis: auto;
   }
   .flex-child--grow-mxl {
     flex-grow: 1 !important;
-    flex-shrink: 1;
     min-width: 0;
   }
 }

--- a/src/layout.css
+++ b/src/layout.css
@@ -652,6 +652,7 @@
  */
 .flex-child--grow {
   flex-grow: 1 !important;
+  flex-shrink: 1;
   min-width: 0;
 }
 
@@ -672,6 +673,7 @@
   }
   .flex-child--grow-mm {
     flex-grow: 1 !important;
+    flex-shrink: 1;
     min-width: 0;
   }
 }
@@ -693,6 +695,7 @@
   }
   .flex-child--grow-ml {
     flex-grow: 1 !important;
+    flex-shrink: 1;
     min-width: 0;
   }
 }
@@ -714,6 +717,7 @@
   }
   .flex-child--grow-mxl {
     flex-grow: 1 !important;
+    flex-shrink: 1;
     min-width: 0;
   }
 }


### PR DESCRIPTION
Important fix!

Currently, a `flex-child--grow` element with long content can overflow its parent:

![screen shot 2017-01-19 at 9 14 44 am](https://cloud.githubusercontent.com/assets/628431/22114739/c5e38632-de27-11e6-9860-1404c79ccfeb.png)

This fixes that.

@samanpwbb for review.