### PR TITLE
Lighten gray-faint

### DIFF
--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -47,11 +47,13 @@ const allColors = [
   'purple-light',
   'purple-faint',
 
+  'darken5',
   'darken10',
   'darken25',
   'darken50',
   'darken75',
 
+  'lighten5',
   'lighten10',
   'lighten25',
   'lighten50',
@@ -66,15 +68,20 @@ function isSemitransparent(color) {
   return /^(lighten|darken)/.test(color);
 }
 
-function isNotAccessible(color) {
+function isNotAccessibleForForms(color) {
   // Do not create form elements from values that are too light or too dark,
   // for accessibility and to save space.
-  return color === 'black' || /^(darken10|lighten10)$/.test(color) || /(-dark|-light|-faint)$/.test(color);
+  return color === 'black' || /^(darken5|darken10|lighten5|lighten10)$/.test(color) || /(-dark|-light|-faint)$/.test(color);
 }
 
-function isNotAccessibleForBg(color) {
+function isNotAccessibleExceptButtons(color) {
   // Elements that are primarily defined by their background can have looser requirements.
-  return color === 'black' || /(-faint|-dark)$/.test(color);
+  return color === 'black' || /^(darken5|lighten5)$/.test(color) || /(-faint|-dark)$/.test(color);
+}
+
+function isNotAccessibleExceptBg(color) {
+  // Five percent opacity classes should only be used for backgrounds.
+  return null || /^(darken5|lighten5)$/.test(color);
 }
 
 function buildColorVariants(variables, config) {
@@ -93,6 +100,8 @@ function buildColorVariants(variables, config) {
       const action = semitransparentMatch[1];
       const magnitude = semitransparentMatch[2];
       switch (magnitude) {
+        case '5':
+          return `${action}10`;
         case '10':
           return `${action}25`;
         case '25':
@@ -128,7 +137,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.buttonFill = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessibleForBg(color)) return result;
+      if (isNotAccessibleExceptButtons(color)) return result;
       const darkerShade = getDarkerShade(color);
       return result += stripIndent(`
         .btn--${color} {
@@ -145,7 +154,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.buttonStroke = function (colors) {
     let css = colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return result += stripIndent(`
         .btn--stroke.btn--${color} {
@@ -168,7 +177,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.selectFill = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessibleForBg(color)) return result;
+      if (isNotAccessibleExceptButtons(color)) return result;
       const darkerShade = getDarkerShade(color);
       return result += stripIndent(`
         .select--${color} {
@@ -184,7 +193,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.selectStroke = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return result += stripIndent(`
         .select--stroke-${color} {
@@ -205,7 +214,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.inputTextarea = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return result += stripIndent(`
         .textarea--border-${color},
@@ -223,7 +232,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.checkbox = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return result += stripIndent(`
         .checkbox--${color} {
@@ -247,7 +256,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.radio = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return result += stripIndent(`
         .radio--${color},
@@ -264,7 +273,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.toggle = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       // Set the text color to regular when inactive.
       // Set the text color to dark when inactive on hover.
@@ -288,7 +297,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.toggleActive = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       // Must be below .toggle group in stylesheet
       return result += stripIndent(`
         input:checked + .toggle--active-${color} {
@@ -300,7 +309,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.switch = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       // Darken background when hovered and when active
       // Darken dot on hover when inactive only
@@ -327,7 +336,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.range = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
 
       // Set the thumb color.
@@ -355,11 +364,13 @@ function buildColorVariants(variables, config) {
        * <div class='grid'>`
     );
     colors.forEach((color) => {
+      if (isNotAccessibleExceptBg(color)) return;
       css += `\n *   <div class='col col--3 color-${color}'>color-${color}</div>`;
     });
     css += `\n *   <div class='col col--3 color-text'>.color-text</div>`; // eslint-disable-line quotes
     css += '\n * </div>\n */';
     css += colors.reduce((result, color) => {
+      if (isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .color-${color} {
           color: var(--${color}) !important;
@@ -405,7 +416,7 @@ function buildColorVariants(variables, config) {
 
   variantGenerators.link = function (colors) {
     return colors.reduce((result, color) => {
-      if (isNotAccessible(color)) return result;
+      if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return result += stripIndent(`
         .link--${color} {
@@ -431,6 +442,7 @@ function buildColorVariants(variables, config) {
        * <div class='border border--red'>border--red</div>
        */`);
     css += colors.reduce((result, color) => {
+      if (isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .border--${color} {
           border-color: var(--${color}) !important;
@@ -452,7 +464,7 @@ function buildColorVariants(variables, config) {
        * <div class='shadow-darken25'>shadow-darken25</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isSemitransparent(color)) return result;
+      if (!isSemitransparent(color) || isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .shadow-${color} {
           box-shadow: 0 0 10px 2px var(--${color}) !important;
@@ -471,7 +483,7 @@ function buildColorVariants(variables, config) {
        * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isSemitransparent(color)) return result;
+      if (!isSemitransparent(color) || isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .shadow-${color}-bold {
           box-shadow: 0 0 30px 6px var(--${color}) !important;
@@ -496,7 +508,7 @@ function buildColorVariants(variables, config) {
        * <div class='shadow-darken25-on-active is-active'>shadow-darken25-on-active (active)</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isSemitransparent(color)) return result;
+      if (!isSemitransparent(color) || isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .shadow-${color}-on-hover:hover,
         .shadow-${color}-on-active.is-active,
@@ -527,7 +539,7 @@ function buildColorVariants(variables, config) {
        * <div class='bg-darken25-on-active is-active'>bg-darken25-on-active (active)</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isNotAccessibleForBg(color)) return result;
+      if (!isNotAccessibleExceptButtons(color)) return result;
       return result += stripIndent(`
         .bg-${color}-on-hover:hover,
         .bg-${color}-on-active.is-active,
@@ -553,7 +565,7 @@ function buildColorVariants(variables, config) {
        * <div class='color-red-on-active is-active'>color-red-on-active (active)</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isNotAccessible(color)) return result;
+      if (!isNotAccessibleForForms(color) || isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .color-${color}-on-hover:hover,
         .color-${color}-on-active.is-active,
@@ -579,7 +591,7 @@ function buildColorVariants(variables, config) {
        * <div class='border border--red-on-active is-active'>border--red-on-active (active)</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isNotAccessibleForBg(color)) return result;
+      if (!isNotAccessibleExceptButtons(color) || isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .border--${color}-on-hover:hover,
         .border--${color}-on-active.is-active,

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -2219,10 +2219,12 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col col--3 bg-purple py6 px6'>bg-purple</div>
  *   <div class='col col--3 bg-purple-light py6 px6'>bg-purple-light</div>
  *   <div class='col col--3 bg-purple-faint py6 px6'>bg-purple-faint</div>
+ *   <div class='col col--3 bg-darken5 py6 px6'>bg-darken5</div>
  *   <div class='col col--3 bg-darken10 py6 px6'>bg-darken10</div>
  *   <div class='col col--3 bg-darken25 py6 px6'>bg-darken25</div>
  *   <div class='col col--3 bg-darken50 py6 px6'>bg-darken50</div>
  *   <div class='col col--3 bg-darken75 py6 px6'>bg-darken75</div>
+ *   <div class='col col--3 bg-lighten5 py6 px6'>bg-lighten5</div>
  *   <div class='col col--3 bg-lighten10 py6 px6'>bg-lighten10</div>
  *   <div class='col col--3 bg-lighten25 py6 px6'>bg-lighten25</div>
  *   <div class='col col--3 bg-lighten50 py6 px6'>bg-lighten50</div>
@@ -2360,6 +2362,10 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--purple-faint) !important;
 }
 
+.bg-darken5 {
+  background-color: var(--darken5) !important;
+}
+
 .bg-darken10 {
   background-color: var(--darken10) !important;
 }
@@ -2374,6 +2380,10 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-darken75 {
   background-color: var(--darken75) !important;
+}
+
+.bg-lighten5 {
+  background-color: var(--lighten5) !important;
 }
 
 .bg-lighten10 {
@@ -3020,6 +3030,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-purple-faint-on-active.is-active,
 .bg-purple-faint-on-active.is-active:hover {
   background-color: var(--purple-faint) !important;
+}
+
+.bg-darken5-on-hover:hover,
+.bg-darken5-on-active.is-active,
+.bg-darken5-on-active.is-active:hover {
+  background-color: var(--darken5) !important;
+}
+
+.bg-lighten5-on-hover:hover,
+.bg-lighten5-on-active.is-active,
+.bg-lighten5-on-active.is-active:hover {
+  background-color: var(--lighten5) !important;
 }
 
 .bg-black-on-hover:hover,

--- a/src/colors.css
+++ b/src/colors.css
@@ -1,5 +1,7 @@
 /**
  * Background and text colors. Colors include dark, light, and faint variations.
+ * Be sure to maintain a readable color contrast between background and text.
+ * Only use `-faint` text colors on dark backgrounds.
  *
  * @section Colors
  */

--- a/src/typography.css
+++ b/src/typography.css
@@ -64,7 +64,7 @@ textarea {
   white-space: pre-wrap;
   font-size: 90%; /* mono fonts have naturally large proportions, scale them down to match open sans. */
   line-height: 1.5em; /* code blocks look better with smaller line height */
-  background: var(--darken10);
+  background: var(--darken5);
   border-radius: 3px;
 }
 
@@ -72,7 +72,7 @@ textarea {
 .pre--dark,
 .prose--dark code,
 .prose--dark pre {
-  background: var(--lighten10);
+  background: var(--lighten5);
 }
 
 /**

--- a/src/variables.json
+++ b/src/variables.json
@@ -39,11 +39,13 @@
   "purple-light": "#c299e3",
   "purple-faint": "#ede1f6",
 
+  "darken5": "rgba(0, 0, 0, 0.05)",
   "darken10": "rgba(0, 0, 0, 0.1)",
   "darken25": "rgba(0, 0, 0, 0.25)",
   "darken50": "rgba(0, 0, 0, 0.5)",
   "darken75": "rgba(0, 0, 0, 0.75)",
 
+  "lighten5": "rgba(255, 255, 255, 0.05)",
   "lighten10": "rgba(255, 255, 255, 0.1)",
   "lighten25": "rgba(255, 255, 255, 0.25)",
   "lighten50": "rgba(255, 255, 255, 0.5)",

--- a/src/variables.json
+++ b/src/variables.json
@@ -2,7 +2,7 @@
   "gray-dark": "#2d2d2d",
   "gray": "#666",
   "gray-light": "#ccc",
-  "gray-faint": "#e5e5e5",
+  "gray-faint": "#f2f2f2",
 
   "pink-dark": "#ab084b",
   "pink": "#ff3c96",

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -2222,10 +2222,12 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col col--3 bg-purple py6 px6'>bg-purple</div>
  *   <div class='col col--3 bg-purple-light py6 px6'>bg-purple-light</div>
  *   <div class='col col--3 bg-purple-faint py6 px6'>bg-purple-faint</div>
+ *   <div class='col col--3 bg-darken5 py6 px6'>bg-darken5</div>
  *   <div class='col col--3 bg-darken10 py6 px6'>bg-darken10</div>
  *   <div class='col col--3 bg-darken25 py6 px6'>bg-darken25</div>
  *   <div class='col col--3 bg-darken50 py6 px6'>bg-darken50</div>
  *   <div class='col col--3 bg-darken75 py6 px6'>bg-darken75</div>
+ *   <div class='col col--3 bg-lighten5 py6 px6'>bg-lighten5</div>
  *   <div class='col col--3 bg-lighten10 py6 px6'>bg-lighten10</div>
  *   <div class='col col--3 bg-lighten25 py6 px6'>bg-lighten25</div>
  *   <div class='col col--3 bg-lighten50 py6 px6'>bg-lighten50</div>
@@ -2363,6 +2365,10 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--purple-faint) !important;
 }
 
+.bg-darken5 {
+  background-color: var(--darken5) !important;
+}
+
 .bg-darken10 {
   background-color: var(--darken10) !important;
 }
@@ -2377,6 +2383,10 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-darken75 {
   background-color: var(--darken75) !important;
+}
+
+.bg-lighten5 {
+  background-color: var(--lighten5) !important;
 }
 
 .bg-lighten10 {
@@ -3023,6 +3033,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-purple-faint-on-active.is-active,
 .bg-purple-faint-on-active.is-active:hover {
   background-color: var(--purple-faint) !important;
+}
+
+.bg-darken5-on-hover:hover,
+.bg-darken5-on-active.is-active,
+.bg-darken5-on-active.is-active:hover {
+  background-color: var(--darken5) !important;
+}
+
+.bg-lighten5-on-hover:hover,
+.bg-lighten5-on-active.is-active,
+.bg-lighten5-on-active.is-active:hover {
+  background-color: var(--lighten5) !important;
 }
 
 .bg-black-on-hover:hover,
@@ -5545,10 +5567,12 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col col--3 bg-purple py6 px6'>bg-purple</div>
  *   <div class='col col--3 bg-purple-light py6 px6'>bg-purple-light</div>
  *   <div class='col col--3 bg-purple-faint py6 px6'>bg-purple-faint</div>
+ *   <div class='col col--3 bg-darken5 py6 px6'>bg-darken5</div>
  *   <div class='col col--3 bg-darken10 py6 px6'>bg-darken10</div>
  *   <div class='col col--3 bg-darken25 py6 px6'>bg-darken25</div>
  *   <div class='col col--3 bg-darken50 py6 px6'>bg-darken50</div>
  *   <div class='col col--3 bg-darken75 py6 px6'>bg-darken75</div>
+ *   <div class='col col--3 bg-lighten5 py6 px6'>bg-lighten5</div>
  *   <div class='col col--3 bg-lighten10 py6 px6'>bg-lighten10</div>
  *   <div class='col col--3 bg-lighten25 py6 px6'>bg-lighten25</div>
  *   <div class='col col--3 bg-lighten50 py6 px6'>bg-lighten50</div>
@@ -5686,6 +5710,10 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--purple-faint) !important;
 }
 
+.bg-darken5 {
+  background-color: var(--darken5) !important;
+}
+
 .bg-darken10 {
   background-color: var(--darken10) !important;
 }
@@ -5700,6 +5728,10 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-darken75 {
   background-color: var(--darken75) !important;
+}
+
+.bg-lighten5 {
+  background-color: var(--lighten5) !important;
 }
 
 .bg-lighten10 {
@@ -6346,6 +6378,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-purple-faint-on-active.is-active,
 .bg-purple-faint-on-active.is-active:hover {
   background-color: var(--purple-faint) !important;
+}
+
+.bg-darken5-on-hover:hover,
+.bg-darken5-on-active.is-active,
+.bg-darken5-on-active.is-active:hover {
+  background-color: var(--darken5) !important;
+}
+
+.bg-lighten5-on-hover:hover,
+.bg-lighten5-on-active.is-active,
+.bg-lighten5-on-active.is-active:hover {
+  background-color: var(--lighten5) !important;
 }
 
 .bg-black-on-hover:hover,

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -1050,9 +1050,9 @@ textarea{
 .range > input:disabled::-ms-fill-upper{ background:rgba(127, 127, 127, 0.25); }
 .range > input:disabled::-ms-fill-lower{ background:rgba(127, 127, 127, 0.25); }
 
-.range > input:disabled::-webkit-slider-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#e5e5e5; }
-.range > input:disabled::-ms-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#e5e5e5; }
-.range > input:disabled::-moz-range-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#e5e5e5; }
+.range > input:disabled::-webkit-slider-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#f2f2f2; }
+.range > input:disabled::-ms-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#f2f2f2; }
+.range > input:disabled::-moz-range-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#f2f2f2; }
 .checkbox-container,
 .switch-container,
 .radio-container{
@@ -10192,7 +10192,7 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .color-gray-faint{
-  color:#e5e5e5 !important;
+  color:#f2f2f2 !important;
 }
 
 .color-pink-dark{
@@ -10367,7 +10367,7 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .bg-gray-faint{
-  background-color:#e5e5e5 !important;
+  background-color:#f2f2f2 !important;
 }
 
 .bg-pink-dark{
@@ -10682,7 +10682,7 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .border--gray-faint{
-  border-color:#e5e5e5 !important;
+  border-color:#f2f2f2 !important;
 }
 
 .border--pink-dark{
@@ -10998,7 +10998,7 @@ input:checked + .switch--dot-transparent::after{
 .bg-gray-faint-on-hover:hover,
 .bg-gray-faint-on-active.is-active,
 .bg-gray-faint-on-active.is-active:hover{
-  background-color:#e5e5e5 !important;
+  background-color:#f2f2f2 !important;
 }
 
 .bg-pink-dark-on-hover:hover,
@@ -11105,7 +11105,7 @@ input:checked + .switch--dot-transparent::after{
 .color-gray-faint-on-hover:hover,
 .color-gray-faint-on-active.is-active,
 .color-gray-faint-on-active.is-active:hover{
-  color:#e5e5e5 !important;
+  color:#f2f2f2 !important;
 }
 
 .color-pink-dark-on-hover:hover,
@@ -11260,7 +11260,7 @@ input:checked + .switch--dot-transparent::after{
 .border--gray-faint-on-hover:hover,
 .border--gray-faint-on-active.is-active,
 .border--gray-faint-on-active.is-active:hover{
-  border-color:#e5e5e5 !important;
+  border-color:#f2f2f2 !important;
 }
 
 .border--pink-dark-on-hover:hover,
@@ -13871,9 +13871,9 @@ textarea{
 .range > input:disabled::-ms-fill-upper{ background:rgba(127, 127, 127, 0.25); }
 .range > input:disabled::-ms-fill-lower{ background:rgba(127, 127, 127, 0.25); }
 
-.range > input:disabled::-webkit-slider-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#e5e5e5; }
-.range > input:disabled::-ms-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#e5e5e5; }
-.range > input:disabled::-moz-range-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#e5e5e5; }
+.range > input:disabled::-webkit-slider-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#f2f2f2; }
+.range > input:disabled::-ms-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#f2f2f2; }
+.range > input:disabled::-moz-range-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#f2f2f2; }
 .checkbox-container,
 .switch-container,
 .radio-container{
@@ -23047,7 +23047,7 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .color-gray-faint{
-  color:#e5e5e5 !important;
+  color:#f2f2f2 !important;
 }
 
 .color-pink-dark{
@@ -23222,7 +23222,7 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .bg-gray-faint{
-  background-color:#e5e5e5 !important;
+  background-color:#f2f2f2 !important;
 }
 
 .bg-pink-dark{
@@ -23537,7 +23537,7 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .border--gray-faint{
-  border-color:#e5e5e5 !important;
+  border-color:#f2f2f2 !important;
 }
 
 .border--pink-dark{
@@ -23853,7 +23853,7 @@ input:checked + .switch--dot-transparent::after{
 .bg-gray-faint-on-hover:hover,
 .bg-gray-faint-on-active.is-active,
 .bg-gray-faint-on-active.is-active:hover{
-  background-color:#e5e5e5 !important;
+  background-color:#f2f2f2 !important;
 }
 
 .bg-pink-dark-on-hover:hover,
@@ -23960,7 +23960,7 @@ input:checked + .switch--dot-transparent::after{
 .color-gray-faint-on-hover:hover,
 .color-gray-faint-on-active.is-active,
 .color-gray-faint-on-active.is-active:hover{
-  color:#e5e5e5 !important;
+  color:#f2f2f2 !important;
 }
 
 .color-pink-dark-on-hover:hover,
@@ -24115,7 +24115,7 @@ input:checked + .switch--dot-transparent::after{
 .border--gray-faint-on-hover:hover,
 .border--gray-faint-on-active.is-active,
 .border--gray-faint-on-active.is-active:hover{
-  border-color:#e5e5e5 !important;
+  border-color:#f2f2f2 !important;
 }
 
 .border--pink-dark-on-hover:hover,

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -234,7 +234,7 @@ textarea{
   white-space:pre-wrap;
   font-size:90%;
   line-height:1.5em;
-  background:rgba(0, 0, 0, 0.1);
+  background:rgba(0, 0, 0, 0.05);
   border-radius:3px;
 }
 
@@ -242,7 +242,7 @@ textarea{
 .pre--dark,
 .prose--dark code,
 .prose--dark pre{
-  background:rgba(255, 255, 255, 0.1);
+  background:rgba(255, 255, 255, 0.05);
 }
 .pre,
 .prose pre{
@@ -10482,6 +10482,10 @@ input:checked + .switch--dot-transparent::after{
   background-color:#ede1f6 !important;
 }
 
+.bg-darken5{
+  background-color:rgba(0, 0, 0, 0.05) !important;
+}
+
 .bg-darken10{
   background-color:rgba(0, 0, 0, 0.1) !important;
 }
@@ -10496,6 +10500,10 @@ input:checked + .switch--dot-transparent::after{
 
 .bg-darken75{
   background-color:rgba(0, 0, 0, 0.75) !important;
+}
+
+.bg-lighten5{
+  background-color:rgba(255, 255, 255, 0.05) !important;
 }
 
 .bg-lighten10{
@@ -11083,6 +11091,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-purple-faint-on-active.is-active,
 .bg-purple-faint-on-active.is-active:hover{
   background-color:#ede1f6 !important;
+}
+
+.bg-darken5-on-hover:hover,
+.bg-darken5-on-active.is-active,
+.bg-darken5-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.05) !important;
+}
+
+.bg-lighten5-on-hover:hover,
+.bg-lighten5-on-active.is-active,
+.bg-lighten5-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.05) !important;
 }
 
 .bg-black-on-hover:hover,
@@ -13055,7 +13075,7 @@ textarea{
   white-space:pre-wrap;
   font-size:90%;
   line-height:1.5em;
-  background:rgba(0, 0, 0, 0.1);
+  background:rgba(0, 0, 0, 0.05);
   border-radius:3px;
 }
 
@@ -13063,7 +13083,7 @@ textarea{
 .pre--dark,
 .prose--dark code,
 .prose--dark pre{
-  background:rgba(255, 255, 255, 0.1);
+  background:rgba(255, 255, 255, 0.05);
 }
 .pre,
 .prose pre{
@@ -23337,6 +23357,10 @@ input:checked + .switch--dot-transparent::after{
   background-color:#ede1f6 !important;
 }
 
+.bg-darken5{
+  background-color:rgba(0, 0, 0, 0.05) !important;
+}
+
 .bg-darken10{
   background-color:rgba(0, 0, 0, 0.1) !important;
 }
@@ -23351,6 +23375,10 @@ input:checked + .switch--dot-transparent::after{
 
 .bg-darken75{
   background-color:rgba(0, 0, 0, 0.75) !important;
+}
+
+.bg-lighten5{
+  background-color:rgba(255, 255, 255, 0.05) !important;
 }
 
 .bg-lighten10{
@@ -23938,6 +23966,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-purple-faint-on-active.is-active,
 .bg-purple-faint-on-active.is-active:hover{
   background-color:#ede1f6 !important;
+}
+
+.bg-darken5-on-hover:hover,
+.bg-darken5-on-active.is-active,
+.bg-darken5-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.05) !important;
+}
+
+.bg-lighten5-on-hover:hover,
+.bg-lighten5-on-active.is-active,
+.bg-lighten5-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.05) !important;
 }
 
 .bg-black-on-hover:hover,


### PR DESCRIPTION
Closes https://github.com/mapbox/assembly/issues/791.

I realize I was mistaken in that comment about using `gray-faint` for code backgrounds— those elements use `darken10`, so my concerns are not resolved by just lightening gray faint:

![screen shot 2017-06-07 at 12 10 30](https://user-images.githubusercontent.com/8495845/26889118-09a8abde-4b7b-11e7-8f8e-a1c325b8582f.png)

@samanpwbb is there a reason not to use `bg-gray-faint` (keeping `bg-lighten10` for the dark theme) for code elements?