### PR TITLE
overhaul typographic scale

### DIFF
--- a/site/catalog/index.js
+++ b/site/catalog/index.js
@@ -23,7 +23,7 @@ class Catalog extends React.Component {
       <div>
         <div className='mt24'>
           <h1 className='txt-subhead txt-bold mb12'>Catalog</h1>
-          <p>A catalog of Assembly variations for reference and debugging purposes.</p>
+          <p className='col col--6-mm'>A catalog of Assembly variations for reference and debugging purposes.</p>
         </div>
         <div id='Typography' className='mb48'>
           <Typography />

--- a/site/catalog/typography.js
+++ b/site/catalog/typography.js
@@ -14,7 +14,7 @@ class Typography extends React.Component {
         <div className='grid grid--gut12'>
 
           <div className='col col--6 prose'>
-            <h1>Justo Elit</h1>
+            <h1>Aenean Elit Parturient Malesuada Euismod</h1>
             <p>Aenean lacinia bibendum nulla sed consectetur. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec ullamcorper nulla non metus auctor fringilla.</p>
 
             <ul>
@@ -45,10 +45,10 @@ class Typography extends React.Component {
           <div className='col col--6'>
 
             {/* note there is no top margin here, on the first element in the container */}
-            <div className='txt-headline txt-bold mb12'>Justo Elit</div>
+            <div className='txt-headline txt-bold mb12'>Aenean Elit Parturient Malesuada Euismod</div>
             <div className='txt-m mb12'>Aenean lacinia bibendum nulla sed consectetur. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec ullamcorper nulla non metus auctor fringilla.</div>
 
-            <div className='txt-ul ml36 mb12'>
+            <div className='txt-ul ml24 mb12'>
               <div className='txt-li mb6'>Nullam quis risus eget urna mollis ornare vel eu leo.</div>
               <div className='txt-li mb6'>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</div>
               <div className='txt-li'>Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</div>

--- a/site/documentation/heading.js
+++ b/site/documentation/heading.js
@@ -17,7 +17,7 @@ class Heading extends React.Component {
     }
 
     const sectionClass = props.level === 1 ? 'pb18 border--gray' : 'pb12 mt12 border--gray-faint';
-    const levelClass = props.level === 1 ? 'txt-subhead mb12 pt24' : 'pt12 txt-l txt-uppercase';
+    const levelClass = props.level === 1 ? 'txt-subhead mb18 pt24' : 'pt12 txt-l txt-uppercase';
 
     const example = !props.parsedComment.example ? null : (
       <HtmlExample code={props.parsedComment.example.description} copy={false} />

--- a/site/examples/index.js
+++ b/site/examples/index.js
@@ -17,8 +17,8 @@ class Examples extends React.Component {
     return (
       <div>
         <div className='my24'>
-          <h1 className='txt-subhead txt-bold my24'>Examples</h1>
-          <p>Composing with classes demonstrates the real flexibility in Assembly. The pages below feature a variety of snippets that cover common components to layout interfaces. They are designed for reusability and adjust elegantly for smaller screens.</p>
+          <h1 className='txt-subhead txt-bold mt24 mb18'>Examples</h1>
+          <p className='col col--6-mm'>Composing with classes demonstrates the real flexibility in Assembly. The pages below feature a variety of snippets that cover common components to layout interfaces. They are designed for reusability and adjust elegantly for smaller screens.</p>
         </div>
         {this.props.children.map(renderChildrenAsNav)}
       </div>

--- a/site/home.js
+++ b/site/home.js
@@ -13,7 +13,7 @@ class Home extends React.Component {
     return (
       <div className='mt24 wmax960'>
         <div className='mt72 flex-parent-ml flex-parent--wrap-ml'>
-          <h1 className='flex-child-ml flex-child--grow-ml txt-subhead txt-headline-mm color-blue txt-uppercase txt-spacing2'>
+          <h1 className='flex-child-ml flex-child--grow-ml txt-subhead txt-headline-mm color-blue txt-uppercase txt-spacing1'>
             Assembly.css
           </h1>
           <div className='flex-child-ml mt18 color-darken50'>
@@ -57,7 +57,7 @@ class Home extends React.Component {
           />
         </div>
 
-        <p className='mt24'>
+        <p className='mt12'>
           Unsure what else you need in the <code className='txt-code'>&lt;head&gt;</code>? Check out <a className='link' href='https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML'>MDN's detailed guide</a>.
         </p>
 

--- a/site/icons.js
+++ b/site/icons.js
@@ -40,7 +40,7 @@ class Icons extends React.Component {
         <h1 className='txt-subhead mb12 txt-bold pt24'>
           Icons
         </h1>
-        <div className='mb48 prose'>
+        <div className='mb48 prose col col--6-mm'>
           <p>Assembly comes with {icons.length} icons covering most UI design needs. The icons are designed to be used as embedded SVGs. For usage instructions, look at <a href='/assembly/documentation/#Icons'>the <code>.icon</code> class documentation</a>.</p>
         </div>
         <div className='flex-parent flex-parent--wrap bg-gray-faint round pl24 pr24 pt12 pb12 txt-m'>

--- a/site/layout_scales.js
+++ b/site/layout_scales.js
@@ -95,10 +95,8 @@ class LayoutScales extends React.Component {
           <h1 className='txt-subhead txt-bold pt24 mb12'>
             Layout Scales
           </h1>
-          <p className='mb12'>
+          <p className='col col--6-mm mb12'>
             These are the numbers, corresponding to pixel values, available for each set of layout classes.
-          </p>
-          <p className='mb12'>
             All of these class sets include <code className='txt-code'>*-mm</code>, <code className='txt-code'>*-ml</code>, and <code className='txt-code'>*-mxl</code> variations to target screen sizes.
           </p>
         </div>

--- a/src/typography.css
+++ b/src/typography.css
@@ -12,7 +12,7 @@ body,
 input,
 textarea {
   color: var(--text-color);
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
   font-family: var(--font-stack-base);
   font-weight: normal;
@@ -150,36 +150,43 @@ textarea {
  * <div class='txt-xs'>Malesuada Pharetra Ridiculus</div>
  */
 .txt-headline {
-  font-size: 32px;
-  line-height: 42px;
+  /* line height ratio: 1.2 */
+  font-size: 45px;
+  line-height: 54px;
 }
 
 .txt-subhead {
-  font-size: 28px;
-  line-height: 36px;
+  /* line height ratio: 1.2 */
+  font-size: 35px;
+  line-height: 42px;
 }
 
 .txt-xl {
-  font-size: 22px;
-  line-height: 30px;
+  /* line height ratio: 1.2 */
+  font-size: 30px;
+  line-height: 36px;
 }
 
 .txt-l {
-  font-size: 18px;
+  /* line height ratio: 1.5 */
+  font-size: 20px;
   line-height: 30px;
 }
 
 .txt-m {
-  font-size: 15px;
+  /* line height ratio: 1.5 */
+  font-size: 16px;
   line-height: 24px;
 }
 
 .txt-s {
+  /* line height ratio: 1.5 */
   font-size: 12px;
   line-height: 18px;
 }
 
 .txt-xs {
+  /* line height ratio: 1.5 */
   font-size: 10px;
   line-height: 15px;
 }
@@ -187,27 +194,27 @@ textarea {
 
 @media (--m-screen) {
   .txt-headline-mm {
-    font-size: 32px;
-    line-height: 42px;
+    font-size: 45px;
+    line-height: 54px;
   }
 
   .txt-subhead-mm {
-    font-size: 28px;
-    line-height: 36px;
+    font-size: 35px;
+    line-height: 42px;
   }
 
   .txt-xl-mm {
-    font-size: 22px;
-    line-height: 30px;
+    font-size: 30px;
+    line-height: 36px;
   }
 
   .txt-l-mm {
-    font-size: 18px;
+    font-size: 20px;
     line-height: 30px;
   }
 
   .txt-m-mm {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 
@@ -224,27 +231,27 @@ textarea {
 
 @media (--l-screen) {
   .txt-headline-ml {
-    font-size: 32px;
-    line-height: 42px;
+    font-size: 45px;
+    line-height: 54px;
   }
 
   .txt-subhead-ml {
-    font-size: 28px;
-    line-height: 36px;
+    font-size: 35px;
+    line-height: 42px;
   }
 
   .txt-xl-ml {
-    font-size: 22px;
-    line-height: 30px;
+    font-size: 30px;
+    line-height: 36px;
   }
 
   .txt-l-ml {
-    font-size: 18px;
+    font-size: 20px;
     line-height: 30px;
   }
 
   .txt-m-ml {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 
@@ -261,27 +268,27 @@ textarea {
 
 @media (--xl-screen) {
   .txt-headline-mxl {
-    font-size: 32px;
-    line-height: 42px;
+    font-size: 45px;
+    line-height: 54px;
   }
 
   .txt-subhead-mxl {
-    font-size: 28px;
-    line-height: 36px;
+    font-size: 35px;
+    line-height: 42px;
   }
 
   .txt-xl-mxl {
-    font-size: 22px;
-    line-height: 30px;
+    font-size: 30px;
+    line-height: 36px;
   }
 
   .txt-l-mxl {
-    font-size: 18px;
+    font-size: 20px;
     line-height: 30px;
   }
 
   .txt-m-mxl {
-    font-size: 15px;
+    font-size: 16px;
     line-height: 24px;
   }
 
@@ -596,6 +603,7 @@ textarea {
  * <div class='txt-spacing2'>spaced out</div>
  * <div class='txt-spacing4'>way spaced out</div>
  */
+.txt-spacing1 { letter-spacing: 0.1em !important; }
 .txt-spacing2 { letter-spacing: 0.2em !important; }
 .txt-spacing4 { letter-spacing: 0.4em !important; }
 /** @endgroup */
@@ -668,31 +676,31 @@ textarea {
 /* start prose-specific rules (no similar txt-) */
 .prose h1 {
   font-weight: bold;
-  font-size: 32px;
-  line-height: 42px;
+  font-size: 45px;
+  line-height: 54px;
   margin-bottom: 12px;
   padding-top: 36px;
 }
 
 .prose h2 {
   font-weight: bold;
-  font-size: 28px;
-  line-height: 36px;
+  font-size: 35px;
+  line-height: 42px;
   margin-bottom: 12px;
   padding-top: 24px;
 }
 
 .prose h3 {
   font-weight: bold;
-  font-size: 22px;
-  line-height: 30px;
+  font-size: 30px;
+  line-height: 36px;
   margin-bottom: 12px;
   padding-top: 24px;
 }
 
 .prose h4 {
   font-weight: bold;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 24px;
   margin-bottom: 12px;
   padding-top: 18px;
@@ -701,7 +709,7 @@ textarea {
 .prose h5,
 .prose h6 {
   font-weight: bold;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 18px;
   margin-bottom: 12px;
   padding-top: 12px;


### PR DESCRIPTION
Reworked the typographic scale to be a little more dramatic. 

New:
![screen shot 2017-02-09 at 1 20 50 pm](https://cloud.githubusercontent.com/assets/108094/22796981/98aea7c4-eeca-11e6-9059-2618be958709.png)


Old:
![screen shot 2017-02-09 at 1 17 52 pm](https://cloud.githubusercontent.com/assets/108094/22796929/69552354-eeca-11e6-8cc2-5837075ec1b3.png)

---

In addition:

- Made all 'headline' style fonts have line height ratio of `1.2`.
- Made all other font styles have line height ratio of `1.5`.
- added a `letter-spacing1` class (.2em is huge for larger fonts).

closes #708