### PR TITLE
examples -- Playback controls

### DIFF
--- a/site/examples/progress_bars.js
+++ b/site/examples/progress_bars.js
@@ -7,7 +7,7 @@ const basic = `<div class='h12 bg-darken10 relative round-full'>
 
 const playback = `<div class='flex-parent flex-parent--row flex-parent--center-cross border border--gray-light round-t'>
     <div class='flex-child py18 pr12 pl18 border-r border--gray-light bg-white cursor-pointer'>
-      <span class='block triangle--r triangle color-green color-green'></span>
+      <div class='triangle--r triangle color-green color-green'></div>
     </div>
     <div class='flex-child flex-child--grow p18 bg-white'>
       <div class='relative w-full h12 bg-darken10 round-full'>

--- a/site/examples/progress_bars.js
+++ b/site/examples/progress_bars.js
@@ -6,13 +6,13 @@ const basic = `<div class='h12 bg-darken10 relative round-full'>
 </div>`;
 
 const playback = `<div class='flex-parent flex-parent--row flex-parent--center-cross border border--gray-light round-t'>
-    <div class='flex-child py12 pr6 pl12 border-r bg-gray-dark cursor-pointer'>
+    <div class='flex-child py12 pr6 pl12 border-r border--gray-light bg-white cursor-pointer'>
       <span class='block triangle-l triangle-l--r color-green'></span>
     </div>
-    <div class='flex-child flex-child--grow p18 bg-blue'>
+    <div class='flex-child flex-child--grow p18 bg-white'>
       <div class='relative w-full h12 bg-darken10 round-full'>
-        <div class='absolute top right bottom left m3 mh6 bg-purple-light round-full' style='width:50%;'>
-          <span class='absolute top right w30 h6 bg-red round-full'></span>
+        <div class='absolute top right bottom left m3 mh6 bg-green-light round-full' style='width:50%;'>
+          <span class='absolute top right w30 h6 bg-green round-full'></span>
         </div>
       </div>
     </div>

--- a/site/examples/progress_bars.js
+++ b/site/examples/progress_bars.js
@@ -6,9 +6,9 @@ const basic = `<div class='h12 bg-darken10 relative round-full'>
 </div>`;
 
 const playback = `<div class='flex-parent flex-parent--row flex-parent--center-cross border border--gray-light round-l'>
-    <div class='flex-child py18 pr12 pl18 border-r border--gray-light bg-white cursor-pointer round-l'>
+    <button class='flex-child py18 pr12 pl18 border-r border--gray-light bg-white bg-green-faint-on-hover cursor-pointer round-l'>
       <div class='triangle--r triangle color-green color-green'></div>
-    </div>
+    </button>
     <div class='flex-child flex-child--grow p18 bg-white'>
       <div class='relative w-full h12 bg-darken10 round-full'>
         <div class='absolute top right bottom left m3 bg-green-light round-full' style='width:50%;'>

--- a/site/examples/progress_bars.js
+++ b/site/examples/progress_bars.js
@@ -11,7 +11,7 @@ const playback = `<div class='flex-parent flex-parent--row flex-parent--center-c
     </div>
     <div class='flex-child flex-child--grow p18 bg-white'>
       <div class='relative w-full h12 bg-darken10 round-full'>
-        <div class='absolute top right bottom left m3 mh6 bg-green-light round-full' style='width:50%;'>
+        <div class='absolute top right bottom left m3 bg-green-light round-full' style='width:50%;'>
           <span class='absolute top right w30 h6 bg-green round-full'></span>
         </div>
       </div>

--- a/site/examples/progress_bars.js
+++ b/site/examples/progress_bars.js
@@ -6,8 +6,8 @@ const basic = `<div class='h12 bg-darken10 relative round-full'>
 </div>`;
 
 const playback = `<div class='flex-parent flex-parent--row flex-parent--center-cross border border--gray-light round-t'>
-    <div class='flex-child py12 pr6 pl12 border-r border--gray-light bg-white cursor-pointer'>
-      <span class='block triangle-l triangle-l--r color-green'></span>
+    <div class='flex-child py18 pr12 pl18 border-r border--gray-light bg-white cursor-pointer'>
+      <span class='block triangle--r triangle color-green color-green'></span>
     </div>
     <div class='flex-child flex-child--grow p18 bg-white'>
       <div class='relative w-full h12 bg-darken10 round-full'>

--- a/site/examples/progress_bars.js
+++ b/site/examples/progress_bars.js
@@ -5,8 +5,8 @@ const basic = `<div class='h12 bg-darken10 relative round-full'>
   <div class='absolute h12 bg-green-light round-full' style='width:50%;'></div>
 </div>`;
 
-const playback = `<div class='flex-parent flex-parent--row flex-parent--center-cross border border--gray-light round-t'>
-    <div class='flex-child py18 pr12 pl18 border-r border--gray-light bg-white cursor-pointer'>
+const playback = `<div class='flex-parent flex-parent--row flex-parent--center-cross border border--gray-light round-l'>
+    <div class='flex-child py18 pr12 pl18 border-r border--gray-light bg-white cursor-pointer round-l'>
       <div class='triangle--r triangle color-green color-green'></div>
     </div>
     <div class='flex-child flex-child--grow p18 bg-white'>

--- a/site/examples/progress_bars.js
+++ b/site/examples/progress_bars.js
@@ -5,6 +5,19 @@ const basic = `<div class='h12 bg-darken10 relative round-full'>
   <div class='absolute h12 bg-green-light round-full' style='width:50%;'></div>
 </div>`;
 
+const playback = `<div class='flex-parent flex-parent--row flex-parent--center-cross border border--gray-light round-t'>
+    <div class='flex-child py12 pr6 pl12 border-r bg-gray-dark cursor-pointer'>
+      <span class='block triangle-l triangle-l--r color-green'></span>
+    </div>
+    <div class='flex-child flex-child--grow p18 bg-blue'>
+      <div class='relative w-full h12 bg-darken10 round-full'>
+        <div class='absolute top right bottom left m3 mh6 bg-purple-light round-full' style='width:50%;'>
+          <span class='absolute top right w30 h6 bg-red round-full'></span>
+        </div>
+      </div>
+    </div>
+  </div>`;
+
 class ExampleProgressBars extends React.Component {
   render() {
     return (
@@ -14,6 +27,12 @@ class ExampleProgressBars extends React.Component {
         </h2>
         <div className='mb24'>
           <HtmlExample code={basic} />
+        </div>
+        <h2 className='border-b border--2 border--gray-faint pb6 mt48 mb24 txt-l txt-bold'>
+          Playback controls
+        </h2>
+        <div className='mb24'>
+          <HtmlExample code={playback} />
         </div>
       </div>
     );


### PR DESCRIPTION
Adds a playback control example to /progress-bars/ examples.

<img width="771" alt="screenshot 2017-01-31 19 29 25" src="https://cloud.githubusercontent.com/assets/7318064/22490503/9ee67a1c-e7eb-11e6-9597-8cd93c5b9bab.png">

(Similar to below playback controls like:
![image](https://cloud.githubusercontent.com/assets/7318064/22490386/09ff30b0-e7eb-11e6-9ccd-2d75a4299685.png)
Example requested by @tristen 🙌 )


