### PR TITLE
make disabled select item look disabled in FF, closes #735

### DIFF
--- a/site/catalog/selects.js
+++ b/site/catalog/selects.js
@@ -41,7 +41,7 @@ class Selects extends React.Component {
                 <div className={selectContainerClass}>
                   <select className={selectClass}>
                     <option>firstoption</option>
-                    <option>two</option>
+                    <option disabled>two</option>
                     <option>three</option>
                   </select>
                   <div className='select-arrow'></div>

--- a/src/forms.css
+++ b/src/forms.css
@@ -234,6 +234,10 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   color: var(--text-color);
 }
 
+.select option:disabled {
+  color: var(--darken25);
+}
+
 /* IE overrides */
 .select::-ms-expand { display: none; }
 /* IE actually colors the options, so they can't be white */

--- a/test/__snapshots__/build-user-assets.jest.js.snap
+++ b/test/__snapshots__/build-user-assets.jest.js.snap
@@ -849,6 +849,10 @@ textarea{
   background-color:#fff;
   color:rgba(0, 0, 0, 0.75);
 }
+
+.select option:disabled{
+  color:rgba(0, 0, 0, 0.25);
+}
 .select::-ms-expand{ display:none; }
 .select option{ color:rgba(0, 0, 0, 0.75); }
 @media all and (-ms-high-contrast: active){
@@ -16659,6 +16663,10 @@ textarea{
 .select option{
   background-color:#fff;
   color:rgba(0, 0, 0, 0.75);
+}
+
+.select option:disabled{
+  color:rgba(0, 0, 0, 0.25);
 }
 .select::-ms-expand{ display:none; }
 .select option{ color:rgba(0, 0, 0, 0.75); }


### PR DESCRIPTION
before:
<img width="276" alt="screen shot 2017-02-26 at 6 28 35 pm" src="https://cloud.githubusercontent.com/assets/108094/23344851/bf2a0d0a-fc51-11e6-877a-73d4b133571f.png">

after:
<img width="232" alt="screen shot 2017-02-26 at 6 29 00 pm" src="https://cloud.githubusercontent.com/assets/108094/23344852/c24fec02-fc51-11e6-858c-892a8981b4d7.png">
