### PR TITLE
btn--pill-stroke proposal

### DIFF
--- a/site/catalog/pills.js
+++ b/site/catalog/pills.js
@@ -16,10 +16,10 @@ class Pills extends React.Component {
         </div>
 
         <div className='flex-parent mb18'>
-          <button className='btn btn--red btn--stroke btn--pill btn--pill-hl round'>Confirm</button>
-          <button className='btn btn--red btn--stroke btn--pill btn--pill-hc round'>Confirm</button>
-          <button className='btn btn--red btn--stroke btn--pill btn--pill-hc round'>Confirm</button>
-          <button className='btn btn--red btn--stroke btn--pill btn--pill-hr round'>Confirm</button>
+          <button className='btn btn--red btn--stroke btn--pill-stroke btn--pill-hl round btn--fill'>Confirm</button>
+          <button className='btn btn--red btn--stroke btn--pill-stroke btn--pill-hc round is-active'>Confirm</button>
+          <button className='btn btn--red btn--pill-stroke btn--pill-hc round is-active'>Confirm</button>
+          <button className='btn btn--red btn--stroke btn--pill-stroke btn--pill-hr round'>Confirm</button>
         </div>
 
         <div className='mb18 flex-parent-inline flex-parent--column'>
@@ -30,10 +30,10 @@ class Pills extends React.Component {
         </div>
 
         <div className='mb18 ml18 flex-parent-inline flex-parent--column'>
-          <button className='btn btn--stroke btn--s btn--pill btn--pill-vt round'>Confirm</button>
-          <button className='btn btn--stroke btn--s btn--pill btn--pill-vc round'>Confirm</button>
-          <button className='btn btn--stroke btn--s btn--pill btn--pill-vc round'>Confirm</button>
-          <button className='btn btn--stroke btn--s btn--pill btn--pill-vb round is-active'>Confirm</button>
+          <button className='btn btn--s btn--pill-stroke btn--pill-vt round'>Confirm</button>
+          <button className='btn btn--stroke btn--s btn--pill-stroke btn--pill-vc round'>Confirm</button>
+          <button className='btn btn--stroke btn--s btn--pill-stroke btn--pill-vc round'>Confirm</button>
+          <button className='btn btn--stroke btn--s btn--pill-stroke btn--pill-vb round is-active'>Confirm</button>
         </div>
       </div>
     );

--- a/src/buttons.css
+++ b/src/buttons.css
@@ -125,19 +125,23 @@
 /**
  * Create pill button groups.
  * Pill groups must be wrapped in a `flex-parent-inline` container.
- * Every button in a pill group must have the `btn` and `btn--pill` classes, along with a modifier specifying its position.
+ * Every button in a pill group must have
+ * - a `btn` class
+ * - any `btn--*` modifiers you want (e.g. `btn--stroke`)
+ * - a `btn--pill` *or* `btn--pill-stroke` modifier. Use the `btn--pill-stroke` modifier if the buttons in the pill group are mostly stroke buttons (though active buttons can be non-stroke, if you like that)
+ * - a `btn--pill-*` modifier specifying its position (e.g. `btn--pill-hc`)
  *
  * For *horizontal* pills, use
  * - `flex-parent-inline` on the container
- * - `btn btn--pill btn--pill-hc` (center)
- * - `btn btn--pill btn--pill-hl` (left)
- * - `btn btn--pill btn--pill-hr` (right)
+ * - `btn btn--pill(-stroke) btn--pill-hc` (center)
+ * - `btn btn--pill(-stroke) btn--pill-hl` (left)
+ * - `btn btn--pill(-stroke) btn--pill-hr` (right)
  *
  * For *vertical* pills, use
  * - `flex-parent-inline flex-parent--column` on the container
- * - `btn btn--pill btn--pill-vc` (center)
- * - `btn btn--pill btn--pill-vt` (top)
- * - `btn btn--pill btn--pill-vb` (bottom)
+ * - `btn btn--pill(-stroke) btn--pill-vc` (center)
+ * - `btn btn--pill(-stroke) btn--pill-vt` (top)
+ * - `btn btn--pill(-stroke) btn--pill-vb` (bottom)
  *
  * Pill buttons can be modified and themed in the same ways as regular buttons.
  *
@@ -149,19 +153,19 @@
  *   <button class="btn btn--pill btn--pill-hr">Right</button>
  * </div>
  * <div class="flex-parent-inline flex-parent--column">
- *   <button class="btn btn--pill btn--pill-vt">Top</button>
- *   <button class="btn btn--pill btn--pill-vc is-active">Center</button>
- *   <button class="btn btn--pill btn--pill-vb">Bottom</button>
+ *   <button class="btn btn--stroke btn--pill-stroke btn--pill-vt">Top</button>
+ *   <button class="btn btn--pill-stroke btn--pill-vc is-active">Center</button>
+ *   <button class="btn btn--stroke btn--pill-stroke btn--pill-vb">Bottom</button>
  * </div>
  */
-.btn--pill {
+.btn--pill-stroke {
   position: relative;
 }
 
 /* Put the active pill on top, so if they're stroke pills its
 active color is visible on all borders */
-.btn--pill:hover,
-.btn--pill.is-active {
+.btn--pill-stroke:hover,
+.btn--pill-stroke.is-active {
   z-index: 2;
 }
 
@@ -172,7 +176,6 @@ against .round class */
 
 .btn.btn--pill-hc {
   border-radius: 0 !important;
-  margin-left: 1px;
 }
 
 .btn.btn--pill-hl {
@@ -183,12 +186,15 @@ against .round class */
 .btn.btn--pill-hr {
   border-top-left-radius: 0 !important;
   border-bottom-left-radius: 0 !important;
+}
+
+.btn.btn--pill-hc:not(.btn--pill-stroke),
+.btn.btn--pill-hr:not(.btn--pill-stroke) {
   margin-left: 1px;
 }
 
 .btn.btn--pill-vc {
   border-radius: 0 !important;
-  margin-top: 1px;
   display: block;
   width: 100%;
 }
@@ -203,25 +209,29 @@ against .round class */
 .btn.btn--pill-vb {
   border-top-right-radius: 0 !important;
   border-top-left-radius: 0 !important;
-  margin-top: 1px;
   display: block;
   width: 100%;
 }
 
-.btn--stroke.btn--pill-hc {
+.btn.btn--pill-vc:not(.btn--pill-stroke),
+.btn.btn--pill-vb:not(.btn--pill-stroke) {
+  margin-top: 1px;
+}
+
+.btn--pill-stroke.btn--pill-hc {
   margin-left: -2px;
   margin-right: 0;
 }
 
-.btn--stroke.btn--pill-hr {
+.btn--pill-stroke.btn--pill-hr {
   margin-left: -2px;
 }
 
-.btn--stroke.btn--pill-vc {
+.btn--pill-stroke.btn--pill-vc {
   margin-top: -2px;
   margin-bottom: 0;
 }
 
-.btn--stroke.btn--pill-vb {
+.btn--pill-stroke.btn--pill-vb {
   margin-top: -2px;
 }

--- a/test/__snapshots__/build-user-assets.jest.js.snap
+++ b/test/__snapshots__/build-user-assets.jest.js.snap
@@ -632,17 +632,16 @@ textarea{
   background-color:rgba(127, 127, 127, 0.25) !important;
   border-color:transparent !important;
 }
-.btn--pill{
+.btn--pill-stroke{
   position:relative;
 }
-.btn--pill:hover,
-.btn--pill.is-active{
+.btn--pill-stroke:hover,
+.btn--pill-stroke.is-active{
   z-index:2;
 }
 
 .btn.btn--pill-hc{
   border-radius:0 !important;
-  margin-left:1px;
 }
 
 .btn.btn--pill-hl{
@@ -653,12 +652,15 @@ textarea{
 .btn.btn--pill-hr{
   border-top-left-radius:0 !important;
   border-bottom-left-radius:0 !important;
+}
+
+.btn.btn--pill-hc:not(.btn--pill-stroke),
+.btn.btn--pill-hr:not(.btn--pill-stroke){
   margin-left:1px;
 }
 
 .btn.btn--pill-vc{
   border-radius:0 !important;
-  margin-top:1px;
   display:block;
   width:100%;
 }
@@ -673,26 +675,30 @@ textarea{
 .btn.btn--pill-vb{
   border-top-right-radius:0 !important;
   border-top-left-radius:0 !important;
-  margin-top:1px;
   display:block;
   width:100%;
 }
 
-.btn--stroke.btn--pill-hc{
+.btn.btn--pill-vc:not(.btn--pill-stroke),
+.btn.btn--pill-vb:not(.btn--pill-stroke){
+  margin-top:1px;
+}
+
+.btn--pill-stroke.btn--pill-hc{
   margin-left:-2px;
   margin-right:0;
 }
 
-.btn--stroke.btn--pill-hr{
+.btn--pill-stroke.btn--pill-hr{
   margin-left:-2px;
 }
 
-.btn--stroke.btn--pill-vc{
+.btn--pill-stroke.btn--pill-vc{
   margin-top:-2px;
   margin-bottom:0;
 }
 
-.btn--stroke.btn--pill-vb{
+.btn--pill-stroke.btn--pill-vb{
   margin-top:-2px;
 }
 .link{
@@ -16447,17 +16453,16 @@ textarea{
   background-color:rgba(127, 127, 127, 0.25) !important;
   border-color:transparent !important;
 }
-.btn--pill{
+.btn--pill-stroke{
   position:relative;
 }
-.btn--pill:hover,
-.btn--pill.is-active{
+.btn--pill-stroke:hover,
+.btn--pill-stroke.is-active{
   z-index:2;
 }
 
 .btn.btn--pill-hc{
   border-radius:0 !important;
-  margin-left:1px;
 }
 
 .btn.btn--pill-hl{
@@ -16468,12 +16473,15 @@ textarea{
 .btn.btn--pill-hr{
   border-top-left-radius:0 !important;
   border-bottom-left-radius:0 !important;
+}
+
+.btn.btn--pill-hc:not(.btn--pill-stroke),
+.btn.btn--pill-hr:not(.btn--pill-stroke){
   margin-left:1px;
 }
 
 .btn.btn--pill-vc{
   border-radius:0 !important;
-  margin-top:1px;
   display:block;
   width:100%;
 }
@@ -16488,26 +16496,30 @@ textarea{
 .btn.btn--pill-vb{
   border-top-right-radius:0 !important;
   border-top-left-radius:0 !important;
-  margin-top:1px;
   display:block;
   width:100%;
 }
 
-.btn--stroke.btn--pill-hc{
+.btn.btn--pill-vc:not(.btn--pill-stroke),
+.btn.btn--pill-vb:not(.btn--pill-stroke){
+  margin-top:1px;
+}
+
+.btn--pill-stroke.btn--pill-hc{
   margin-left:-2px;
   margin-right:0;
 }
 
-.btn--stroke.btn--pill-hr{
+.btn--pill-stroke.btn--pill-hr{
   margin-left:-2px;
 }
 
-.btn--stroke.btn--pill-vc{
+.btn--pill-stroke.btn--pill-vc{
   margin-top:-2px;
   margin-bottom:0;
 }
 
-.btn--stroke.btn--pill-vb{
+.btn--pill-stroke.btn--pill-vb{
   margin-top:-2px;
 }
 .link{


### PR DESCRIPTION
Closes #722, if we like it.

Introduces a `btn--pill-stroke` modifier that should be used *instead of* `btn--pill` when the pill group is primarily stroke buttons. Solves #722. Adds a minuscule amount of complexity to the pill group, but not much and you already have to read the instructions.

<img width="484" alt="screen shot 2017-02-27 at 10 23 52 am" src="https://cloud.githubusercontent.com/assets/628431/23367072/fc4c0fe6-fcd6-11e6-8b90-6e6980127877.png">
<img width="432" alt="screen shot 2017-02-27 at 10 24 01 am" src="https://cloud.githubusercontent.com/assets/628431/23367073/fc7292a6-fcd6-11e6-8a38-785960f627ba.png">

@samanpwbb for review.