### PR TITLE
force txt-bold to be 1em line height, fixes line height offsets, clos…

### DIFF
--- a/src/typography.css
+++ b/src/typography.css
@@ -128,6 +128,19 @@ textarea {
 }
 
 /**
+ * Apply a bold font weight.
+ *
+ * @memberof Type utils
+ * @example
+ * <div class='txt-bold'>txt-bold</div>
+ */
+.txt-bold {
+  font-weight: bold !important;
+  /* prevent bold text inside inline text from offsetting line height */
+  line-height: 1em;
+}
+
+/**
  * Classes for font size and line height, lists, block quotes, code blocks, and more.
  *
  * @section Type basics
@@ -375,15 +388,6 @@ textarea {
 .txt-normal {
   font-weight: normal !important;
 }
-
-/**
- * Apply a bold font weight.
- *
- * @memberof Type utils
- * @example
- * <div class='txt-bold'>txt-bold</div>
- */
-.txt-bold { font-weight: bold !important; }
 
 /**
  * Italicize text.

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -264,6 +264,10 @@ textarea{
   font-family:'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace;
   font-size:90%;
 }
+.txt-bold{
+  font-weight:bold !important;
+  line-height:1em;
+}
 .txt-h1{
   font-size:45px;
   line-height:54px;
@@ -393,7 +397,6 @@ textarea{
 .txt-normal{
   font-weight:normal !important;
 }
-.txt-bold{ font-weight:bold !important; }
 .txt-em{ font-style:italic !important; }
 .txt-uppercase{ text-transform:uppercase !important; }
 .txt-lowercase{ text-transform:lowercase !important; }
@@ -16732,6 +16735,10 @@ textarea{
   font-family:'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace;
   font-size:90%;
 }
+.txt-bold{
+  font-weight:bold !important;
+  line-height:1em;
+}
 .txt-h1{
   font-size:45px;
   line-height:54px;
@@ -16861,7 +16868,6 @@ textarea{
 .txt-normal{
   font-weight:normal !important;
 }
-.txt-bold{ font-weight:bold !important; }
 .txt-em{ font-style:italic !important; }
 .txt-uppercase{ text-transform:uppercase !important; }
 .txt-lowercase{ text-transform:lowercase !important; }


### PR DESCRIPTION
…es #775 

@tristen for review. I also moved `txt-bold` _above_ font declarations so something with `txt-bold txt-h2` will get the correct line height.