### PR TITLE
Normalize shadow-bold names and automate shadow classes

### DIFF
--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -452,6 +452,48 @@ function buildColorVariants(variables, config) {
     return css;
   };
 
+  variantGenerators.shadow = function (colors) {
+    let css = stripIndent(`
+      /**
+       * Apply a box shadow.
+       *
+       * @group
+       * @memberof Shadows
+       * @example
+       * <div class='shadow-darken25'>shadow-darken25</div>
+       */`);
+    css += colors.reduce((result, color) => {
+      if (!isSemitransparent(color)) return result;
+      return result += stripIndent(`
+        .shadow-${color} {
+          box-shadow: 0 0 10px 2px var(--${color}) !important;
+        }
+      `);
+    }, '');
+    css += '\n/** @endgroup */\n';
+
+    css += stripIndent(`
+      /**
+       * Apply a larger box shadow.
+       *
+       * @group
+       * @memberof Shadows
+       * @example
+       * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+       */`);
+    css += colors.reduce((result, color) => {
+      if (!isSemitransparent(color)) return result;
+      return result += stripIndent(`
+        .shadow-${color}-bold {
+          box-shadow: 0 0 30px 6px var(--${color}) !important;
+        }
+      `);
+    }, '');
+    css += '\n/** @endgroup */\n';
+
+    return css;
+  };
+
   variantGenerators.hoverShadow = function (colors) {
     let css = stripIndent(`
       /**
@@ -472,9 +514,9 @@ function buildColorVariants(variables, config) {
         .shadow-${color}-on-active.is-active:hover {
           box-shadow: 0 0 10px 2px var(--${color}) !important;
         }
-        .shadow-bold-${color}-on-hover:hover,
-        .shadow-bold-${color}-on-active.is-active,
-        .shadow-bold-${color}-on-active.is-active:hover {
+        .shadow-${color}-bold-on-hover:hover,
+        .shadow-${color}-bold-on-active.is-active,
+        .shadow-${color}-bold-on-active.is-active:hover {
           box-shadow: 0 0 30px 6px var(--${color}) !important;
         }
       `);

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -6044,6 +6044,106 @@ input:checked + .toggle--active-transparent {
 /** @endgroup */
 
 /**
+ * Apply a box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='shadow-darken25'>shadow-darken25</div>
+ */
+.shadow-darken5 {
+  box-shadow: 0 0 10px 2px var(--darken5) !important;
+}
+
+.shadow-darken10 {
+  box-shadow: 0 0 10px 2px var(--darken10) !important;
+}
+
+.shadow-darken25 {
+  box-shadow: 0 0 10px 2px var(--darken25) !important;
+}
+
+.shadow-darken50 {
+  box-shadow: 0 0 10px 2px var(--darken50) !important;
+}
+
+.shadow-darken75 {
+  box-shadow: 0 0 10px 2px var(--darken75) !important;
+}
+
+.shadow-lighten5 {
+  box-shadow: 0 0 10px 2px var(--lighten5) !important;
+}
+
+.shadow-lighten10 {
+  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+}
+
+.shadow-lighten25 {
+  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+}
+
+.shadow-lighten50 {
+  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+}
+
+.shadow-lighten75 {
+  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+}
+
+/** @endgroup */
+
+/**
+ * Apply a larger box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ */
+.shadow-darken5-bold {
+  box-shadow: 0 0 30px 6px var(--darken5) !important;
+}
+
+.shadow-darken10-bold {
+  box-shadow: 0 0 30px 6px var(--darken10) !important;
+}
+
+.shadow-darken25-bold {
+  box-shadow: 0 0 30px 6px var(--darken25) !important;
+}
+
+.shadow-darken50-bold {
+  box-shadow: 0 0 30px 6px var(--darken50) !important;
+}
+
+.shadow-darken75-bold {
+  box-shadow: 0 0 30px 6px var(--darken75) !important;
+}
+
+.shadow-lighten5-bold {
+  box-shadow: 0 0 30px 6px var(--lighten5) !important;
+}
+
+.shadow-lighten10-bold {
+  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+}
+
+.shadow-lighten25-bold {
+  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+}
+
+.shadow-lighten50-bold {
+  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+}
+
+.shadow-lighten75-bold {
+  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+}
+
+/** @endgroup */
+
+/**
  * Apply a box shadow on hover and active states.
  *
  * @group
@@ -6058,9 +6158,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken5-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken5) !important;
 }
-.shadow-bold-darken5-on-hover:hover,
-.shadow-bold-darken5-on-active.is-active,
-.shadow-bold-darken5-on-active.is-active:hover {
+.shadow-darken5-bold-on-hover:hover,
+.shadow-darken5-bold-on-active.is-active,
+.shadow-darken5-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken5) !important;
 }
 
@@ -6069,9 +6169,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken10-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken10) !important;
 }
-.shadow-bold-darken10-on-hover:hover,
-.shadow-bold-darken10-on-active.is-active,
-.shadow-bold-darken10-on-active.is-active:hover {
+.shadow-darken10-bold-on-hover:hover,
+.shadow-darken10-bold-on-active.is-active,
+.shadow-darken10-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken10) !important;
 }
 
@@ -6080,9 +6180,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken25-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken25) !important;
 }
-.shadow-bold-darken25-on-hover:hover,
-.shadow-bold-darken25-on-active.is-active,
-.shadow-bold-darken25-on-active.is-active:hover {
+.shadow-darken25-bold-on-hover:hover,
+.shadow-darken25-bold-on-active.is-active,
+.shadow-darken25-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken25) !important;
 }
 
@@ -6091,9 +6191,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken50-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken50) !important;
 }
-.shadow-bold-darken50-on-hover:hover,
-.shadow-bold-darken50-on-active.is-active,
-.shadow-bold-darken50-on-active.is-active:hover {
+.shadow-darken50-bold-on-hover:hover,
+.shadow-darken50-bold-on-active.is-active,
+.shadow-darken50-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken50) !important;
 }
 
@@ -6102,9 +6202,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken75-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken75) !important;
 }
-.shadow-bold-darken75-on-hover:hover,
-.shadow-bold-darken75-on-active.is-active,
-.shadow-bold-darken75-on-active.is-active:hover {
+.shadow-darken75-bold-on-hover:hover,
+.shadow-darken75-bold-on-active.is-active,
+.shadow-darken75-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken75) !important;
 }
 
@@ -6113,9 +6213,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten5-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten5) !important;
 }
-.shadow-bold-lighten5-on-hover:hover,
-.shadow-bold-lighten5-on-active.is-active,
-.shadow-bold-lighten5-on-active.is-active:hover {
+.shadow-lighten5-bold-on-hover:hover,
+.shadow-lighten5-bold-on-active.is-active,
+.shadow-lighten5-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten5) !important;
 }
 
@@ -6124,9 +6224,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten10-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten10) !important;
 }
-.shadow-bold-lighten10-on-hover:hover,
-.shadow-bold-lighten10-on-active.is-active,
-.shadow-bold-lighten10-on-active.is-active:hover {
+.shadow-lighten10-bold-on-hover:hover,
+.shadow-lighten10-bold-on-active.is-active,
+.shadow-lighten10-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten10) !important;
 }
 
@@ -6135,9 +6235,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten25-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten25) !important;
 }
-.shadow-bold-lighten25-on-hover:hover,
-.shadow-bold-lighten25-on-active.is-active,
-.shadow-bold-lighten25-on-active.is-active:hover {
+.shadow-lighten25-bold-on-hover:hover,
+.shadow-lighten25-bold-on-active.is-active,
+.shadow-lighten25-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten25) !important;
 }
 
@@ -6146,9 +6246,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten50-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten50) !important;
 }
-.shadow-bold-lighten50-on-hover:hover,
-.shadow-bold-lighten50-on-active.is-active,
-.shadow-bold-lighten50-on-active.is-active:hover {
+.shadow-lighten50-bold-on-hover:hover,
+.shadow-lighten50-bold-on-active.is-active,
+.shadow-lighten50-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten50) !important;
 }
 
@@ -6157,9 +6257,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten75-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten75) !important;
 }
-.shadow-bold-lighten75-on-hover:hover,
-.shadow-bold-lighten75-on-active.is-active,
-.shadow-bold-lighten75-on-active.is-active:hover {
+.shadow-lighten75-bold-on-hover:hover,
+.shadow-lighten75-bold-on-active.is-active,
+.shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten75) !important;
 }
 

--- a/src/theming.css
+++ b/src/theming.css
@@ -155,43 +155,6 @@
  */
 
 /**
- * Apply a box shadow.
- *
- * @group
- * @memberof Shadows
- * @example
- * <div class='shadow-darken25'>shadow-darken25</div>
- */
-.shadow-darken5 { box-shadow: 0 0 10px 2px var(--darken5) !important; }
-.shadow-darken10 { box-shadow: 0 0 10px 2px var(--darken10) !important; }
-.shadow-darken25 { box-shadow: 0 0 10px 2px var(--darken25) !important; }
-.shadow-darken50 { box-shadow: 0 0 10px 2px var(--darken50) !important; }
-
-.shadow-lighten5 { box-shadow: 0 0 10px 2px var(--lighten5) !important; }
-.shadow-lighten10 { box-shadow: 0 0 10px 2px var(--lighten10) !important; }
-.shadow-lighten25 { box-shadow: 0 0 10px 2px var(--lighten25) !important; }
-.shadow-lighten50 { box-shadow: 0 0 10px 2px var(--lighten50) !important; }
-/** @endgroup */
-
-/**
- * Apply a larger box shadow.
- *
- * @group
- * @memberof Shadows
- * @example
- * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div> */
-.shadow-darken5-bold { box-shadow: 0 0 30px 6px var(--darken5) !important; }
-.shadow-darken10-bold { box-shadow: 0 0 30px 6px var(--darken10) !important; }
-.shadow-darken25-bold { box-shadow: 0 0 30px 6px var(--darken25) !important; }
-.shadow-darken50-bold { box-shadow: 0 0 30px 6px var(--darken50) !important; }
-
-.shadow-lighten5-bold { box-shadow: 0 0 30px 6px var(--lighten5) !important; }
-.shadow-lighten10-bold { box-shadow: 0 0 30px 6px var(--lighten10) !important; }
-.shadow-lighten25-bold { box-shadow: 0 0 30px 6px var(--lighten25) !important; }
-.shadow-lighten50-bold { box-shadow: 0 0 30px 6px var(--lighten50) !important; }
-/** @endgroup */
-
-/**
  * Set the style of the cursor when hovering over an element.
  *
  * @section Cursors

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -6047,6 +6047,106 @@ input:checked + .toggle--active-transparent {
 /** @endgroup */
 
 /**
+ * Apply a box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='shadow-darken25'>shadow-darken25</div>
+ */
+.shadow-darken5 {
+  box-shadow: 0 0 10px 2px var(--darken5) !important;
+}
+
+.shadow-darken10 {
+  box-shadow: 0 0 10px 2px var(--darken10) !important;
+}
+
+.shadow-darken25 {
+  box-shadow: 0 0 10px 2px var(--darken25) !important;
+}
+
+.shadow-darken50 {
+  box-shadow: 0 0 10px 2px var(--darken50) !important;
+}
+
+.shadow-darken75 {
+  box-shadow: 0 0 10px 2px var(--darken75) !important;
+}
+
+.shadow-lighten5 {
+  box-shadow: 0 0 10px 2px var(--lighten5) !important;
+}
+
+.shadow-lighten10 {
+  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+}
+
+.shadow-lighten25 {
+  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+}
+
+.shadow-lighten50 {
+  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+}
+
+.shadow-lighten75 {
+  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+}
+
+/** @endgroup */
+
+/**
+ * Apply a larger box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ */
+.shadow-darken5-bold {
+  box-shadow: 0 0 30px 6px var(--darken5) !important;
+}
+
+.shadow-darken10-bold {
+  box-shadow: 0 0 30px 6px var(--darken10) !important;
+}
+
+.shadow-darken25-bold {
+  box-shadow: 0 0 30px 6px var(--darken25) !important;
+}
+
+.shadow-darken50-bold {
+  box-shadow: 0 0 30px 6px var(--darken50) !important;
+}
+
+.shadow-darken75-bold {
+  box-shadow: 0 0 30px 6px var(--darken75) !important;
+}
+
+.shadow-lighten5-bold {
+  box-shadow: 0 0 30px 6px var(--lighten5) !important;
+}
+
+.shadow-lighten10-bold {
+  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+}
+
+.shadow-lighten25-bold {
+  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+}
+
+.shadow-lighten50-bold {
+  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+}
+
+.shadow-lighten75-bold {
+  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+}
+
+/** @endgroup */
+
+/**
  * Apply a box shadow on hover and active states.
  *
  * @group
@@ -6061,9 +6161,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken5-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken5) !important;
 }
-.shadow-bold-darken5-on-hover:hover,
-.shadow-bold-darken5-on-active.is-active,
-.shadow-bold-darken5-on-active.is-active:hover {
+.shadow-darken5-bold-on-hover:hover,
+.shadow-darken5-bold-on-active.is-active,
+.shadow-darken5-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken5) !important;
 }
 
@@ -6072,9 +6172,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken10-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken10) !important;
 }
-.shadow-bold-darken10-on-hover:hover,
-.shadow-bold-darken10-on-active.is-active,
-.shadow-bold-darken10-on-active.is-active:hover {
+.shadow-darken10-bold-on-hover:hover,
+.shadow-darken10-bold-on-active.is-active,
+.shadow-darken10-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken10) !important;
 }
 
@@ -6083,9 +6183,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken25-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken25) !important;
 }
-.shadow-bold-darken25-on-hover:hover,
-.shadow-bold-darken25-on-active.is-active,
-.shadow-bold-darken25-on-active.is-active:hover {
+.shadow-darken25-bold-on-hover:hover,
+.shadow-darken25-bold-on-active.is-active,
+.shadow-darken25-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken25) !important;
 }
 
@@ -6094,9 +6194,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken50-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken50) !important;
 }
-.shadow-bold-darken50-on-hover:hover,
-.shadow-bold-darken50-on-active.is-active,
-.shadow-bold-darken50-on-active.is-active:hover {
+.shadow-darken50-bold-on-hover:hover,
+.shadow-darken50-bold-on-active.is-active,
+.shadow-darken50-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken50) !important;
 }
 
@@ -6105,9 +6205,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken75-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken75) !important;
 }
-.shadow-bold-darken75-on-hover:hover,
-.shadow-bold-darken75-on-active.is-active,
-.shadow-bold-darken75-on-active.is-active:hover {
+.shadow-darken75-bold-on-hover:hover,
+.shadow-darken75-bold-on-active.is-active,
+.shadow-darken75-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken75) !important;
 }
 
@@ -6116,9 +6216,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten5-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten5) !important;
 }
-.shadow-bold-lighten5-on-hover:hover,
-.shadow-bold-lighten5-on-active.is-active,
-.shadow-bold-lighten5-on-active.is-active:hover {
+.shadow-lighten5-bold-on-hover:hover,
+.shadow-lighten5-bold-on-active.is-active,
+.shadow-lighten5-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten5) !important;
 }
 
@@ -6127,9 +6227,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten10-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten10) !important;
 }
-.shadow-bold-lighten10-on-hover:hover,
-.shadow-bold-lighten10-on-active.is-active,
-.shadow-bold-lighten10-on-active.is-active:hover {
+.shadow-lighten10-bold-on-hover:hover,
+.shadow-lighten10-bold-on-active.is-active,
+.shadow-lighten10-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten10) !important;
 }
 
@@ -6138,9 +6238,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten25-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten25) !important;
 }
-.shadow-bold-lighten25-on-hover:hover,
-.shadow-bold-lighten25-on-active.is-active,
-.shadow-bold-lighten25-on-active.is-active:hover {
+.shadow-lighten25-bold-on-hover:hover,
+.shadow-lighten25-bold-on-active.is-active,
+.shadow-lighten25-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten25) !important;
 }
 
@@ -6149,9 +6249,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten50-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten50) !important;
 }
-.shadow-bold-lighten50-on-hover:hover,
-.shadow-bold-lighten50-on-active.is-active,
-.shadow-bold-lighten50-on-active.is-active:hover {
+.shadow-lighten50-bold-on-hover:hover,
+.shadow-lighten50-bold-on-active.is-active,
+.shadow-lighten50-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten50) !important;
 }
 
@@ -6160,9 +6260,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten75-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten75) !important;
 }
-.shadow-bold-lighten75-on-hover:hover,
-.shadow-bold-lighten75-on-active.is-active,
-.shadow-bold-lighten75-on-active.is-active:hover {
+.shadow-lighten75-bold-on-hover:hover,
+.shadow-lighten75-bold-on-active.is-active,
+.shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten75) !important;
 }
 
@@ -13135,6 +13235,106 @@ input:checked + .toggle--active-transparent {
 /** @endgroup */
 
 /**
+ * Apply a box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='shadow-darken25'>shadow-darken25</div>
+ */
+.shadow-darken5 {
+  box-shadow: 0 0 10px 2px var(--darken5) !important;
+}
+
+.shadow-darken10 {
+  box-shadow: 0 0 10px 2px var(--darken10) !important;
+}
+
+.shadow-darken25 {
+  box-shadow: 0 0 10px 2px var(--darken25) !important;
+}
+
+.shadow-darken50 {
+  box-shadow: 0 0 10px 2px var(--darken50) !important;
+}
+
+.shadow-darken75 {
+  box-shadow: 0 0 10px 2px var(--darken75) !important;
+}
+
+.shadow-lighten5 {
+  box-shadow: 0 0 10px 2px var(--lighten5) !important;
+}
+
+.shadow-lighten10 {
+  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+}
+
+.shadow-lighten25 {
+  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+}
+
+.shadow-lighten50 {
+  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+}
+
+.shadow-lighten75 {
+  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+}
+
+/** @endgroup */
+
+/**
+ * Apply a larger box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ */
+.shadow-darken5-bold {
+  box-shadow: 0 0 30px 6px var(--darken5) !important;
+}
+
+.shadow-darken10-bold {
+  box-shadow: 0 0 30px 6px var(--darken10) !important;
+}
+
+.shadow-darken25-bold {
+  box-shadow: 0 0 30px 6px var(--darken25) !important;
+}
+
+.shadow-darken50-bold {
+  box-shadow: 0 0 30px 6px var(--darken50) !important;
+}
+
+.shadow-darken75-bold {
+  box-shadow: 0 0 30px 6px var(--darken75) !important;
+}
+
+.shadow-lighten5-bold {
+  box-shadow: 0 0 30px 6px var(--lighten5) !important;
+}
+
+.shadow-lighten10-bold {
+  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+}
+
+.shadow-lighten25-bold {
+  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+}
+
+.shadow-lighten50-bold {
+  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+}
+
+.shadow-lighten75-bold {
+  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+}
+
+/** @endgroup */
+
+/**
  * Apply a box shadow on hover and active states.
  *
  * @group
@@ -13149,9 +13349,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken5-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken5) !important;
 }
-.shadow-bold-darken5-on-hover:hover,
-.shadow-bold-darken5-on-active.is-active,
-.shadow-bold-darken5-on-active.is-active:hover {
+.shadow-darken5-bold-on-hover:hover,
+.shadow-darken5-bold-on-active.is-active,
+.shadow-darken5-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken5) !important;
 }
 
@@ -13160,9 +13360,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken10-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken10) !important;
 }
-.shadow-bold-darken10-on-hover:hover,
-.shadow-bold-darken10-on-active.is-active,
-.shadow-bold-darken10-on-active.is-active:hover {
+.shadow-darken10-bold-on-hover:hover,
+.shadow-darken10-bold-on-active.is-active,
+.shadow-darken10-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken10) !important;
 }
 
@@ -13171,9 +13371,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken25-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken25) !important;
 }
-.shadow-bold-darken25-on-hover:hover,
-.shadow-bold-darken25-on-active.is-active,
-.shadow-bold-darken25-on-active.is-active:hover {
+.shadow-darken25-bold-on-hover:hover,
+.shadow-darken25-bold-on-active.is-active,
+.shadow-darken25-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken25) !important;
 }
 
@@ -13182,9 +13382,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken50-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken50) !important;
 }
-.shadow-bold-darken50-on-hover:hover,
-.shadow-bold-darken50-on-active.is-active,
-.shadow-bold-darken50-on-active.is-active:hover {
+.shadow-darken50-bold-on-hover:hover,
+.shadow-darken50-bold-on-active.is-active,
+.shadow-darken50-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken50) !important;
 }
 
@@ -13193,9 +13393,9 @@ input:checked + .toggle--active-transparent {
 .shadow-darken75-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--darken75) !important;
 }
-.shadow-bold-darken75-on-hover:hover,
-.shadow-bold-darken75-on-active.is-active,
-.shadow-bold-darken75-on-active.is-active:hover {
+.shadow-darken75-bold-on-hover:hover,
+.shadow-darken75-bold-on-active.is-active,
+.shadow-darken75-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--darken75) !important;
 }
 
@@ -13204,9 +13404,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten5-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten5) !important;
 }
-.shadow-bold-lighten5-on-hover:hover,
-.shadow-bold-lighten5-on-active.is-active,
-.shadow-bold-lighten5-on-active.is-active:hover {
+.shadow-lighten5-bold-on-hover:hover,
+.shadow-lighten5-bold-on-active.is-active,
+.shadow-lighten5-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten5) !important;
 }
 
@@ -13215,9 +13415,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten10-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten10) !important;
 }
-.shadow-bold-lighten10-on-hover:hover,
-.shadow-bold-lighten10-on-active.is-active,
-.shadow-bold-lighten10-on-active.is-active:hover {
+.shadow-lighten10-bold-on-hover:hover,
+.shadow-lighten10-bold-on-active.is-active,
+.shadow-lighten10-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten10) !important;
 }
 
@@ -13226,9 +13426,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten25-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten25) !important;
 }
-.shadow-bold-lighten25-on-hover:hover,
-.shadow-bold-lighten25-on-active.is-active,
-.shadow-bold-lighten25-on-active.is-active:hover {
+.shadow-lighten25-bold-on-hover:hover,
+.shadow-lighten25-bold-on-active.is-active,
+.shadow-lighten25-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten25) !important;
 }
 
@@ -13237,9 +13437,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten50-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten50) !important;
 }
-.shadow-bold-lighten50-on-hover:hover,
-.shadow-bold-lighten50-on-active.is-active,
-.shadow-bold-lighten50-on-active.is-active:hover {
+.shadow-lighten50-bold-on-hover:hover,
+.shadow-lighten50-bold-on-active.is-active,
+.shadow-lighten50-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten50) !important;
 }
 
@@ -13248,9 +13448,9 @@ input:checked + .toggle--active-transparent {
 .shadow-lighten75-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten75) !important;
 }
-.shadow-bold-lighten75-on-hover:hover,
-.shadow-bold-lighten75-on-active.is-active,
-.shadow-bold-lighten75-on-active.is-active:hover {
+.shadow-lighten75-bold-on-hover:hover,
+.shadow-lighten75-bold-on-active.is-active,
+.shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten75) !important;
 }
 
@@ -14697,6 +14897,26 @@ input:checked + .toggle--active-green-light {
 /** @endgroup */
 
 /**
+ * Apply a box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='shadow-darken25'>shadow-darken25</div>
+ */
+/** @endgroup */
+
+/**
+ * Apply a larger box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ */
+/** @endgroup */
+
+/**
  * Apply a box shadow on hover and active states.
  *
  * @group
@@ -15173,6 +15393,42 @@ input:checked + .toggle--active-gray {
 /** @endgroup */
 
 /**
+ * Apply a box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='shadow-darken25'>shadow-darken25</div>
+ */
+.shadow-lighten50 {
+  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+}
+
+.shadow-lighten25 {
+  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+}
+
+/** @endgroup */
+
+/**
+ * Apply a larger box shadow.
+ *
+ * @group
+ * @memberof Shadows
+ * @example
+ * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ */
+.shadow-lighten50-bold {
+  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+}
+
+.shadow-lighten25-bold {
+  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+}
+
+/** @endgroup */
+
+/**
  * Apply a box shadow on hover and active states.
  *
  * @group
@@ -15187,9 +15443,9 @@ input:checked + .toggle--active-gray {
 .shadow-lighten50-on-active.is-active:hover {
   box-shadow: 0 0 10px 2px var(--lighten50) !important;
 }
-.shadow-bold-lighten50-on-hover:hover,
-.shadow-bold-lighten50-on-active.is-active,
-.shadow-bold-lighten50-on-active.is-active:hover {
+.shadow-lighten50-bold-on-hover:hover,
+.shadow-lighten50-bold-on-active.is-active,
+.shadow-lighten50-bold-on-active.is-active:hover {
   box-shadow: 0 0 30px 6px var(--lighten50) !important;
 }
 

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -1286,24 +1286,6 @@ input:checked:disabled + .toggle{
 .unround-tr{ border-top-right-radius:0 !important; }
 .unround-br{ border-bottom-right-radius:0 !important; }
 .unround-bl{ border-bottom-left-radius:0 !important; }
-.shadow-darken5{ box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.05) !important; }
-.shadow-darken10{ box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important; }
-.shadow-darken25{ box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important; }
-.shadow-darken50{ box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important; }
-
-.shadow-lighten5{ box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.05) !important; }
-.shadow-lighten10{ box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important; }
-.shadow-lighten25{ box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important; }
-.shadow-lighten50{ box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important; }
-.shadow-darken5-bold{ box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.05) !important; }
-.shadow-darken10-bold{ box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important; }
-.shadow-darken25-bold{ box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important; }
-.shadow-darken50-bold{ box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important; }
-
-.shadow-lighten5-bold{ box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.05) !important; }
-.shadow-lighten10-bold{ box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important; }
-.shadow-lighten25-bold{ box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important; }
-.shadow-lighten50-bold{ box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important; }
 .cursor-default{ cursor:default !important; }
 .cursor-pointer{ cursor:pointer !important; }
 .cursor-crosshair{ cursor:crosshair !important; }
@@ -13536,14 +13518,92 @@ input:checked + .toggle--active-transparent{
 .border--transparent{
   border-color:transparent !important;
 }
+.shadow-darken5{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.05) !important;
+}
+
+.shadow-darken10{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important;
+}
+
+.shadow-darken25{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important;
+}
+
+.shadow-darken50{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important;
+}
+
+.shadow-darken75{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.75) !important;
+}
+
+.shadow-lighten5{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.05) !important;
+}
+
+.shadow-lighten10{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important;
+}
+
+.shadow-lighten25{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important;
+}
+
+.shadow-lighten50{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important;
+}
+
+.shadow-lighten75{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.75) !important;
+}
+.shadow-darken5-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.05) !important;
+}
+
+.shadow-darken10-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important;
+}
+
+.shadow-darken25-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important;
+}
+
+.shadow-darken50-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important;
+}
+
+.shadow-darken75-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.75) !important;
+}
+
+.shadow-lighten5-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.05) !important;
+}
+
+.shadow-lighten10-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important;
+}
+
+.shadow-lighten25-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important;
+}
+
+.shadow-lighten50-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important;
+}
+
+.shadow-lighten75-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.75) !important;
+}
 .shadow-darken5-on-hover:hover,
 .shadow-darken5-on-active.is-active,
 .shadow-darken5-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.05) !important;
 }
-.shadow-bold-darken5-on-hover:hover,
-.shadow-bold-darken5-on-active.is-active,
-.shadow-bold-darken5-on-active.is-active:hover{
+.shadow-darken5-bold-on-hover:hover,
+.shadow-darken5-bold-on-active.is-active,
+.shadow-darken5-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.05) !important;
 }
 
@@ -13552,9 +13612,9 @@ input:checked + .toggle--active-transparent{
 .shadow-darken10-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important;
 }
-.shadow-bold-darken10-on-hover:hover,
-.shadow-bold-darken10-on-active.is-active,
-.shadow-bold-darken10-on-active.is-active:hover{
+.shadow-darken10-bold-on-hover:hover,
+.shadow-darken10-bold-on-active.is-active,
+.shadow-darken10-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important;
 }
 
@@ -13563,9 +13623,9 @@ input:checked + .toggle--active-transparent{
 .shadow-darken25-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important;
 }
-.shadow-bold-darken25-on-hover:hover,
-.shadow-bold-darken25-on-active.is-active,
-.shadow-bold-darken25-on-active.is-active:hover{
+.shadow-darken25-bold-on-hover:hover,
+.shadow-darken25-bold-on-active.is-active,
+.shadow-darken25-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important;
 }
 
@@ -13574,9 +13634,9 @@ input:checked + .toggle--active-transparent{
 .shadow-darken50-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important;
 }
-.shadow-bold-darken50-on-hover:hover,
-.shadow-bold-darken50-on-active.is-active,
-.shadow-bold-darken50-on-active.is-active:hover{
+.shadow-darken50-bold-on-hover:hover,
+.shadow-darken50-bold-on-active.is-active,
+.shadow-darken50-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important;
 }
 
@@ -13585,9 +13645,9 @@ input:checked + .toggle--active-transparent{
 .shadow-darken75-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.75) !important;
 }
-.shadow-bold-darken75-on-hover:hover,
-.shadow-bold-darken75-on-active.is-active,
-.shadow-bold-darken75-on-active.is-active:hover{
+.shadow-darken75-bold-on-hover:hover,
+.shadow-darken75-bold-on-active.is-active,
+.shadow-darken75-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.75) !important;
 }
 
@@ -13596,9 +13656,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten5-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.05) !important;
 }
-.shadow-bold-lighten5-on-hover:hover,
-.shadow-bold-lighten5-on-active.is-active,
-.shadow-bold-lighten5-on-active.is-active:hover{
+.shadow-lighten5-bold-on-hover:hover,
+.shadow-lighten5-bold-on-active.is-active,
+.shadow-lighten5-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.05) !important;
 }
 
@@ -13607,9 +13667,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten10-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important;
 }
-.shadow-bold-lighten10-on-hover:hover,
-.shadow-bold-lighten10-on-active.is-active,
-.shadow-bold-lighten10-on-active.is-active:hover{
+.shadow-lighten10-bold-on-hover:hover,
+.shadow-lighten10-bold-on-active.is-active,
+.shadow-lighten10-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important;
 }
 
@@ -13618,9 +13678,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten25-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important;
 }
-.shadow-bold-lighten25-on-hover:hover,
-.shadow-bold-lighten25-on-active.is-active,
-.shadow-bold-lighten25-on-active.is-active:hover{
+.shadow-lighten25-bold-on-hover:hover,
+.shadow-lighten25-bold-on-active.is-active,
+.shadow-lighten25-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important;
 }
 
@@ -13629,9 +13689,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten50-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important;
 }
-.shadow-bold-lighten50-on-hover:hover,
-.shadow-bold-lighten50-on-active.is-active,
-.shadow-bold-lighten50-on-active.is-active:hover{
+.shadow-lighten50-bold-on-hover:hover,
+.shadow-lighten50-bold-on-active.is-active,
+.shadow-lighten50-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important;
 }
 
@@ -13640,9 +13700,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten75-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.75) !important;
 }
-.shadow-bold-lighten75-on-hover:hover,
-.shadow-bold-lighten75-on-active.is-active,
-.shadow-bold-lighten75-on-active.is-active:hover{
+.shadow-lighten75-bold-on-hover:hover,
+.shadow-lighten75-bold-on-active.is-active,
+.shadow-lighten75-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.75) !important;
 }
 .bg-gray-dark-on-hover:hover,
@@ -17279,24 +17339,6 @@ input:checked:disabled + .toggle{
 .unround-tr{ border-top-right-radius:0 !important; }
 .unround-br{ border-bottom-right-radius:0 !important; }
 .unround-bl{ border-bottom-left-radius:0 !important; }
-.shadow-darken5{ box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.05) !important; }
-.shadow-darken10{ box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important; }
-.shadow-darken25{ box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important; }
-.shadow-darken50{ box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important; }
-
-.shadow-lighten5{ box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.05) !important; }
-.shadow-lighten10{ box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important; }
-.shadow-lighten25{ box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important; }
-.shadow-lighten50{ box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important; }
-.shadow-darken5-bold{ box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.05) !important; }
-.shadow-darken10-bold{ box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important; }
-.shadow-darken25-bold{ box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important; }
-.shadow-darken50-bold{ box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important; }
-
-.shadow-lighten5-bold{ box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.05) !important; }
-.shadow-lighten10-bold{ box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important; }
-.shadow-lighten25-bold{ box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important; }
-.shadow-lighten50-bold{ box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important; }
 .cursor-default{ cursor:default !important; }
 .cursor-pointer{ cursor:pointer !important; }
 .cursor-crosshair{ cursor:crosshair !important; }
@@ -30199,14 +30241,92 @@ input:checked + .toggle--active-transparent{
 .border--transparent{
   border-color:transparent !important;
 }
+.shadow-darken5{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.05) !important;
+}
+
+.shadow-darken10{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important;
+}
+
+.shadow-darken25{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important;
+}
+
+.shadow-darken50{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important;
+}
+
+.shadow-darken75{
+  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.75) !important;
+}
+
+.shadow-lighten5{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.05) !important;
+}
+
+.shadow-lighten10{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important;
+}
+
+.shadow-lighten25{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important;
+}
+
+.shadow-lighten50{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important;
+}
+
+.shadow-lighten75{
+  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.75) !important;
+}
+.shadow-darken5-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.05) !important;
+}
+
+.shadow-darken10-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important;
+}
+
+.shadow-darken25-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important;
+}
+
+.shadow-darken50-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important;
+}
+
+.shadow-darken75-bold{
+  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.75) !important;
+}
+
+.shadow-lighten5-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.05) !important;
+}
+
+.shadow-lighten10-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important;
+}
+
+.shadow-lighten25-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important;
+}
+
+.shadow-lighten50-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important;
+}
+
+.shadow-lighten75-bold{
+  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.75) !important;
+}
 .shadow-darken5-on-hover:hover,
 .shadow-darken5-on-active.is-active,
 .shadow-darken5-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.05) !important;
 }
-.shadow-bold-darken5-on-hover:hover,
-.shadow-bold-darken5-on-active.is-active,
-.shadow-bold-darken5-on-active.is-active:hover{
+.shadow-darken5-bold-on-hover:hover,
+.shadow-darken5-bold-on-active.is-active,
+.shadow-darken5-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.05) !important;
 }
 
@@ -30215,9 +30335,9 @@ input:checked + .toggle--active-transparent{
 .shadow-darken10-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important;
 }
-.shadow-bold-darken10-on-hover:hover,
-.shadow-bold-darken10-on-active.is-active,
-.shadow-bold-darken10-on-active.is-active:hover{
+.shadow-darken10-bold-on-hover:hover,
+.shadow-darken10-bold-on-active.is-active,
+.shadow-darken10-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important;
 }
 
@@ -30226,9 +30346,9 @@ input:checked + .toggle--active-transparent{
 .shadow-darken25-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important;
 }
-.shadow-bold-darken25-on-hover:hover,
-.shadow-bold-darken25-on-active.is-active,
-.shadow-bold-darken25-on-active.is-active:hover{
+.shadow-darken25-bold-on-hover:hover,
+.shadow-darken25-bold-on-active.is-active,
+.shadow-darken25-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important;
 }
 
@@ -30237,9 +30357,9 @@ input:checked + .toggle--active-transparent{
 .shadow-darken50-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important;
 }
-.shadow-bold-darken50-on-hover:hover,
-.shadow-bold-darken50-on-active.is-active,
-.shadow-bold-darken50-on-active.is-active:hover{
+.shadow-darken50-bold-on-hover:hover,
+.shadow-darken50-bold-on-active.is-active,
+.shadow-darken50-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important;
 }
 
@@ -30248,9 +30368,9 @@ input:checked + .toggle--active-transparent{
 .shadow-darken75-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.75) !important;
 }
-.shadow-bold-darken75-on-hover:hover,
-.shadow-bold-darken75-on-active.is-active,
-.shadow-bold-darken75-on-active.is-active:hover{
+.shadow-darken75-bold-on-hover:hover,
+.shadow-darken75-bold-on-active.is-active,
+.shadow-darken75-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.75) !important;
 }
 
@@ -30259,9 +30379,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten5-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.05) !important;
 }
-.shadow-bold-lighten5-on-hover:hover,
-.shadow-bold-lighten5-on-active.is-active,
-.shadow-bold-lighten5-on-active.is-active:hover{
+.shadow-lighten5-bold-on-hover:hover,
+.shadow-lighten5-bold-on-active.is-active,
+.shadow-lighten5-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.05) !important;
 }
 
@@ -30270,9 +30390,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten10-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important;
 }
-.shadow-bold-lighten10-on-hover:hover,
-.shadow-bold-lighten10-on-active.is-active,
-.shadow-bold-lighten10-on-active.is-active:hover{
+.shadow-lighten10-bold-on-hover:hover,
+.shadow-lighten10-bold-on-active.is-active,
+.shadow-lighten10-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important;
 }
 
@@ -30281,9 +30401,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten25-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important;
 }
-.shadow-bold-lighten25-on-hover:hover,
-.shadow-bold-lighten25-on-active.is-active,
-.shadow-bold-lighten25-on-active.is-active:hover{
+.shadow-lighten25-bold-on-hover:hover,
+.shadow-lighten25-bold-on-active.is-active,
+.shadow-lighten25-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important;
 }
 
@@ -30292,9 +30412,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten50-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important;
 }
-.shadow-bold-lighten50-on-hover:hover,
-.shadow-bold-lighten50-on-active.is-active,
-.shadow-bold-lighten50-on-active.is-active:hover{
+.shadow-lighten50-bold-on-hover:hover,
+.shadow-lighten50-bold-on-active.is-active,
+.shadow-lighten50-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important;
 }
 
@@ -30303,9 +30423,9 @@ input:checked + .toggle--active-transparent{
 .shadow-lighten75-on-active.is-active:hover{
   box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.75) !important;
 }
-.shadow-bold-lighten75-on-hover:hover,
-.shadow-bold-lighten75-on-active.is-active,
-.shadow-bold-lighten75-on-active.is-active:hover{
+.shadow-lighten75-bold-on-hover:hover,
+.shadow-lighten75-bold-on-active.is-active,
+.shadow-lighten75-bold-on-active.is-active:hover{
   box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.75) !important;
 }
 .bg-gray-dark-on-hover:hover,

--- a/test/build-css.jest.js
+++ b/test/build-css.jest.js
@@ -10,6 +10,8 @@ const os = require('os');
 const crypto = require('crypto');
 const buildCss = require('../scripts/build-css');
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+
 function getTmp() {
   return path.join(os.tmpdir(), crypto.randomBytes(16).toString('hex'));
 }


### PR DESCRIPTION
Closes #741.

Also moved all shadow class generation into `build-color-variants`. I think that's where they *should* have been and we just made an oversight?

Should wait until #766 merges to update tests.

@tristen for review.