### PR TITLE
simplify toggles, remove built-in padding and stroke modifiers, close…

### DIFF
--- a/site/catalog/toggles.js
+++ b/site/catalog/toggles.js
@@ -32,7 +32,7 @@ const lightenColors = [
 
 function ToggleEl(props) {
   const toggleClass = `toggle toggle--active-${props.activeColor} toggle--${props.color}`;
-  const toggleGroupClass = `mb12 mr12 toggle-group ${props.small ? 'toggle-group--s txt-s' : ''} ${props.stroke ? 'toggle-group--stroke color-' + props.color : ''}`;
+  const toggleGroupClass = `mb12 mr12 toggle-group ${props.small ? 'toggle-group--s txt-s' : ''}`;
   return (
     <div className={toggleGroupClass}>
       <label className='toggle-container'>
@@ -78,19 +78,9 @@ class Toggles extends React.Component {
         {colors.map((c) => <ToggleEl key={c} color={c} disabled={true} />)}
         </div>
 
-        <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>Stroked</div>
-        <div className='mb24'>
-        {colors.map((c) => <ToggleEl key={c} color={c} stroke={true} />)}
-        </div>
-
         <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>Small</div>
         <div className='mb24'>
         {colors.map((c) => <ToggleEl key={c} color={c} small={true} />)}
-        </div>
-
-        <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>Small and stroked</div>
-        <div className='mb24'>
-        {colors.map((c) => <ToggleEl key={c} color={c} small={true} stroke={true} />)}
         </div>
 
         <div className='mb12 txt-bold color-darken50 txt-uppercase txt-s'>Light variations</div>

--- a/src/forms.css
+++ b/src/forms.css
@@ -781,7 +781,6 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   display: inline-flex;
   text-align: center;
   border-radius: 18px;
-  padding: 6px;
 }
 
 .toggle {
@@ -797,40 +796,6 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
     background-color var(--transition);
 }
 /** @endgroup */
-
-/*
- * Add a border to a toggle group.
- *
- * @memberof Toggle group
- * @example
- * <div class='toggle-group toggle-group--stroke'>
- *   <label class='toggle-container'>
- *     <input checked name='stroked' type='radio' />
- *     <div class='toggle'>cat</div>
- *   </label>
- *   <label class='toggle-container'>
- *     <input checked  name='stroked' type='radio' />
- *     <div class='toggle'>dog</div>
- *   </label>
- * </div>
- */
-.toggle-group--stroke {
-  padding: 4px;
-  border-width: 2px;
-  border-style: solid;
-  border-color: var(--default-secondary-interactive-color);
-}
-
-/* Adjust border radiuses with small text – only necessary for vertical toggle groups */
-.toggle-group--s {
-  border-radius: 12px;
-  padding: 3px;
-}
-
-.toggle-group--s.toggle-group--stroke {
-  padding: 2px;
-  line-height: 16px !important; /* align to baseline grid */
-}
 
 /* align labels with small text */
 .switch--s-label,


### PR DESCRIPTION
…s #673 

I ended up removing the toggle stroke modifier, and removing all built in padding. The built in padding was there to ensure toggles are aligned when user adds background to toggles – but we can trust implementors to use padding classes to acheive the same effect. The stroke modifier class had a similar purpose: to ensure that both small and large toggles are aligned to grid even when stroked – again, we can leave this responsibility to implementors.  

@davidtheclark  for review