### PR TITLE
remove invisible border frm btn and select elements, closes #701

### DIFF
--- a/src/buttons.css
+++ b/src/buttons.css
@@ -29,11 +29,8 @@
   display: inline-block;
   background-color: var(--default-primary-interactive-color);
   color: var(--white);
-  border-width: 2px;
-  border-style: solid;
-  border-color: transparent;
   border-radius: 18px; /* fully round by default */
-  padding: 4px 12px; /* Padding accommodates borders */
+  padding: 6px 12px;
   font-weight: bold;
   text-align: center;
   text-decoration: none !important; /* prevent underline when inside .prose */
@@ -58,7 +55,7 @@
  */
 .btn--stroke {
   background-color: transparent;
-  border-color: currentColor;
+  box-shadow: inset 0 0 0 2px currentColor;
   color: var(--default-primary-interactive-color);
 }
 
@@ -71,7 +68,7 @@
  */
 .btn--s {
   font-size: 12px;
-  padding: 1px 18px;
+  padding: 0 12px;
   border-radius: 15px;
 }
 
@@ -83,9 +80,9 @@
  * <button class='btn btn--xs'>Extra small</button>
  */
 .btn--xs {
-  line-height: 14px; /* Forces height of btn--xs to be 18px */
+  line-height: 18px;
   font-size: 10px;
-  padding: 0 8px;
+  padding: 0 6px;
   border-radius: 14px;
 }
 

--- a/src/forms.css
+++ b/src/forms.css
@@ -198,14 +198,11 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   font-size: inherit;
   font-weight: bold;
   color: currentColor;
-  padding: 4px 30px 4px 12px; /* plus arrow, minus border */
+  padding: 6px 30px 6px 12px; /* plus arrow */
   cursor: pointer;
   display: inline-block;
   transition: color var(--transition),
     background-color var(--transition);
-  border-width: 2px;
-  border-style: solid;
-  border-color: transparent;
   border-radius: var(--border-radius);
   background-color: var(--default-primary-interactive-color); /* match btn default state */
 }
@@ -274,7 +271,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 .select--stroke {
   color: var(--gray);
   background-color: transparent;
-  border-color: currentColor;
+  box-shadow: inset 0 0 0 2px currentColor;
 }
 
 .select--stroke + .select-arrow {

--- a/test/__snapshots__/build-user-assets.jest.js.snap
+++ b/test/__snapshots__/build-user-assets.jest.js.snap
@@ -579,11 +579,8 @@ textarea{
   display:inline-block;
   background-color:#448ee4;
   color:#fff;
-  border-width:2px;
-  border-style:solid;
-  border-color:transparent;
   border-radius:18px;
-  padding:4px 12px;
+  padding:6px 12px;
   font-weight:bold;
   text-align:center;
   text-decoration:none !important;
@@ -593,18 +590,18 @@ textarea{
 }
 .btn--stroke{
   background-color:transparent;
-  border-color:currentColor;
+  box-shadow:inset 0 0 0 2px currentColor;
   color:#448ee4;
 }
 .btn--s{
   font-size:12px;
-  padding:1px 18px;
+  padding:0 12px;
   border-radius:15px;
 }
 .btn--xs{
-  line-height:14px;
+  line-height:18px;
   font-size:10px;
-  padding:0 8px;
+  padding:0 6px;
   border-radius:14px;
 }
 .btn:hover,
@@ -811,14 +808,11 @@ textarea{
   font-size:inherit;
   font-weight:bold;
   color:currentColor;
-  padding:4px 30px 4px 12px;
+  padding:6px 30px 6px 12px;
   cursor:pointer;
   display:inline-block;
   transition:color 0.125s,
     background-color 0.125s;
-  border-width:2px;
-  border-style:solid;
-  border-color:transparent;
   border-radius:4px;
   background-color:#448ee4;
 }
@@ -860,7 +854,7 @@ textarea{
 .select--stroke{
   color:#666;
   background-color:transparent;
-  border-color:currentColor;
+  box-shadow:inset 0 0 0 2px currentColor;
 }
 
 .select--stroke + .select-arrow{
@@ -16350,11 +16344,8 @@ textarea{
   display:inline-block;
   background-color:#448ee4;
   color:#fff;
-  border-width:2px;
-  border-style:solid;
-  border-color:transparent;
   border-radius:18px;
-  padding:4px 12px;
+  padding:6px 12px;
   font-weight:bold;
   text-align:center;
   text-decoration:none !important;
@@ -16364,18 +16355,18 @@ textarea{
 }
 .btn--stroke{
   background-color:transparent;
-  border-color:currentColor;
+  box-shadow:inset 0 0 0 2px currentColor;
   color:#448ee4;
 }
 .btn--s{
   font-size:12px;
-  padding:1px 18px;
+  padding:0 12px;
   border-radius:15px;
 }
 .btn--xs{
-  line-height:14px;
+  line-height:18px;
   font-size:10px;
-  padding:0 8px;
+  padding:0 6px;
   border-radius:14px;
 }
 .btn:hover,
@@ -16582,14 +16573,11 @@ textarea{
   font-size:inherit;
   font-weight:bold;
   color:currentColor;
-  padding:4px 30px 4px 12px;
+  padding:6px 30px 6px 12px;
   cursor:pointer;
   display:inline-block;
   transition:color 0.125s,
     background-color 0.125s;
-  border-width:2px;
-  border-style:solid;
-  border-color:transparent;
   border-radius:4px;
   background-color:#448ee4;
 }
@@ -16631,7 +16619,7 @@ textarea{
 .select--stroke{
   color:#666;
   background-color:transparent;
-  border-color:currentColor;
+  box-shadow:inset 0 0 0 2px currentColor;
 }
 
 .select--stroke + .select-arrow{


### PR DESCRIPTION
The effect of this PR is that buttons look and act identical to how they did before, but non-stroked buttons will now fall on the pixel grid when vertical padding is added to them.