### PR TITLE
reset abbr text-decoration, fixes txt-abbr rule

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -79,6 +79,10 @@ button::-moz-focus-inner {
   border: 0;
 }
 
+abbr {
+  text-decoration: none;
+}
+
 svg {
   display: inline-block;
 }

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -83,6 +83,10 @@ button::-moz-focus-inner{
   border:0;
 }
 
+abbr{
+  text-decoration:none;
+}
+
 svg{
   display:inline-block;
 }
@@ -17141,6 +17145,10 @@ button{
 button::-moz-focus-inner{
   padding:0;
   border:0;
+}
+
+abbr{
+  text-decoration:none;
 }
 
 svg{


### PR DESCRIPTION
Minor fix.

Before:
<img width="276" alt="screen shot 2017-06-03 at 11 48 23 pm" src="https://cloud.githubusercontent.com/assets/108094/26758813/184b3a6e-48b8-11e7-9a3a-cfd93bfa8399.png">

After:
<img width="296" alt="screen shot 2017-06-03 at 11 48 15 pm" src="https://cloud.githubusercontent.com/assets/108094/26758815/1ba86d08-48b8-11e7-895b-485ee9161bfd.png">

Question:

Should we even have a `txt-abbr` rule? I don't predict this getting much use, and it's annoying to have to maintain.