### PR TITLE
Exposing users to CSS

### DIFF
--- a/site/css_snippet.js
+++ b/site/css_snippet.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import Lowlight from 'react-lowlight';
+import cssLanguage from 'highlight.js/lib/languages/css';
+
+Lowlight.registerLanguage('css', cssLanguage);
+
+class CssSnippet extends React.Component {
+  render() {
+    // flex-parent removes line-height
+    return (
+      <div>
+        <button
+          className='flex-child btn btn--xs btn--blue round'
+          data-css-snippet-button={true}
+        >
+          Show CSS
+        </button>
+        {/* The code block must be the next sibling */}
+        <div className='none mt6 pre bg-gray-faint scroll-auto hmax180 border border--gray-light round-b relative'>
+          <div className='absolute top right p12'>
+            <button
+              data-clipboard-text={this.props.code}
+              className='ml3 btn btn--xs btn--darken25 round js-clipboard'>
+              Copy
+            </button>
+          </div>
+          <Lowlight
+            language='css'
+            value={this.props.code}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export { CssSnippet };

--- a/site/documentation/entry.js
+++ b/site/documentation/entry.js
@@ -3,6 +3,7 @@ import remark from 'remark';
 import reactRenderer from 'remark-react';
 import _ from 'lodash';
 import { HtmlExample } from '../html_example';
+import { CssSnippet } from '../css_snippet';
 
 class Entry extends React.Component {
   constructor(props) {
@@ -69,6 +70,12 @@ class Entry extends React.Component {
       </button>
     ) : null;
 
+    const css = !props.referencedSource ? null : (
+      <div className='mt6'>
+        <CssSnippet code={props.referencedSource.toString()} />
+      </div>
+    );
+
     return (
       <div className='grid-mxl grid--gut18-mxl border-t border--2 border--gray-faint pt48 pb48'>
         <div className='col col--4-mxl pr18-ml mb6'>
@@ -85,6 +92,7 @@ class Entry extends React.Component {
             {remark().use(reactRenderer).process(props.parsedComment.description).contents}
           </div>
           {example}
+          {css}
         </div>
       </div>
     );

--- a/site/html_example.js
+++ b/site/html_example.js
@@ -8,10 +8,10 @@ function HtmlExample(props) {
   const copy = props.copy === false ? false : true;
   return (
     <div>
-        <div
-          className='border border--gray-light p12 round-t'
-          dangerouslySetInnerHTML={{ __html: props.code }}
-        />
+      <div
+        className='border border--gray-light p12 round-t'
+        dangerouslySetInnerHTML={{ __html: props.code }}
+      />
       <div className='pre bg-gray-faint scroll-auto hmax180 border-l border-b border-r border--gray-light round-b relative'>
 
         {copy && <div className='absolute top right p12'>

--- a/site/js/enable_css_snippet.js
+++ b/site/js/enable_css_snippet.js
@@ -1,0 +1,14 @@
+(function () {
+  document.addEventListener('click', function (event) {
+    if (!event.target.getAttribute('data-css-snippet-button')) return;
+    var codeElement = event.target.nextElementSibling;
+    if (!codeElement) throw new Error('No code element found');
+    if (codeElement.classList.contains('none')) {
+      event.target.textContent = 'Hide CSS';
+      codeElement.classList.remove('none');
+    } else {
+      event.target.textContent = 'Show CSS';
+      codeElement.classList.add('none');
+    }
+  });
+}());

--- a/site/template.html
+++ b/site/template.html
@@ -10,9 +10,10 @@
   <script async defer src='/assembly/assembly.js'></script>
 </head>
 <body>
-{content}
+  {content}
+  <script src='/assembly/clipboard.min.js'></script>
+  <script src='/assembly/enable_css_snippet.js'></script>
+  <script src='/assembly/copy.js'></script>
+  <script src='/assembly/expander.js'></script>
 </body>
-<script src='/assembly/clipboard.min.js'></script>
-<script src='/assembly/copy.js'></script>
-<script src='/assembly/expander.js'></script>
 </html>


### PR DESCRIPTION
I was thinking about ways to address #626 and expose users to the CSS code.

This implements one possibility: just add a little "Show CSS" button.

<img width="1050" alt="screen shot 2017-01-20 at 4 05 27 pm" src="https://cloud.githubusercontent.com/assets/628431/22168507/4d3b1c6e-df2a-11e6-9bf5-c38b43dda919.png">
<img width="1044" alt="screen shot 2017-01-20 at 4 05 31 pm" src="https://cloud.githubusercontent.com/assets/628431/22168508/4d3b871c-df2a-11e6-927b-38caace622a5.png">

There is one problem with this: most selector *groups* (e.g. the widths) do not have a corresponding `referencedSource` at all, some just don't have one that makes a lot of sense. 

To address this problem, I see two options:

- Work on a way in documentation-css to better control the `referencedSource` (e.g. so it can refer to a set of rules rather than just one) and then modify our CSS to use that.
- Work on a way in documentation-css to pass along information about the source file, line, and column; then instead of an on-page CSS toggle, provide a link to the original documentation-generating comment in GitHub.

What would you prefer (cc @tmcw)?