### PR TITLE
make table padding match the scale

### DIFF
--- a/src/tables.css
+++ b/src/tables.css
@@ -54,7 +54,7 @@ be adjusted based on their position. */
 .prose table td {
   text-align: left;
   vertical-align: top;
-  padding: 10px;
+  padding: 12px;
   border-style: solid;
   border-color: var(--gray-light);
   border-left-width: 1px;

--- a/test/__snapshots__/build-user-assets.jest.js.snap
+++ b/test/__snapshots__/build-user-assets.jest.js.snap
@@ -547,7 +547,7 @@ textarea{
 .prose table td{
   text-align:left;
   vertical-align:top;
-  padding:10px;
+  padding:12px;
   border-style:solid;
   border-color:#ccc;
   border-left-width:1px;
@@ -16368,7 +16368,7 @@ textarea{
 .prose table td{
   text-align:left;
   vertical-align:top;
-  padding:10px;
+  padding:12px;
   border-style:solid;
   border-color:#ccc;
   border-left-width:1px;


### PR DESCRIPTION
I just noticed that the padding on tr and td is 10px which no longer matches the scale. This PR updates the padding to 12px.

@samanpwbb for review