### PR TITLE
match hover variant options to regular variant options

### DIFF
--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -81,7 +81,7 @@ function isNotAccessibleExceptButtons(color) {
 
 function isNotAccessibleExceptBg(color) {
   // Five percent opacity classes should only be used for backgrounds.
-  return null || /^(darken5|lighten5)$/.test(color);
+  return /^(darken5|lighten5)$/.test(color);
 }
 
 function buildColorVariants(variables, config) {
@@ -539,7 +539,6 @@ function buildColorVariants(variables, config) {
        * <div class='bg-darken25-on-active is-active'>bg-darken25-on-active (active)</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isNotAccessibleExceptButtons(color)) return result;
       return result += stripIndent(`
         .bg-${color}-on-hover:hover,
         .bg-${color}-on-active.is-active,
@@ -565,7 +564,7 @@ function buildColorVariants(variables, config) {
        * <div class='color-red-on-active is-active'>color-red-on-active (active)</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isNotAccessibleForForms(color) || isNotAccessibleExceptBg(color)) return result;
+      if (isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .color-${color}-on-hover:hover,
         .color-${color}-on-active.is-active,
@@ -591,7 +590,7 @@ function buildColorVariants(variables, config) {
        * <div class='border border--red-on-active is-active'>border--red-on-active (active)</div>
        */`);
     css += colors.reduce((result, color) => {
-      if (!isNotAccessibleExceptButtons(color) || isNotAccessibleExceptBg(color)) return result;
+      if (isNotAccessibleExceptBg(color)) return result;
       return result += stripIndent(`
         .border--${color}-on-hover:hover,
         .border--${color}-on-active.is-active,

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -2942,6 +2942,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--gray-dark) !important;
 }
 
+.bg-gray-on-hover:hover,
+.bg-gray-on-active.is-active,
+.bg-gray-on-active.is-active:hover {
+  background-color: var(--gray) !important;
+}
+
+.bg-gray-light-on-hover:hover,
+.bg-gray-light-on-active.is-active,
+.bg-gray-light-on-active.is-active:hover {
+  background-color: var(--gray-light) !important;
+}
+
 .bg-gray-faint-on-hover:hover,
 .bg-gray-faint-on-active.is-active,
 .bg-gray-faint-on-active.is-active:hover {
@@ -2952,6 +2964,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-pink-dark-on-active.is-active,
 .bg-pink-dark-on-active.is-active:hover {
   background-color: var(--pink-dark) !important;
+}
+
+.bg-pink-on-hover:hover,
+.bg-pink-on-active.is-active,
+.bg-pink-on-active.is-active:hover {
+  background-color: var(--pink) !important;
+}
+
+.bg-pink-light-on-hover:hover,
+.bg-pink-light-on-active.is-active,
+.bg-pink-light-on-active.is-active:hover {
+  background-color: var(--pink-light) !important;
 }
 
 .bg-pink-faint-on-hover:hover,
@@ -2966,6 +2990,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--red-dark) !important;
 }
 
+.bg-red-on-hover:hover,
+.bg-red-on-active.is-active,
+.bg-red-on-active.is-active:hover {
+  background-color: var(--red) !important;
+}
+
+.bg-red-light-on-hover:hover,
+.bg-red-light-on-active.is-active,
+.bg-red-light-on-active.is-active:hover {
+  background-color: var(--red-light) !important;
+}
+
 .bg-red-faint-on-hover:hover,
 .bg-red-faint-on-active.is-active,
 .bg-red-faint-on-active.is-active:hover {
@@ -2976,6 +3012,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-orange-dark-on-active.is-active,
 .bg-orange-dark-on-active.is-active:hover {
   background-color: var(--orange-dark) !important;
+}
+
+.bg-orange-on-hover:hover,
+.bg-orange-on-active.is-active,
+.bg-orange-on-active.is-active:hover {
+  background-color: var(--orange) !important;
+}
+
+.bg-orange-light-on-hover:hover,
+.bg-orange-light-on-active.is-active,
+.bg-orange-light-on-active.is-active:hover {
+  background-color: var(--orange-light) !important;
 }
 
 .bg-orange-faint-on-hover:hover,
@@ -2990,6 +3038,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--yellow-dark) !important;
 }
 
+.bg-yellow-on-hover:hover,
+.bg-yellow-on-active.is-active,
+.bg-yellow-on-active.is-active:hover {
+  background-color: var(--yellow) !important;
+}
+
+.bg-yellow-light-on-hover:hover,
+.bg-yellow-light-on-active.is-active,
+.bg-yellow-light-on-active.is-active:hover {
+  background-color: var(--yellow-light) !important;
+}
+
 .bg-yellow-faint-on-hover:hover,
 .bg-yellow-faint-on-active.is-active,
 .bg-yellow-faint-on-active.is-active:hover {
@@ -3000,6 +3060,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-green-dark-on-active.is-active,
 .bg-green-dark-on-active.is-active:hover {
   background-color: var(--green-dark) !important;
+}
+
+.bg-green-on-hover:hover,
+.bg-green-on-active.is-active,
+.bg-green-on-active.is-active:hover {
+  background-color: var(--green) !important;
+}
+
+.bg-green-light-on-hover:hover,
+.bg-green-light-on-active.is-active,
+.bg-green-light-on-active.is-active:hover {
+  background-color: var(--green-light) !important;
 }
 
 .bg-green-faint-on-hover:hover,
@@ -3014,6 +3086,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--blue-dark) !important;
 }
 
+.bg-blue-on-hover:hover,
+.bg-blue-on-active.is-active,
+.bg-blue-on-active.is-active:hover {
+  background-color: var(--blue) !important;
+}
+
+.bg-blue-light-on-hover:hover,
+.bg-blue-light-on-active.is-active,
+.bg-blue-light-on-active.is-active:hover {
+  background-color: var(--blue-light) !important;
+}
+
 .bg-blue-faint-on-hover:hover,
 .bg-blue-faint-on-active.is-active,
 .bg-blue-faint-on-active.is-active:hover {
@@ -3024,6 +3108,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-purple-dark-on-active.is-active,
 .bg-purple-dark-on-active.is-active:hover {
   background-color: var(--purple-dark) !important;
+}
+
+.bg-purple-on-hover:hover,
+.bg-purple-on-active.is-active,
+.bg-purple-on-active.is-active:hover {
+  background-color: var(--purple) !important;
+}
+
+.bg-purple-light-on-hover:hover,
+.bg-purple-light-on-active.is-active,
+.bg-purple-light-on-active.is-active:hover {
+  background-color: var(--purple-light) !important;
 }
 
 .bg-purple-faint-on-hover:hover,
@@ -3038,16 +3134,76 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--darken5) !important;
 }
 
+.bg-darken10-on-hover:hover,
+.bg-darken10-on-active.is-active,
+.bg-darken10-on-active.is-active:hover {
+  background-color: var(--darken10) !important;
+}
+
+.bg-darken25-on-hover:hover,
+.bg-darken25-on-active.is-active,
+.bg-darken25-on-active.is-active:hover {
+  background-color: var(--darken25) !important;
+}
+
+.bg-darken50-on-hover:hover,
+.bg-darken50-on-active.is-active,
+.bg-darken50-on-active.is-active:hover {
+  background-color: var(--darken50) !important;
+}
+
+.bg-darken75-on-hover:hover,
+.bg-darken75-on-active.is-active,
+.bg-darken75-on-active.is-active:hover {
+  background-color: var(--darken75) !important;
+}
+
 .bg-lighten5-on-hover:hover,
 .bg-lighten5-on-active.is-active,
 .bg-lighten5-on-active.is-active:hover {
   background-color: var(--lighten5) !important;
 }
 
+.bg-lighten10-on-hover:hover,
+.bg-lighten10-on-active.is-active,
+.bg-lighten10-on-active.is-active:hover {
+  background-color: var(--lighten10) !important;
+}
+
+.bg-lighten25-on-hover:hover,
+.bg-lighten25-on-active.is-active,
+.bg-lighten25-on-active.is-active:hover {
+  background-color: var(--lighten25) !important;
+}
+
+.bg-lighten50-on-hover:hover,
+.bg-lighten50-on-active.is-active,
+.bg-lighten50-on-active.is-active:hover {
+  background-color: var(--lighten50) !important;
+}
+
+.bg-lighten75-on-hover:hover,
+.bg-lighten75-on-active.is-active,
+.bg-lighten75-on-active.is-active:hover {
+  background-color: var(--lighten75) !important;
+}
+
+.bg-white-on-hover:hover,
+.bg-white-on-active.is-active,
+.bg-white-on-active.is-active:hover {
+  background-color: var(--white) !important;
+}
+
 .bg-black-on-hover:hover,
 .bg-black-on-active.is-active,
 .bg-black-on-active.is-active:hover {
   background-color: var(--black) !important;
+}
+
+.bg-transparent-on-hover:hover,
+.bg-transparent-on-active.is-active,
+.bg-transparent-on-active.is-active:hover {
+  background-color: var(--transparent) !important;
 }
 
 /** @endgroup */
@@ -3068,6 +3224,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--gray-dark) !important;
 }
 
+.color-gray-on-hover:hover,
+.color-gray-on-active.is-active,
+.color-gray-on-active.is-active:hover {
+  color: var(--gray) !important;
+}
+
 .color-gray-light-on-hover:hover,
 .color-gray-light-on-active.is-active,
 .color-gray-light-on-active.is-active:hover {
@@ -3084,6 +3246,12 @@ input:checked + .switch--dot-transparent::after {
 .color-pink-dark-on-active.is-active,
 .color-pink-dark-on-active.is-active:hover {
   color: var(--pink-dark) !important;
+}
+
+.color-pink-on-hover:hover,
+.color-pink-on-active.is-active,
+.color-pink-on-active.is-active:hover {
+  color: var(--pink) !important;
 }
 
 .color-pink-light-on-hover:hover,
@@ -3104,6 +3272,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--red-dark) !important;
 }
 
+.color-red-on-hover:hover,
+.color-red-on-active.is-active,
+.color-red-on-active.is-active:hover {
+  color: var(--red) !important;
+}
+
 .color-red-light-on-hover:hover,
 .color-red-light-on-active.is-active,
 .color-red-light-on-active.is-active:hover {
@@ -3120,6 +3294,12 @@ input:checked + .switch--dot-transparent::after {
 .color-orange-dark-on-active.is-active,
 .color-orange-dark-on-active.is-active:hover {
   color: var(--orange-dark) !important;
+}
+
+.color-orange-on-hover:hover,
+.color-orange-on-active.is-active,
+.color-orange-on-active.is-active:hover {
+  color: var(--orange) !important;
 }
 
 .color-orange-light-on-hover:hover,
@@ -3140,6 +3320,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--yellow-dark) !important;
 }
 
+.color-yellow-on-hover:hover,
+.color-yellow-on-active.is-active,
+.color-yellow-on-active.is-active:hover {
+  color: var(--yellow) !important;
+}
+
 .color-yellow-light-on-hover:hover,
 .color-yellow-light-on-active.is-active,
 .color-yellow-light-on-active.is-active:hover {
@@ -3156,6 +3342,12 @@ input:checked + .switch--dot-transparent::after {
 .color-green-dark-on-active.is-active,
 .color-green-dark-on-active.is-active:hover {
   color: var(--green-dark) !important;
+}
+
+.color-green-on-hover:hover,
+.color-green-on-active.is-active,
+.color-green-on-active.is-active:hover {
+  color: var(--green) !important;
 }
 
 .color-green-light-on-hover:hover,
@@ -3176,6 +3368,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--blue-dark) !important;
 }
 
+.color-blue-on-hover:hover,
+.color-blue-on-active.is-active,
+.color-blue-on-active.is-active:hover {
+  color: var(--blue) !important;
+}
+
 .color-blue-light-on-hover:hover,
 .color-blue-light-on-active.is-active,
 .color-blue-light-on-active.is-active:hover {
@@ -3192,6 +3390,12 @@ input:checked + .switch--dot-transparent::after {
 .color-purple-dark-on-active.is-active,
 .color-purple-dark-on-active.is-active:hover {
   color: var(--purple-dark) !important;
+}
+
+.color-purple-on-hover:hover,
+.color-purple-on-active.is-active,
+.color-purple-on-active.is-active:hover {
+  color: var(--purple) !important;
 }
 
 .color-purple-light-on-hover:hover,
@@ -3212,16 +3416,64 @@ input:checked + .switch--dot-transparent::after {
   color: var(--darken10) !important;
 }
 
+.color-darken25-on-hover:hover,
+.color-darken25-on-active.is-active,
+.color-darken25-on-active.is-active:hover {
+  color: var(--darken25) !important;
+}
+
+.color-darken50-on-hover:hover,
+.color-darken50-on-active.is-active,
+.color-darken50-on-active.is-active:hover {
+  color: var(--darken50) !important;
+}
+
+.color-darken75-on-hover:hover,
+.color-darken75-on-active.is-active,
+.color-darken75-on-active.is-active:hover {
+  color: var(--darken75) !important;
+}
+
 .color-lighten10-on-hover:hover,
 .color-lighten10-on-active.is-active,
 .color-lighten10-on-active.is-active:hover {
   color: var(--lighten10) !important;
 }
 
+.color-lighten25-on-hover:hover,
+.color-lighten25-on-active.is-active,
+.color-lighten25-on-active.is-active:hover {
+  color: var(--lighten25) !important;
+}
+
+.color-lighten50-on-hover:hover,
+.color-lighten50-on-active.is-active,
+.color-lighten50-on-active.is-active:hover {
+  color: var(--lighten50) !important;
+}
+
+.color-lighten75-on-hover:hover,
+.color-lighten75-on-active.is-active,
+.color-lighten75-on-active.is-active:hover {
+  color: var(--lighten75) !important;
+}
+
+.color-white-on-hover:hover,
+.color-white-on-active.is-active,
+.color-white-on-active.is-active:hover {
+  color: var(--white) !important;
+}
+
 .color-black-on-hover:hover,
 .color-black-on-active.is-active,
 .color-black-on-active.is-active:hover {
   color: var(--black) !important;
+}
+
+.color-transparent-on-hover:hover,
+.color-transparent-on-active.is-active,
+.color-transparent-on-active.is-active:hover {
+  color: var(--transparent) !important;
 }
 
 /** @endgroup */
@@ -3242,6 +3494,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--gray-dark) !important;
 }
 
+.border--gray-on-hover:hover,
+.border--gray-on-active.is-active,
+.border--gray-on-active.is-active:hover {
+  border-color: var(--gray) !important;
+}
+
+.border--gray-light-on-hover:hover,
+.border--gray-light-on-active.is-active,
+.border--gray-light-on-active.is-active:hover {
+  border-color: var(--gray-light) !important;
+}
+
 .border--gray-faint-on-hover:hover,
 .border--gray-faint-on-active.is-active,
 .border--gray-faint-on-active.is-active:hover {
@@ -3252,6 +3516,18 @@ input:checked + .switch--dot-transparent::after {
 .border--pink-dark-on-active.is-active,
 .border--pink-dark-on-active.is-active:hover {
   border-color: var(--pink-dark) !important;
+}
+
+.border--pink-on-hover:hover,
+.border--pink-on-active.is-active,
+.border--pink-on-active.is-active:hover {
+  border-color: var(--pink) !important;
+}
+
+.border--pink-light-on-hover:hover,
+.border--pink-light-on-active.is-active,
+.border--pink-light-on-active.is-active:hover {
+  border-color: var(--pink-light) !important;
 }
 
 .border--pink-faint-on-hover:hover,
@@ -3266,6 +3542,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--red-dark) !important;
 }
 
+.border--red-on-hover:hover,
+.border--red-on-active.is-active,
+.border--red-on-active.is-active:hover {
+  border-color: var(--red) !important;
+}
+
+.border--red-light-on-hover:hover,
+.border--red-light-on-active.is-active,
+.border--red-light-on-active.is-active:hover {
+  border-color: var(--red-light) !important;
+}
+
 .border--red-faint-on-hover:hover,
 .border--red-faint-on-active.is-active,
 .border--red-faint-on-active.is-active:hover {
@@ -3276,6 +3564,18 @@ input:checked + .switch--dot-transparent::after {
 .border--orange-dark-on-active.is-active,
 .border--orange-dark-on-active.is-active:hover {
   border-color: var(--orange-dark) !important;
+}
+
+.border--orange-on-hover:hover,
+.border--orange-on-active.is-active,
+.border--orange-on-active.is-active:hover {
+  border-color: var(--orange) !important;
+}
+
+.border--orange-light-on-hover:hover,
+.border--orange-light-on-active.is-active,
+.border--orange-light-on-active.is-active:hover {
+  border-color: var(--orange-light) !important;
 }
 
 .border--orange-faint-on-hover:hover,
@@ -3290,6 +3590,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--yellow-dark) !important;
 }
 
+.border--yellow-on-hover:hover,
+.border--yellow-on-active.is-active,
+.border--yellow-on-active.is-active:hover {
+  border-color: var(--yellow) !important;
+}
+
+.border--yellow-light-on-hover:hover,
+.border--yellow-light-on-active.is-active,
+.border--yellow-light-on-active.is-active:hover {
+  border-color: var(--yellow-light) !important;
+}
+
 .border--yellow-faint-on-hover:hover,
 .border--yellow-faint-on-active.is-active,
 .border--yellow-faint-on-active.is-active:hover {
@@ -3300,6 +3612,18 @@ input:checked + .switch--dot-transparent::after {
 .border--green-dark-on-active.is-active,
 .border--green-dark-on-active.is-active:hover {
   border-color: var(--green-dark) !important;
+}
+
+.border--green-on-hover:hover,
+.border--green-on-active.is-active,
+.border--green-on-active.is-active:hover {
+  border-color: var(--green) !important;
+}
+
+.border--green-light-on-hover:hover,
+.border--green-light-on-active.is-active,
+.border--green-light-on-active.is-active:hover {
+  border-color: var(--green-light) !important;
 }
 
 .border--green-faint-on-hover:hover,
@@ -3314,6 +3638,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--blue-dark) !important;
 }
 
+.border--blue-on-hover:hover,
+.border--blue-on-active.is-active,
+.border--blue-on-active.is-active:hover {
+  border-color: var(--blue) !important;
+}
+
+.border--blue-light-on-hover:hover,
+.border--blue-light-on-active.is-active,
+.border--blue-light-on-active.is-active:hover {
+  border-color: var(--blue-light) !important;
+}
+
 .border--blue-faint-on-hover:hover,
 .border--blue-faint-on-active.is-active,
 .border--blue-faint-on-active.is-active:hover {
@@ -3326,16 +3662,88 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--purple-dark) !important;
 }
 
+.border--purple-on-hover:hover,
+.border--purple-on-active.is-active,
+.border--purple-on-active.is-active:hover {
+  border-color: var(--purple) !important;
+}
+
+.border--purple-light-on-hover:hover,
+.border--purple-light-on-active.is-active,
+.border--purple-light-on-active.is-active:hover {
+  border-color: var(--purple-light) !important;
+}
+
 .border--purple-faint-on-hover:hover,
 .border--purple-faint-on-active.is-active,
 .border--purple-faint-on-active.is-active:hover {
   border-color: var(--purple-faint) !important;
 }
 
+.border--darken10-on-hover:hover,
+.border--darken10-on-active.is-active,
+.border--darken10-on-active.is-active:hover {
+  border-color: var(--darken10) !important;
+}
+
+.border--darken25-on-hover:hover,
+.border--darken25-on-active.is-active,
+.border--darken25-on-active.is-active:hover {
+  border-color: var(--darken25) !important;
+}
+
+.border--darken50-on-hover:hover,
+.border--darken50-on-active.is-active,
+.border--darken50-on-active.is-active:hover {
+  border-color: var(--darken50) !important;
+}
+
+.border--darken75-on-hover:hover,
+.border--darken75-on-active.is-active,
+.border--darken75-on-active.is-active:hover {
+  border-color: var(--darken75) !important;
+}
+
+.border--lighten10-on-hover:hover,
+.border--lighten10-on-active.is-active,
+.border--lighten10-on-active.is-active:hover {
+  border-color: var(--lighten10) !important;
+}
+
+.border--lighten25-on-hover:hover,
+.border--lighten25-on-active.is-active,
+.border--lighten25-on-active.is-active:hover {
+  border-color: var(--lighten25) !important;
+}
+
+.border--lighten50-on-hover:hover,
+.border--lighten50-on-active.is-active,
+.border--lighten50-on-active.is-active:hover {
+  border-color: var(--lighten50) !important;
+}
+
+.border--lighten75-on-hover:hover,
+.border--lighten75-on-active.is-active,
+.border--lighten75-on-active.is-active:hover {
+  border-color: var(--lighten75) !important;
+}
+
+.border--white-on-hover:hover,
+.border--white-on-active.is-active,
+.border--white-on-active.is-active:hover {
+  border-color: var(--white) !important;
+}
+
 .border--black-on-hover:hover,
 .border--black-on-active.is-active,
 .border--black-on-active.is-active:hover {
   border-color: var(--black) !important;
+}
+
+.border--transparent-on-hover:hover,
+.border--transparent-on-active.is-active,
+.border--transparent-on-active.is-active:hover {
+  border-color: var(--transparent) !important;
 }
 
 /** @endgroup */

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -2945,6 +2945,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--gray-dark) !important;
 }
 
+.bg-gray-on-hover:hover,
+.bg-gray-on-active.is-active,
+.bg-gray-on-active.is-active:hover {
+  background-color: var(--gray) !important;
+}
+
+.bg-gray-light-on-hover:hover,
+.bg-gray-light-on-active.is-active,
+.bg-gray-light-on-active.is-active:hover {
+  background-color: var(--gray-light) !important;
+}
+
 .bg-gray-faint-on-hover:hover,
 .bg-gray-faint-on-active.is-active,
 .bg-gray-faint-on-active.is-active:hover {
@@ -2955,6 +2967,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-pink-dark-on-active.is-active,
 .bg-pink-dark-on-active.is-active:hover {
   background-color: var(--pink-dark) !important;
+}
+
+.bg-pink-on-hover:hover,
+.bg-pink-on-active.is-active,
+.bg-pink-on-active.is-active:hover {
+  background-color: var(--pink) !important;
+}
+
+.bg-pink-light-on-hover:hover,
+.bg-pink-light-on-active.is-active,
+.bg-pink-light-on-active.is-active:hover {
+  background-color: var(--pink-light) !important;
 }
 
 .bg-pink-faint-on-hover:hover,
@@ -2969,6 +2993,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--red-dark) !important;
 }
 
+.bg-red-on-hover:hover,
+.bg-red-on-active.is-active,
+.bg-red-on-active.is-active:hover {
+  background-color: var(--red) !important;
+}
+
+.bg-red-light-on-hover:hover,
+.bg-red-light-on-active.is-active,
+.bg-red-light-on-active.is-active:hover {
+  background-color: var(--red-light) !important;
+}
+
 .bg-red-faint-on-hover:hover,
 .bg-red-faint-on-active.is-active,
 .bg-red-faint-on-active.is-active:hover {
@@ -2979,6 +3015,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-orange-dark-on-active.is-active,
 .bg-orange-dark-on-active.is-active:hover {
   background-color: var(--orange-dark) !important;
+}
+
+.bg-orange-on-hover:hover,
+.bg-orange-on-active.is-active,
+.bg-orange-on-active.is-active:hover {
+  background-color: var(--orange) !important;
+}
+
+.bg-orange-light-on-hover:hover,
+.bg-orange-light-on-active.is-active,
+.bg-orange-light-on-active.is-active:hover {
+  background-color: var(--orange-light) !important;
 }
 
 .bg-orange-faint-on-hover:hover,
@@ -2993,6 +3041,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--yellow-dark) !important;
 }
 
+.bg-yellow-on-hover:hover,
+.bg-yellow-on-active.is-active,
+.bg-yellow-on-active.is-active:hover {
+  background-color: var(--yellow) !important;
+}
+
+.bg-yellow-light-on-hover:hover,
+.bg-yellow-light-on-active.is-active,
+.bg-yellow-light-on-active.is-active:hover {
+  background-color: var(--yellow-light) !important;
+}
+
 .bg-yellow-faint-on-hover:hover,
 .bg-yellow-faint-on-active.is-active,
 .bg-yellow-faint-on-active.is-active:hover {
@@ -3003,6 +3063,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-green-dark-on-active.is-active,
 .bg-green-dark-on-active.is-active:hover {
   background-color: var(--green-dark) !important;
+}
+
+.bg-green-on-hover:hover,
+.bg-green-on-active.is-active,
+.bg-green-on-active.is-active:hover {
+  background-color: var(--green) !important;
+}
+
+.bg-green-light-on-hover:hover,
+.bg-green-light-on-active.is-active,
+.bg-green-light-on-active.is-active:hover {
+  background-color: var(--green-light) !important;
 }
 
 .bg-green-faint-on-hover:hover,
@@ -3017,6 +3089,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--blue-dark) !important;
 }
 
+.bg-blue-on-hover:hover,
+.bg-blue-on-active.is-active,
+.bg-blue-on-active.is-active:hover {
+  background-color: var(--blue) !important;
+}
+
+.bg-blue-light-on-hover:hover,
+.bg-blue-light-on-active.is-active,
+.bg-blue-light-on-active.is-active:hover {
+  background-color: var(--blue-light) !important;
+}
+
 .bg-blue-faint-on-hover:hover,
 .bg-blue-faint-on-active.is-active,
 .bg-blue-faint-on-active.is-active:hover {
@@ -3027,6 +3111,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-purple-dark-on-active.is-active,
 .bg-purple-dark-on-active.is-active:hover {
   background-color: var(--purple-dark) !important;
+}
+
+.bg-purple-on-hover:hover,
+.bg-purple-on-active.is-active,
+.bg-purple-on-active.is-active:hover {
+  background-color: var(--purple) !important;
+}
+
+.bg-purple-light-on-hover:hover,
+.bg-purple-light-on-active.is-active,
+.bg-purple-light-on-active.is-active:hover {
+  background-color: var(--purple-light) !important;
 }
 
 .bg-purple-faint-on-hover:hover,
@@ -3041,16 +3137,76 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--darken5) !important;
 }
 
+.bg-darken10-on-hover:hover,
+.bg-darken10-on-active.is-active,
+.bg-darken10-on-active.is-active:hover {
+  background-color: var(--darken10) !important;
+}
+
+.bg-darken25-on-hover:hover,
+.bg-darken25-on-active.is-active,
+.bg-darken25-on-active.is-active:hover {
+  background-color: var(--darken25) !important;
+}
+
+.bg-darken50-on-hover:hover,
+.bg-darken50-on-active.is-active,
+.bg-darken50-on-active.is-active:hover {
+  background-color: var(--darken50) !important;
+}
+
+.bg-darken75-on-hover:hover,
+.bg-darken75-on-active.is-active,
+.bg-darken75-on-active.is-active:hover {
+  background-color: var(--darken75) !important;
+}
+
 .bg-lighten5-on-hover:hover,
 .bg-lighten5-on-active.is-active,
 .bg-lighten5-on-active.is-active:hover {
   background-color: var(--lighten5) !important;
 }
 
+.bg-lighten10-on-hover:hover,
+.bg-lighten10-on-active.is-active,
+.bg-lighten10-on-active.is-active:hover {
+  background-color: var(--lighten10) !important;
+}
+
+.bg-lighten25-on-hover:hover,
+.bg-lighten25-on-active.is-active,
+.bg-lighten25-on-active.is-active:hover {
+  background-color: var(--lighten25) !important;
+}
+
+.bg-lighten50-on-hover:hover,
+.bg-lighten50-on-active.is-active,
+.bg-lighten50-on-active.is-active:hover {
+  background-color: var(--lighten50) !important;
+}
+
+.bg-lighten75-on-hover:hover,
+.bg-lighten75-on-active.is-active,
+.bg-lighten75-on-active.is-active:hover {
+  background-color: var(--lighten75) !important;
+}
+
+.bg-white-on-hover:hover,
+.bg-white-on-active.is-active,
+.bg-white-on-active.is-active:hover {
+  background-color: var(--white) !important;
+}
+
 .bg-black-on-hover:hover,
 .bg-black-on-active.is-active,
 .bg-black-on-active.is-active:hover {
   background-color: var(--black) !important;
+}
+
+.bg-transparent-on-hover:hover,
+.bg-transparent-on-active.is-active,
+.bg-transparent-on-active.is-active:hover {
+  background-color: var(--transparent) !important;
 }
 
 /** @endgroup */
@@ -3071,6 +3227,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--gray-dark) !important;
 }
 
+.color-gray-on-hover:hover,
+.color-gray-on-active.is-active,
+.color-gray-on-active.is-active:hover {
+  color: var(--gray) !important;
+}
+
 .color-gray-light-on-hover:hover,
 .color-gray-light-on-active.is-active,
 .color-gray-light-on-active.is-active:hover {
@@ -3087,6 +3249,12 @@ input:checked + .switch--dot-transparent::after {
 .color-pink-dark-on-active.is-active,
 .color-pink-dark-on-active.is-active:hover {
   color: var(--pink-dark) !important;
+}
+
+.color-pink-on-hover:hover,
+.color-pink-on-active.is-active,
+.color-pink-on-active.is-active:hover {
+  color: var(--pink) !important;
 }
 
 .color-pink-light-on-hover:hover,
@@ -3107,6 +3275,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--red-dark) !important;
 }
 
+.color-red-on-hover:hover,
+.color-red-on-active.is-active,
+.color-red-on-active.is-active:hover {
+  color: var(--red) !important;
+}
+
 .color-red-light-on-hover:hover,
 .color-red-light-on-active.is-active,
 .color-red-light-on-active.is-active:hover {
@@ -3123,6 +3297,12 @@ input:checked + .switch--dot-transparent::after {
 .color-orange-dark-on-active.is-active,
 .color-orange-dark-on-active.is-active:hover {
   color: var(--orange-dark) !important;
+}
+
+.color-orange-on-hover:hover,
+.color-orange-on-active.is-active,
+.color-orange-on-active.is-active:hover {
+  color: var(--orange) !important;
 }
 
 .color-orange-light-on-hover:hover,
@@ -3143,6 +3323,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--yellow-dark) !important;
 }
 
+.color-yellow-on-hover:hover,
+.color-yellow-on-active.is-active,
+.color-yellow-on-active.is-active:hover {
+  color: var(--yellow) !important;
+}
+
 .color-yellow-light-on-hover:hover,
 .color-yellow-light-on-active.is-active,
 .color-yellow-light-on-active.is-active:hover {
@@ -3159,6 +3345,12 @@ input:checked + .switch--dot-transparent::after {
 .color-green-dark-on-active.is-active,
 .color-green-dark-on-active.is-active:hover {
   color: var(--green-dark) !important;
+}
+
+.color-green-on-hover:hover,
+.color-green-on-active.is-active,
+.color-green-on-active.is-active:hover {
+  color: var(--green) !important;
 }
 
 .color-green-light-on-hover:hover,
@@ -3179,6 +3371,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--blue-dark) !important;
 }
 
+.color-blue-on-hover:hover,
+.color-blue-on-active.is-active,
+.color-blue-on-active.is-active:hover {
+  color: var(--blue) !important;
+}
+
 .color-blue-light-on-hover:hover,
 .color-blue-light-on-active.is-active,
 .color-blue-light-on-active.is-active:hover {
@@ -3195,6 +3393,12 @@ input:checked + .switch--dot-transparent::after {
 .color-purple-dark-on-active.is-active,
 .color-purple-dark-on-active.is-active:hover {
   color: var(--purple-dark) !important;
+}
+
+.color-purple-on-hover:hover,
+.color-purple-on-active.is-active,
+.color-purple-on-active.is-active:hover {
+  color: var(--purple) !important;
 }
 
 .color-purple-light-on-hover:hover,
@@ -3215,16 +3419,64 @@ input:checked + .switch--dot-transparent::after {
   color: var(--darken10) !important;
 }
 
+.color-darken25-on-hover:hover,
+.color-darken25-on-active.is-active,
+.color-darken25-on-active.is-active:hover {
+  color: var(--darken25) !important;
+}
+
+.color-darken50-on-hover:hover,
+.color-darken50-on-active.is-active,
+.color-darken50-on-active.is-active:hover {
+  color: var(--darken50) !important;
+}
+
+.color-darken75-on-hover:hover,
+.color-darken75-on-active.is-active,
+.color-darken75-on-active.is-active:hover {
+  color: var(--darken75) !important;
+}
+
 .color-lighten10-on-hover:hover,
 .color-lighten10-on-active.is-active,
 .color-lighten10-on-active.is-active:hover {
   color: var(--lighten10) !important;
 }
 
+.color-lighten25-on-hover:hover,
+.color-lighten25-on-active.is-active,
+.color-lighten25-on-active.is-active:hover {
+  color: var(--lighten25) !important;
+}
+
+.color-lighten50-on-hover:hover,
+.color-lighten50-on-active.is-active,
+.color-lighten50-on-active.is-active:hover {
+  color: var(--lighten50) !important;
+}
+
+.color-lighten75-on-hover:hover,
+.color-lighten75-on-active.is-active,
+.color-lighten75-on-active.is-active:hover {
+  color: var(--lighten75) !important;
+}
+
+.color-white-on-hover:hover,
+.color-white-on-active.is-active,
+.color-white-on-active.is-active:hover {
+  color: var(--white) !important;
+}
+
 .color-black-on-hover:hover,
 .color-black-on-active.is-active,
 .color-black-on-active.is-active:hover {
   color: var(--black) !important;
+}
+
+.color-transparent-on-hover:hover,
+.color-transparent-on-active.is-active,
+.color-transparent-on-active.is-active:hover {
+  color: var(--transparent) !important;
 }
 
 /** @endgroup */
@@ -3245,6 +3497,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--gray-dark) !important;
 }
 
+.border--gray-on-hover:hover,
+.border--gray-on-active.is-active,
+.border--gray-on-active.is-active:hover {
+  border-color: var(--gray) !important;
+}
+
+.border--gray-light-on-hover:hover,
+.border--gray-light-on-active.is-active,
+.border--gray-light-on-active.is-active:hover {
+  border-color: var(--gray-light) !important;
+}
+
 .border--gray-faint-on-hover:hover,
 .border--gray-faint-on-active.is-active,
 .border--gray-faint-on-active.is-active:hover {
@@ -3255,6 +3519,18 @@ input:checked + .switch--dot-transparent::after {
 .border--pink-dark-on-active.is-active,
 .border--pink-dark-on-active.is-active:hover {
   border-color: var(--pink-dark) !important;
+}
+
+.border--pink-on-hover:hover,
+.border--pink-on-active.is-active,
+.border--pink-on-active.is-active:hover {
+  border-color: var(--pink) !important;
+}
+
+.border--pink-light-on-hover:hover,
+.border--pink-light-on-active.is-active,
+.border--pink-light-on-active.is-active:hover {
+  border-color: var(--pink-light) !important;
 }
 
 .border--pink-faint-on-hover:hover,
@@ -3269,6 +3545,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--red-dark) !important;
 }
 
+.border--red-on-hover:hover,
+.border--red-on-active.is-active,
+.border--red-on-active.is-active:hover {
+  border-color: var(--red) !important;
+}
+
+.border--red-light-on-hover:hover,
+.border--red-light-on-active.is-active,
+.border--red-light-on-active.is-active:hover {
+  border-color: var(--red-light) !important;
+}
+
 .border--red-faint-on-hover:hover,
 .border--red-faint-on-active.is-active,
 .border--red-faint-on-active.is-active:hover {
@@ -3279,6 +3567,18 @@ input:checked + .switch--dot-transparent::after {
 .border--orange-dark-on-active.is-active,
 .border--orange-dark-on-active.is-active:hover {
   border-color: var(--orange-dark) !important;
+}
+
+.border--orange-on-hover:hover,
+.border--orange-on-active.is-active,
+.border--orange-on-active.is-active:hover {
+  border-color: var(--orange) !important;
+}
+
+.border--orange-light-on-hover:hover,
+.border--orange-light-on-active.is-active,
+.border--orange-light-on-active.is-active:hover {
+  border-color: var(--orange-light) !important;
 }
 
 .border--orange-faint-on-hover:hover,
@@ -3293,6 +3593,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--yellow-dark) !important;
 }
 
+.border--yellow-on-hover:hover,
+.border--yellow-on-active.is-active,
+.border--yellow-on-active.is-active:hover {
+  border-color: var(--yellow) !important;
+}
+
+.border--yellow-light-on-hover:hover,
+.border--yellow-light-on-active.is-active,
+.border--yellow-light-on-active.is-active:hover {
+  border-color: var(--yellow-light) !important;
+}
+
 .border--yellow-faint-on-hover:hover,
 .border--yellow-faint-on-active.is-active,
 .border--yellow-faint-on-active.is-active:hover {
@@ -3303,6 +3615,18 @@ input:checked + .switch--dot-transparent::after {
 .border--green-dark-on-active.is-active,
 .border--green-dark-on-active.is-active:hover {
   border-color: var(--green-dark) !important;
+}
+
+.border--green-on-hover:hover,
+.border--green-on-active.is-active,
+.border--green-on-active.is-active:hover {
+  border-color: var(--green) !important;
+}
+
+.border--green-light-on-hover:hover,
+.border--green-light-on-active.is-active,
+.border--green-light-on-active.is-active:hover {
+  border-color: var(--green-light) !important;
 }
 
 .border--green-faint-on-hover:hover,
@@ -3317,6 +3641,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--blue-dark) !important;
 }
 
+.border--blue-on-hover:hover,
+.border--blue-on-active.is-active,
+.border--blue-on-active.is-active:hover {
+  border-color: var(--blue) !important;
+}
+
+.border--blue-light-on-hover:hover,
+.border--blue-light-on-active.is-active,
+.border--blue-light-on-active.is-active:hover {
+  border-color: var(--blue-light) !important;
+}
+
 .border--blue-faint-on-hover:hover,
 .border--blue-faint-on-active.is-active,
 .border--blue-faint-on-active.is-active:hover {
@@ -3329,16 +3665,88 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--purple-dark) !important;
 }
 
+.border--purple-on-hover:hover,
+.border--purple-on-active.is-active,
+.border--purple-on-active.is-active:hover {
+  border-color: var(--purple) !important;
+}
+
+.border--purple-light-on-hover:hover,
+.border--purple-light-on-active.is-active,
+.border--purple-light-on-active.is-active:hover {
+  border-color: var(--purple-light) !important;
+}
+
 .border--purple-faint-on-hover:hover,
 .border--purple-faint-on-active.is-active,
 .border--purple-faint-on-active.is-active:hover {
   border-color: var(--purple-faint) !important;
 }
 
+.border--darken10-on-hover:hover,
+.border--darken10-on-active.is-active,
+.border--darken10-on-active.is-active:hover {
+  border-color: var(--darken10) !important;
+}
+
+.border--darken25-on-hover:hover,
+.border--darken25-on-active.is-active,
+.border--darken25-on-active.is-active:hover {
+  border-color: var(--darken25) !important;
+}
+
+.border--darken50-on-hover:hover,
+.border--darken50-on-active.is-active,
+.border--darken50-on-active.is-active:hover {
+  border-color: var(--darken50) !important;
+}
+
+.border--darken75-on-hover:hover,
+.border--darken75-on-active.is-active,
+.border--darken75-on-active.is-active:hover {
+  border-color: var(--darken75) !important;
+}
+
+.border--lighten10-on-hover:hover,
+.border--lighten10-on-active.is-active,
+.border--lighten10-on-active.is-active:hover {
+  border-color: var(--lighten10) !important;
+}
+
+.border--lighten25-on-hover:hover,
+.border--lighten25-on-active.is-active,
+.border--lighten25-on-active.is-active:hover {
+  border-color: var(--lighten25) !important;
+}
+
+.border--lighten50-on-hover:hover,
+.border--lighten50-on-active.is-active,
+.border--lighten50-on-active.is-active:hover {
+  border-color: var(--lighten50) !important;
+}
+
+.border--lighten75-on-hover:hover,
+.border--lighten75-on-active.is-active,
+.border--lighten75-on-active.is-active:hover {
+  border-color: var(--lighten75) !important;
+}
+
+.border--white-on-hover:hover,
+.border--white-on-active.is-active,
+.border--white-on-active.is-active:hover {
+  border-color: var(--white) !important;
+}
+
 .border--black-on-hover:hover,
 .border--black-on-active.is-active,
 .border--black-on-active.is-active:hover {
   border-color: var(--black) !important;
+}
+
+.border--transparent-on-hover:hover,
+.border--transparent-on-active.is-active,
+.border--transparent-on-active.is-active:hover {
+  border-color: var(--transparent) !important;
 }
 
 /** @endgroup */
@@ -6290,6 +6698,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--gray-dark) !important;
 }
 
+.bg-gray-on-hover:hover,
+.bg-gray-on-active.is-active,
+.bg-gray-on-active.is-active:hover {
+  background-color: var(--gray) !important;
+}
+
+.bg-gray-light-on-hover:hover,
+.bg-gray-light-on-active.is-active,
+.bg-gray-light-on-active.is-active:hover {
+  background-color: var(--gray-light) !important;
+}
+
 .bg-gray-faint-on-hover:hover,
 .bg-gray-faint-on-active.is-active,
 .bg-gray-faint-on-active.is-active:hover {
@@ -6300,6 +6720,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-pink-dark-on-active.is-active,
 .bg-pink-dark-on-active.is-active:hover {
   background-color: var(--pink-dark) !important;
+}
+
+.bg-pink-on-hover:hover,
+.bg-pink-on-active.is-active,
+.bg-pink-on-active.is-active:hover {
+  background-color: var(--pink) !important;
+}
+
+.bg-pink-light-on-hover:hover,
+.bg-pink-light-on-active.is-active,
+.bg-pink-light-on-active.is-active:hover {
+  background-color: var(--pink-light) !important;
 }
 
 .bg-pink-faint-on-hover:hover,
@@ -6314,6 +6746,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--red-dark) !important;
 }
 
+.bg-red-on-hover:hover,
+.bg-red-on-active.is-active,
+.bg-red-on-active.is-active:hover {
+  background-color: var(--red) !important;
+}
+
+.bg-red-light-on-hover:hover,
+.bg-red-light-on-active.is-active,
+.bg-red-light-on-active.is-active:hover {
+  background-color: var(--red-light) !important;
+}
+
 .bg-red-faint-on-hover:hover,
 .bg-red-faint-on-active.is-active,
 .bg-red-faint-on-active.is-active:hover {
@@ -6324,6 +6768,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-orange-dark-on-active.is-active,
 .bg-orange-dark-on-active.is-active:hover {
   background-color: var(--orange-dark) !important;
+}
+
+.bg-orange-on-hover:hover,
+.bg-orange-on-active.is-active,
+.bg-orange-on-active.is-active:hover {
+  background-color: var(--orange) !important;
+}
+
+.bg-orange-light-on-hover:hover,
+.bg-orange-light-on-active.is-active,
+.bg-orange-light-on-active.is-active:hover {
+  background-color: var(--orange-light) !important;
 }
 
 .bg-orange-faint-on-hover:hover,
@@ -6338,6 +6794,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--yellow-dark) !important;
 }
 
+.bg-yellow-on-hover:hover,
+.bg-yellow-on-active.is-active,
+.bg-yellow-on-active.is-active:hover {
+  background-color: var(--yellow) !important;
+}
+
+.bg-yellow-light-on-hover:hover,
+.bg-yellow-light-on-active.is-active,
+.bg-yellow-light-on-active.is-active:hover {
+  background-color: var(--yellow-light) !important;
+}
+
 .bg-yellow-faint-on-hover:hover,
 .bg-yellow-faint-on-active.is-active,
 .bg-yellow-faint-on-active.is-active:hover {
@@ -6348,6 +6816,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-green-dark-on-active.is-active,
 .bg-green-dark-on-active.is-active:hover {
   background-color: var(--green-dark) !important;
+}
+
+.bg-green-on-hover:hover,
+.bg-green-on-active.is-active,
+.bg-green-on-active.is-active:hover {
+  background-color: var(--green) !important;
+}
+
+.bg-green-light-on-hover:hover,
+.bg-green-light-on-active.is-active,
+.bg-green-light-on-active.is-active:hover {
+  background-color: var(--green-light) !important;
 }
 
 .bg-green-faint-on-hover:hover,
@@ -6362,6 +6842,18 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--blue-dark) !important;
 }
 
+.bg-blue-on-hover:hover,
+.bg-blue-on-active.is-active,
+.bg-blue-on-active.is-active:hover {
+  background-color: var(--blue) !important;
+}
+
+.bg-blue-light-on-hover:hover,
+.bg-blue-light-on-active.is-active,
+.bg-blue-light-on-active.is-active:hover {
+  background-color: var(--blue-light) !important;
+}
+
 .bg-blue-faint-on-hover:hover,
 .bg-blue-faint-on-active.is-active,
 .bg-blue-faint-on-active.is-active:hover {
@@ -6372,6 +6864,18 @@ input:checked + .switch--dot-transparent::after {
 .bg-purple-dark-on-active.is-active,
 .bg-purple-dark-on-active.is-active:hover {
   background-color: var(--purple-dark) !important;
+}
+
+.bg-purple-on-hover:hover,
+.bg-purple-on-active.is-active,
+.bg-purple-on-active.is-active:hover {
+  background-color: var(--purple) !important;
+}
+
+.bg-purple-light-on-hover:hover,
+.bg-purple-light-on-active.is-active,
+.bg-purple-light-on-active.is-active:hover {
+  background-color: var(--purple-light) !important;
 }
 
 .bg-purple-faint-on-hover:hover,
@@ -6386,16 +6890,76 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--darken5) !important;
 }
 
+.bg-darken10-on-hover:hover,
+.bg-darken10-on-active.is-active,
+.bg-darken10-on-active.is-active:hover {
+  background-color: var(--darken10) !important;
+}
+
+.bg-darken25-on-hover:hover,
+.bg-darken25-on-active.is-active,
+.bg-darken25-on-active.is-active:hover {
+  background-color: var(--darken25) !important;
+}
+
+.bg-darken50-on-hover:hover,
+.bg-darken50-on-active.is-active,
+.bg-darken50-on-active.is-active:hover {
+  background-color: var(--darken50) !important;
+}
+
+.bg-darken75-on-hover:hover,
+.bg-darken75-on-active.is-active,
+.bg-darken75-on-active.is-active:hover {
+  background-color: var(--darken75) !important;
+}
+
 .bg-lighten5-on-hover:hover,
 .bg-lighten5-on-active.is-active,
 .bg-lighten5-on-active.is-active:hover {
   background-color: var(--lighten5) !important;
 }
 
+.bg-lighten10-on-hover:hover,
+.bg-lighten10-on-active.is-active,
+.bg-lighten10-on-active.is-active:hover {
+  background-color: var(--lighten10) !important;
+}
+
+.bg-lighten25-on-hover:hover,
+.bg-lighten25-on-active.is-active,
+.bg-lighten25-on-active.is-active:hover {
+  background-color: var(--lighten25) !important;
+}
+
+.bg-lighten50-on-hover:hover,
+.bg-lighten50-on-active.is-active,
+.bg-lighten50-on-active.is-active:hover {
+  background-color: var(--lighten50) !important;
+}
+
+.bg-lighten75-on-hover:hover,
+.bg-lighten75-on-active.is-active,
+.bg-lighten75-on-active.is-active:hover {
+  background-color: var(--lighten75) !important;
+}
+
+.bg-white-on-hover:hover,
+.bg-white-on-active.is-active,
+.bg-white-on-active.is-active:hover {
+  background-color: var(--white) !important;
+}
+
 .bg-black-on-hover:hover,
 .bg-black-on-active.is-active,
 .bg-black-on-active.is-active:hover {
   background-color: var(--black) !important;
+}
+
+.bg-transparent-on-hover:hover,
+.bg-transparent-on-active.is-active,
+.bg-transparent-on-active.is-active:hover {
+  background-color: var(--transparent) !important;
 }
 
 /** @endgroup */
@@ -6416,6 +6980,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--gray-dark) !important;
 }
 
+.color-gray-on-hover:hover,
+.color-gray-on-active.is-active,
+.color-gray-on-active.is-active:hover {
+  color: var(--gray) !important;
+}
+
 .color-gray-light-on-hover:hover,
 .color-gray-light-on-active.is-active,
 .color-gray-light-on-active.is-active:hover {
@@ -6432,6 +7002,12 @@ input:checked + .switch--dot-transparent::after {
 .color-pink-dark-on-active.is-active,
 .color-pink-dark-on-active.is-active:hover {
   color: var(--pink-dark) !important;
+}
+
+.color-pink-on-hover:hover,
+.color-pink-on-active.is-active,
+.color-pink-on-active.is-active:hover {
+  color: var(--pink) !important;
 }
 
 .color-pink-light-on-hover:hover,
@@ -6452,6 +7028,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--red-dark) !important;
 }
 
+.color-red-on-hover:hover,
+.color-red-on-active.is-active,
+.color-red-on-active.is-active:hover {
+  color: var(--red) !important;
+}
+
 .color-red-light-on-hover:hover,
 .color-red-light-on-active.is-active,
 .color-red-light-on-active.is-active:hover {
@@ -6468,6 +7050,12 @@ input:checked + .switch--dot-transparent::after {
 .color-orange-dark-on-active.is-active,
 .color-orange-dark-on-active.is-active:hover {
   color: var(--orange-dark) !important;
+}
+
+.color-orange-on-hover:hover,
+.color-orange-on-active.is-active,
+.color-orange-on-active.is-active:hover {
+  color: var(--orange) !important;
 }
 
 .color-orange-light-on-hover:hover,
@@ -6488,6 +7076,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--yellow-dark) !important;
 }
 
+.color-yellow-on-hover:hover,
+.color-yellow-on-active.is-active,
+.color-yellow-on-active.is-active:hover {
+  color: var(--yellow) !important;
+}
+
 .color-yellow-light-on-hover:hover,
 .color-yellow-light-on-active.is-active,
 .color-yellow-light-on-active.is-active:hover {
@@ -6504,6 +7098,12 @@ input:checked + .switch--dot-transparent::after {
 .color-green-dark-on-active.is-active,
 .color-green-dark-on-active.is-active:hover {
   color: var(--green-dark) !important;
+}
+
+.color-green-on-hover:hover,
+.color-green-on-active.is-active,
+.color-green-on-active.is-active:hover {
+  color: var(--green) !important;
 }
 
 .color-green-light-on-hover:hover,
@@ -6524,6 +7124,12 @@ input:checked + .switch--dot-transparent::after {
   color: var(--blue-dark) !important;
 }
 
+.color-blue-on-hover:hover,
+.color-blue-on-active.is-active,
+.color-blue-on-active.is-active:hover {
+  color: var(--blue) !important;
+}
+
 .color-blue-light-on-hover:hover,
 .color-blue-light-on-active.is-active,
 .color-blue-light-on-active.is-active:hover {
@@ -6540,6 +7146,12 @@ input:checked + .switch--dot-transparent::after {
 .color-purple-dark-on-active.is-active,
 .color-purple-dark-on-active.is-active:hover {
   color: var(--purple-dark) !important;
+}
+
+.color-purple-on-hover:hover,
+.color-purple-on-active.is-active,
+.color-purple-on-active.is-active:hover {
+  color: var(--purple) !important;
 }
 
 .color-purple-light-on-hover:hover,
@@ -6560,16 +7172,64 @@ input:checked + .switch--dot-transparent::after {
   color: var(--darken10) !important;
 }
 
+.color-darken25-on-hover:hover,
+.color-darken25-on-active.is-active,
+.color-darken25-on-active.is-active:hover {
+  color: var(--darken25) !important;
+}
+
+.color-darken50-on-hover:hover,
+.color-darken50-on-active.is-active,
+.color-darken50-on-active.is-active:hover {
+  color: var(--darken50) !important;
+}
+
+.color-darken75-on-hover:hover,
+.color-darken75-on-active.is-active,
+.color-darken75-on-active.is-active:hover {
+  color: var(--darken75) !important;
+}
+
 .color-lighten10-on-hover:hover,
 .color-lighten10-on-active.is-active,
 .color-lighten10-on-active.is-active:hover {
   color: var(--lighten10) !important;
 }
 
+.color-lighten25-on-hover:hover,
+.color-lighten25-on-active.is-active,
+.color-lighten25-on-active.is-active:hover {
+  color: var(--lighten25) !important;
+}
+
+.color-lighten50-on-hover:hover,
+.color-lighten50-on-active.is-active,
+.color-lighten50-on-active.is-active:hover {
+  color: var(--lighten50) !important;
+}
+
+.color-lighten75-on-hover:hover,
+.color-lighten75-on-active.is-active,
+.color-lighten75-on-active.is-active:hover {
+  color: var(--lighten75) !important;
+}
+
+.color-white-on-hover:hover,
+.color-white-on-active.is-active,
+.color-white-on-active.is-active:hover {
+  color: var(--white) !important;
+}
+
 .color-black-on-hover:hover,
 .color-black-on-active.is-active,
 .color-black-on-active.is-active:hover {
   color: var(--black) !important;
+}
+
+.color-transparent-on-hover:hover,
+.color-transparent-on-active.is-active,
+.color-transparent-on-active.is-active:hover {
+  color: var(--transparent) !important;
 }
 
 /** @endgroup */
@@ -6590,6 +7250,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--gray-dark) !important;
 }
 
+.border--gray-on-hover:hover,
+.border--gray-on-active.is-active,
+.border--gray-on-active.is-active:hover {
+  border-color: var(--gray) !important;
+}
+
+.border--gray-light-on-hover:hover,
+.border--gray-light-on-active.is-active,
+.border--gray-light-on-active.is-active:hover {
+  border-color: var(--gray-light) !important;
+}
+
 .border--gray-faint-on-hover:hover,
 .border--gray-faint-on-active.is-active,
 .border--gray-faint-on-active.is-active:hover {
@@ -6600,6 +7272,18 @@ input:checked + .switch--dot-transparent::after {
 .border--pink-dark-on-active.is-active,
 .border--pink-dark-on-active.is-active:hover {
   border-color: var(--pink-dark) !important;
+}
+
+.border--pink-on-hover:hover,
+.border--pink-on-active.is-active,
+.border--pink-on-active.is-active:hover {
+  border-color: var(--pink) !important;
+}
+
+.border--pink-light-on-hover:hover,
+.border--pink-light-on-active.is-active,
+.border--pink-light-on-active.is-active:hover {
+  border-color: var(--pink-light) !important;
 }
 
 .border--pink-faint-on-hover:hover,
@@ -6614,6 +7298,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--red-dark) !important;
 }
 
+.border--red-on-hover:hover,
+.border--red-on-active.is-active,
+.border--red-on-active.is-active:hover {
+  border-color: var(--red) !important;
+}
+
+.border--red-light-on-hover:hover,
+.border--red-light-on-active.is-active,
+.border--red-light-on-active.is-active:hover {
+  border-color: var(--red-light) !important;
+}
+
 .border--red-faint-on-hover:hover,
 .border--red-faint-on-active.is-active,
 .border--red-faint-on-active.is-active:hover {
@@ -6624,6 +7320,18 @@ input:checked + .switch--dot-transparent::after {
 .border--orange-dark-on-active.is-active,
 .border--orange-dark-on-active.is-active:hover {
   border-color: var(--orange-dark) !important;
+}
+
+.border--orange-on-hover:hover,
+.border--orange-on-active.is-active,
+.border--orange-on-active.is-active:hover {
+  border-color: var(--orange) !important;
+}
+
+.border--orange-light-on-hover:hover,
+.border--orange-light-on-active.is-active,
+.border--orange-light-on-active.is-active:hover {
+  border-color: var(--orange-light) !important;
 }
 
 .border--orange-faint-on-hover:hover,
@@ -6638,6 +7346,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--yellow-dark) !important;
 }
 
+.border--yellow-on-hover:hover,
+.border--yellow-on-active.is-active,
+.border--yellow-on-active.is-active:hover {
+  border-color: var(--yellow) !important;
+}
+
+.border--yellow-light-on-hover:hover,
+.border--yellow-light-on-active.is-active,
+.border--yellow-light-on-active.is-active:hover {
+  border-color: var(--yellow-light) !important;
+}
+
 .border--yellow-faint-on-hover:hover,
 .border--yellow-faint-on-active.is-active,
 .border--yellow-faint-on-active.is-active:hover {
@@ -6648,6 +7368,18 @@ input:checked + .switch--dot-transparent::after {
 .border--green-dark-on-active.is-active,
 .border--green-dark-on-active.is-active:hover {
   border-color: var(--green-dark) !important;
+}
+
+.border--green-on-hover:hover,
+.border--green-on-active.is-active,
+.border--green-on-active.is-active:hover {
+  border-color: var(--green) !important;
+}
+
+.border--green-light-on-hover:hover,
+.border--green-light-on-active.is-active,
+.border--green-light-on-active.is-active:hover {
+  border-color: var(--green-light) !important;
 }
 
 .border--green-faint-on-hover:hover,
@@ -6662,6 +7394,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--blue-dark) !important;
 }
 
+.border--blue-on-hover:hover,
+.border--blue-on-active.is-active,
+.border--blue-on-active.is-active:hover {
+  border-color: var(--blue) !important;
+}
+
+.border--blue-light-on-hover:hover,
+.border--blue-light-on-active.is-active,
+.border--blue-light-on-active.is-active:hover {
+  border-color: var(--blue-light) !important;
+}
+
 .border--blue-faint-on-hover:hover,
 .border--blue-faint-on-active.is-active,
 .border--blue-faint-on-active.is-active:hover {
@@ -6674,16 +7418,88 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--purple-dark) !important;
 }
 
+.border--purple-on-hover:hover,
+.border--purple-on-active.is-active,
+.border--purple-on-active.is-active:hover {
+  border-color: var(--purple) !important;
+}
+
+.border--purple-light-on-hover:hover,
+.border--purple-light-on-active.is-active,
+.border--purple-light-on-active.is-active:hover {
+  border-color: var(--purple-light) !important;
+}
+
 .border--purple-faint-on-hover:hover,
 .border--purple-faint-on-active.is-active,
 .border--purple-faint-on-active.is-active:hover {
   border-color: var(--purple-faint) !important;
 }
 
+.border--darken10-on-hover:hover,
+.border--darken10-on-active.is-active,
+.border--darken10-on-active.is-active:hover {
+  border-color: var(--darken10) !important;
+}
+
+.border--darken25-on-hover:hover,
+.border--darken25-on-active.is-active,
+.border--darken25-on-active.is-active:hover {
+  border-color: var(--darken25) !important;
+}
+
+.border--darken50-on-hover:hover,
+.border--darken50-on-active.is-active,
+.border--darken50-on-active.is-active:hover {
+  border-color: var(--darken50) !important;
+}
+
+.border--darken75-on-hover:hover,
+.border--darken75-on-active.is-active,
+.border--darken75-on-active.is-active:hover {
+  border-color: var(--darken75) !important;
+}
+
+.border--lighten10-on-hover:hover,
+.border--lighten10-on-active.is-active,
+.border--lighten10-on-active.is-active:hover {
+  border-color: var(--lighten10) !important;
+}
+
+.border--lighten25-on-hover:hover,
+.border--lighten25-on-active.is-active,
+.border--lighten25-on-active.is-active:hover {
+  border-color: var(--lighten25) !important;
+}
+
+.border--lighten50-on-hover:hover,
+.border--lighten50-on-active.is-active,
+.border--lighten50-on-active.is-active:hover {
+  border-color: var(--lighten50) !important;
+}
+
+.border--lighten75-on-hover:hover,
+.border--lighten75-on-active.is-active,
+.border--lighten75-on-active.is-active:hover {
+  border-color: var(--lighten75) !important;
+}
+
+.border--white-on-hover:hover,
+.border--white-on-active.is-active,
+.border--white-on-active.is-active:hover {
+  border-color: var(--white) !important;
+}
+
 .border--black-on-hover:hover,
 .border--black-on-active.is-active,
 .border--black-on-active.is-active:hover {
   border-color: var(--black) !important;
+}
+
+.border--transparent-on-hover:hover,
+.border--transparent-on-active.is-active,
+.border--transparent-on-active.is-active:hover {
+  border-color: var(--transparent) !important;
 }
 
 /** @endgroup */
@@ -7102,10 +7918,28 @@ input:checked + .switch--dot-teal::after {
  * <div class='bg-darken25-on-active'>bg-darken25-on-active (not active)</div>
  * <div class='bg-darken25-on-active is-active'>bg-darken25-on-active (active)</div>
  */
+.bg-red-on-hover:hover,
+.bg-red-on-active.is-active,
+.bg-red-on-active.is-active:hover {
+  background-color: var(--red) !important;
+}
+
+.bg-teal-on-hover:hover,
+.bg-teal-on-active.is-active,
+.bg-teal-on-active.is-active:hover {
+  background-color: var(--teal) !important;
+}
+
 .bg-teal-dark-on-hover:hover,
 .bg-teal-dark-on-active.is-active,
 .bg-teal-dark-on-active.is-active:hover {
   background-color: var(--teal-dark) !important;
+}
+
+.bg-green-light-on-hover:hover,
+.bg-green-light-on-active.is-active,
+.bg-green-light-on-active.is-active:hover {
+  background-color: var(--green-light) !important;
 }
 
 /** @endgroup */
@@ -7120,6 +7954,18 @@ input:checked + .switch--dot-teal::after {
  * <div class='color-red-on-active'>color-red-on-active (not active)</div>
  * <div class='color-red-on-active is-active'>color-red-on-active (active)</div>
  */
+.color-red-on-hover:hover,
+.color-red-on-active.is-active,
+.color-red-on-active.is-active:hover {
+  color: var(--red) !important;
+}
+
+.color-teal-on-hover:hover,
+.color-teal-on-active.is-active,
+.color-teal-on-active.is-active:hover {
+  color: var(--teal) !important;
+}
+
 .color-teal-dark-on-hover:hover,
 .color-teal-dark-on-active.is-active,
 .color-teal-dark-on-active.is-active:hover {
@@ -7144,10 +7990,28 @@ input:checked + .switch--dot-teal::after {
  * <div class='border border--red-on-active'>border--red-on-active (not active)</div>
  * <div class='border border--red-on-active is-active'>border--red-on-active (active)</div>
  */
+.border--red-on-hover:hover,
+.border--red-on-active.is-active,
+.border--red-on-active.is-active:hover {
+  border-color: var(--red) !important;
+}
+
+.border--teal-on-hover:hover,
+.border--teal-on-active.is-active,
+.border--teal-on-active.is-active:hover {
+  border-color: var(--teal) !important;
+}
+
 .border--teal-dark-on-hover:hover,
 .border--teal-dark-on-active.is-active,
 .border--teal-dark-on-active.is-active:hover {
   border-color: var(--teal-dark) !important;
+}
+
+.border--green-light-on-hover:hover,
+.border--green-light-on-active.is-active,
+.border--green-light-on-active.is-active:hover {
+  border-color: var(--green-light) !important;
 }
 
 /** @endgroup */
@@ -7578,6 +8442,24 @@ input:checked + .toggle--active-gray {
  * <div class='bg-darken25-on-active'>bg-darken25-on-active (not active)</div>
  * <div class='bg-darken25-on-active is-active'>bg-darken25-on-active (active)</div>
  */
+.bg-lighten50-on-hover:hover,
+.bg-lighten50-on-active.is-active,
+.bg-lighten50-on-active.is-active:hover {
+  background-color: var(--lighten50) !important;
+}
+
+.bg-lighten25-on-hover:hover,
+.bg-lighten25-on-active.is-active,
+.bg-lighten25-on-active.is-active:hover {
+  background-color: var(--lighten25) !important;
+}
+
+.bg-gray-on-hover:hover,
+.bg-gray-on-active.is-active,
+.bg-gray-on-active.is-active:hover {
+  background-color: var(--gray) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -7590,6 +8472,24 @@ input:checked + .toggle--active-gray {
  * <div class='color-red-on-active'>color-red-on-active (not active)</div>
  * <div class='color-red-on-active is-active'>color-red-on-active (active)</div>
  */
+.color-lighten50-on-hover:hover,
+.color-lighten50-on-active.is-active,
+.color-lighten50-on-active.is-active:hover {
+  color: var(--lighten50) !important;
+}
+
+.color-lighten25-on-hover:hover,
+.color-lighten25-on-active.is-active,
+.color-lighten25-on-active.is-active:hover {
+  color: var(--lighten25) !important;
+}
+
+.color-gray-on-hover:hover,
+.color-gray-on-active.is-active,
+.color-gray-on-active.is-active:hover {
+  color: var(--gray) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -7602,6 +8502,24 @@ input:checked + .toggle--active-gray {
  * <div class='border border--red-on-active'>border--red-on-active (not active)</div>
  * <div class='border border--red-on-active is-active'>border--red-on-active (active)</div>
  */
+.border--lighten50-on-hover:hover,
+.border--lighten50-on-active.is-active,
+.border--lighten50-on-active.is-active:hover {
+  border-color: var(--lighten50) !important;
+}
+
+.border--lighten25-on-hover:hover,
+.border--lighten25-on-active.is-active,
+.border--lighten25-on-active.is-active:hover {
+  border-color: var(--lighten25) !important;
+}
+
+.border--gray-on-hover:hover,
+.border--gray-on-active.is-active,
+.border--gray-on-active.is-active:hover {
+  border-color: var(--gray) !important;
+}
+
 /** @endgroup */
 "
 `;

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -11023,6 +11023,18 @@ input:checked + .switch--dot-transparent::after{
   background-color:#2d2d2d !important;
 }
 
+.bg-gray-on-hover:hover,
+.bg-gray-on-active.is-active,
+.bg-gray-on-active.is-active:hover{
+  background-color:#666 !important;
+}
+
+.bg-gray-light-on-hover:hover,
+.bg-gray-light-on-active.is-active,
+.bg-gray-light-on-active.is-active:hover{
+  background-color:#ccc !important;
+}
+
 .bg-gray-faint-on-hover:hover,
 .bg-gray-faint-on-active.is-active,
 .bg-gray-faint-on-active.is-active:hover{
@@ -11033,6 +11045,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-pink-dark-on-active.is-active,
 .bg-pink-dark-on-active.is-active:hover{
   background-color:#ab084b !important;
+}
+
+.bg-pink-on-hover:hover,
+.bg-pink-on-active.is-active,
+.bg-pink-on-active.is-active:hover{
+  background-color:#ff3c96 !important;
+}
+
+.bg-pink-light-on-hover:hover,
+.bg-pink-light-on-active.is-active,
+.bg-pink-light-on-active.is-active:hover{
+  background-color:#ff88c0 !important;
 }
 
 .bg-pink-faint-on-hover:hover,
@@ -11047,6 +11071,18 @@ input:checked + .switch--dot-transparent::after{
   background-color:#a30003 !important;
 }
 
+.bg-red-on-hover:hover,
+.bg-red-on-active.is-active,
+.bg-red-on-active.is-active:hover{
+  background-color:#dc2b28 !important;
+}
+
+.bg-red-light-on-hover:hover,
+.bg-red-light-on-active.is-active,
+.bg-red-light-on-active.is-active:hover{
+  background-color:#ff8280 !important;
+}
+
 .bg-red-faint-on-hover:hover,
 .bg-red-faint-on-active.is-active,
 .bg-red-faint-on-active.is-active:hover{
@@ -11057,6 +11093,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-orange-dark-on-active.is-active,
 .bg-orange-dark-on-active.is-active:hover{
   background-color:#bc3a00 !important;
+}
+
+.bg-orange-on-hover:hover,
+.bg-orange-on-active.is-active,
+.bg-orange-on-active.is-active:hover{
+  background-color:#ff6e00 !important;
+}
+
+.bg-orange-light-on-hover:hover,
+.bg-orange-light-on-active.is-active,
+.bg-orange-light-on-active.is-active:hover{
+  background-color:#ffa950 !important;
 }
 
 .bg-orange-faint-on-hover:hover,
@@ -11071,6 +11119,18 @@ input:checked + .switch--dot-transparent::after{
   background-color:#d9a100 !important;
 }
 
+.bg-yellow-on-hover:hover,
+.bg-yellow-on-active.is-active,
+.bg-yellow-on-active.is-active:hover{
+  background-color:#f0dc00 !important;
+}
+
+.bg-yellow-light-on-hover:hover,
+.bg-yellow-light-on-active.is-active,
+.bg-yellow-light-on-active.is-active:hover{
+  background-color:#f0f062 !important;
+}
+
 .bg-yellow-faint-on-hover:hover,
 .bg-yellow-faint-on-active.is-active,
 .bg-yellow-faint-on-active.is-active:hover{
@@ -11081,6 +11141,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-green-dark-on-active.is-active,
 .bg-green-dark-on-active.is-active:hover{
   background-color:#006427 !important;
+}
+
+.bg-green-on-hover:hover,
+.bg-green-on-active.is-active,
+.bg-green-on-active.is-active:hover{
+  background-color:#01aa46 !important;
+}
+
+.bg-green-light-on-hover:hover,
+.bg-green-light-on-active.is-active,
+.bg-green-light-on-active.is-active:hover{
+  background-color:#72c781 !important;
 }
 
 .bg-green-faint-on-hover:hover,
@@ -11095,6 +11167,18 @@ input:checked + .switch--dot-transparent::after{
   background-color:#223B53 !important;
 }
 
+.bg-blue-on-hover:hover,
+.bg-blue-on-active.is-active,
+.bg-blue-on-active.is-active:hover{
+  background-color:#3887BE !important;
+}
+
+.bg-blue-light-on-hover:hover,
+.bg-blue-light-on-active.is-active,
+.bg-blue-light-on-active.is-active:hover{
+  background-color:#52A1D8 !important;
+}
+
 .bg-blue-faint-on-hover:hover,
 .bg-blue-faint-on-active.is-active,
 .bg-blue-faint-on-active.is-active:hover{
@@ -11105,6 +11189,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-purple-dark-on-active.is-active,
 .bg-purple-dark-on-active.is-active:hover{
   background-color:#440067 !important;
+}
+
+.bg-purple-on-hover:hover,
+.bg-purple-on-active.is-active,
+.bg-purple-on-active.is-active:hover{
+  background-color:#8c50c7 !important;
+}
+
+.bg-purple-light-on-hover:hover,
+.bg-purple-light-on-active.is-active,
+.bg-purple-light-on-active.is-active:hover{
+  background-color:#c299e3 !important;
 }
 
 .bg-purple-faint-on-hover:hover,
@@ -11119,10 +11215,64 @@ input:checked + .switch--dot-transparent::after{
   background-color:rgba(0, 0, 0, 0.05) !important;
 }
 
+.bg-darken10-on-hover:hover,
+.bg-darken10-on-active.is-active,
+.bg-darken10-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.1) !important;
+}
+
+.bg-darken25-on-hover:hover,
+.bg-darken25-on-active.is-active,
+.bg-darken25-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.25) !important;
+}
+
+.bg-darken50-on-hover:hover,
+.bg-darken50-on-active.is-active,
+.bg-darken50-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.5) !important;
+}
+
+.bg-darken75-on-hover:hover,
+.bg-darken75-on-active.is-active,
+.bg-darken75-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.75) !important;
+}
+
 .bg-lighten5-on-hover:hover,
 .bg-lighten5-on-active.is-active,
 .bg-lighten5-on-active.is-active:hover{
   background-color:rgba(255, 255, 255, 0.05) !important;
+}
+
+.bg-lighten10-on-hover:hover,
+.bg-lighten10-on-active.is-active,
+.bg-lighten10-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.1) !important;
+}
+
+.bg-lighten25-on-hover:hover,
+.bg-lighten25-on-active.is-active,
+.bg-lighten25-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.25) !important;
+}
+
+.bg-lighten50-on-hover:hover,
+.bg-lighten50-on-active.is-active,
+.bg-lighten50-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.5) !important;
+}
+
+.bg-lighten75-on-hover:hover,
+.bg-lighten75-on-active.is-active,
+.bg-lighten75-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.75) !important;
+}
+
+.bg-white-on-hover:hover,
+.bg-white-on-active.is-active,
+.bg-white-on-active.is-active:hover{
+  background-color:#fff !important;
 }
 
 .bg-black-on-hover:hover,
@@ -11130,10 +11280,22 @@ input:checked + .switch--dot-transparent::after{
 .bg-black-on-active.is-active:hover{
   background-color:#000 !important;
 }
+
+.bg-transparent-on-hover:hover,
+.bg-transparent-on-active.is-active,
+.bg-transparent-on-active.is-active:hover{
+  background-color:transparent !important;
+}
 .color-gray-dark-on-hover:hover,
 .color-gray-dark-on-active.is-active,
 .color-gray-dark-on-active.is-active:hover{
   color:#2d2d2d !important;
+}
+
+.color-gray-on-hover:hover,
+.color-gray-on-active.is-active,
+.color-gray-on-active.is-active:hover{
+  color:#666 !important;
 }
 
 .color-gray-light-on-hover:hover,
@@ -11154,6 +11316,12 @@ input:checked + .switch--dot-transparent::after{
   color:#ab084b !important;
 }
 
+.color-pink-on-hover:hover,
+.color-pink-on-active.is-active,
+.color-pink-on-active.is-active:hover{
+  color:#ff3c96 !important;
+}
+
 .color-pink-light-on-hover:hover,
 .color-pink-light-on-active.is-active,
 .color-pink-light-on-active.is-active:hover{
@@ -11170,6 +11338,12 @@ input:checked + .switch--dot-transparent::after{
 .color-red-dark-on-active.is-active,
 .color-red-dark-on-active.is-active:hover{
   color:#a30003 !important;
+}
+
+.color-red-on-hover:hover,
+.color-red-on-active.is-active,
+.color-red-on-active.is-active:hover{
+  color:#dc2b28 !important;
 }
 
 .color-red-light-on-hover:hover,
@@ -11190,6 +11364,12 @@ input:checked + .switch--dot-transparent::after{
   color:#bc3a00 !important;
 }
 
+.color-orange-on-hover:hover,
+.color-orange-on-active.is-active,
+.color-orange-on-active.is-active:hover{
+  color:#ff6e00 !important;
+}
+
 .color-orange-light-on-hover:hover,
 .color-orange-light-on-active.is-active,
 .color-orange-light-on-active.is-active:hover{
@@ -11206,6 +11386,12 @@ input:checked + .switch--dot-transparent::after{
 .color-yellow-dark-on-active.is-active,
 .color-yellow-dark-on-active.is-active:hover{
   color:#d9a100 !important;
+}
+
+.color-yellow-on-hover:hover,
+.color-yellow-on-active.is-active,
+.color-yellow-on-active.is-active:hover{
+  color:#f0dc00 !important;
 }
 
 .color-yellow-light-on-hover:hover,
@@ -11226,6 +11412,12 @@ input:checked + .switch--dot-transparent::after{
   color:#006427 !important;
 }
 
+.color-green-on-hover:hover,
+.color-green-on-active.is-active,
+.color-green-on-active.is-active:hover{
+  color:#01aa46 !important;
+}
+
 .color-green-light-on-hover:hover,
 .color-green-light-on-active.is-active,
 .color-green-light-on-active.is-active:hover{
@@ -11242,6 +11434,12 @@ input:checked + .switch--dot-transparent::after{
 .color-blue-dark-on-active.is-active,
 .color-blue-dark-on-active.is-active:hover{
   color:#223B53 !important;
+}
+
+.color-blue-on-hover:hover,
+.color-blue-on-active.is-active,
+.color-blue-on-active.is-active:hover{
+  color:#3887BE !important;
 }
 
 .color-blue-light-on-hover:hover,
@@ -11262,6 +11460,12 @@ input:checked + .switch--dot-transparent::after{
   color:#440067 !important;
 }
 
+.color-purple-on-hover:hover,
+.color-purple-on-active.is-active,
+.color-purple-on-active.is-active:hover{
+  color:#8c50c7 !important;
+}
+
 .color-purple-light-on-hover:hover,
 .color-purple-light-on-active.is-active,
 .color-purple-light-on-active.is-active:hover{
@@ -11280,10 +11484,52 @@ input:checked + .switch--dot-transparent::after{
   color:rgba(0, 0, 0, 0.1) !important;
 }
 
+.color-darken25-on-hover:hover,
+.color-darken25-on-active.is-active,
+.color-darken25-on-active.is-active:hover{
+  color:rgba(0, 0, 0, 0.25) !important;
+}
+
+.color-darken50-on-hover:hover,
+.color-darken50-on-active.is-active,
+.color-darken50-on-active.is-active:hover{
+  color:rgba(0, 0, 0, 0.5) !important;
+}
+
+.color-darken75-on-hover:hover,
+.color-darken75-on-active.is-active,
+.color-darken75-on-active.is-active:hover{
+  color:rgba(0, 0, 0, 0.75) !important;
+}
+
 .color-lighten10-on-hover:hover,
 .color-lighten10-on-active.is-active,
 .color-lighten10-on-active.is-active:hover{
   color:rgba(255, 255, 255, 0.1) !important;
+}
+
+.color-lighten25-on-hover:hover,
+.color-lighten25-on-active.is-active,
+.color-lighten25-on-active.is-active:hover{
+  color:rgba(255, 255, 255, 0.25) !important;
+}
+
+.color-lighten50-on-hover:hover,
+.color-lighten50-on-active.is-active,
+.color-lighten50-on-active.is-active:hover{
+  color:rgba(255, 255, 255, 0.5) !important;
+}
+
+.color-lighten75-on-hover:hover,
+.color-lighten75-on-active.is-active,
+.color-lighten75-on-active.is-active:hover{
+  color:rgba(255, 255, 255, 0.75) !important;
+}
+
+.color-white-on-hover:hover,
+.color-white-on-active.is-active,
+.color-white-on-active.is-active:hover{
+  color:#fff !important;
 }
 
 .color-black-on-hover:hover,
@@ -11291,10 +11537,28 @@ input:checked + .switch--dot-transparent::after{
 .color-black-on-active.is-active:hover{
   color:#000 !important;
 }
+
+.color-transparent-on-hover:hover,
+.color-transparent-on-active.is-active,
+.color-transparent-on-active.is-active:hover{
+  color:transparent !important;
+}
 .border--gray-dark-on-hover:hover,
 .border--gray-dark-on-active.is-active,
 .border--gray-dark-on-active.is-active:hover{
   border-color:#2d2d2d !important;
+}
+
+.border--gray-on-hover:hover,
+.border--gray-on-active.is-active,
+.border--gray-on-active.is-active:hover{
+  border-color:#666 !important;
+}
+
+.border--gray-light-on-hover:hover,
+.border--gray-light-on-active.is-active,
+.border--gray-light-on-active.is-active:hover{
+  border-color:#ccc !important;
 }
 
 .border--gray-faint-on-hover:hover,
@@ -11309,6 +11573,18 @@ input:checked + .switch--dot-transparent::after{
   border-color:#ab084b !important;
 }
 
+.border--pink-on-hover:hover,
+.border--pink-on-active.is-active,
+.border--pink-on-active.is-active:hover{
+  border-color:#ff3c96 !important;
+}
+
+.border--pink-light-on-hover:hover,
+.border--pink-light-on-active.is-active,
+.border--pink-light-on-active.is-active:hover{
+  border-color:#ff88c0 !important;
+}
+
 .border--pink-faint-on-hover:hover,
 .border--pink-faint-on-active.is-active,
 .border--pink-faint-on-active.is-active:hover{
@@ -11319,6 +11595,18 @@ input:checked + .switch--dot-transparent::after{
 .border--red-dark-on-active.is-active,
 .border--red-dark-on-active.is-active:hover{
   border-color:#a30003 !important;
+}
+
+.border--red-on-hover:hover,
+.border--red-on-active.is-active,
+.border--red-on-active.is-active:hover{
+  border-color:#dc2b28 !important;
+}
+
+.border--red-light-on-hover:hover,
+.border--red-light-on-active.is-active,
+.border--red-light-on-active.is-active:hover{
+  border-color:#ff8280 !important;
 }
 
 .border--red-faint-on-hover:hover,
@@ -11333,6 +11621,18 @@ input:checked + .switch--dot-transparent::after{
   border-color:#bc3a00 !important;
 }
 
+.border--orange-on-hover:hover,
+.border--orange-on-active.is-active,
+.border--orange-on-active.is-active:hover{
+  border-color:#ff6e00 !important;
+}
+
+.border--orange-light-on-hover:hover,
+.border--orange-light-on-active.is-active,
+.border--orange-light-on-active.is-active:hover{
+  border-color:#ffa950 !important;
+}
+
 .border--orange-faint-on-hover:hover,
 .border--orange-faint-on-active.is-active,
 .border--orange-faint-on-active.is-active:hover{
@@ -11343,6 +11643,18 @@ input:checked + .switch--dot-transparent::after{
 .border--yellow-dark-on-active.is-active,
 .border--yellow-dark-on-active.is-active:hover{
   border-color:#d9a100 !important;
+}
+
+.border--yellow-on-hover:hover,
+.border--yellow-on-active.is-active,
+.border--yellow-on-active.is-active:hover{
+  border-color:#f0dc00 !important;
+}
+
+.border--yellow-light-on-hover:hover,
+.border--yellow-light-on-active.is-active,
+.border--yellow-light-on-active.is-active:hover{
+  border-color:#f0f062 !important;
 }
 
 .border--yellow-faint-on-hover:hover,
@@ -11357,6 +11669,18 @@ input:checked + .switch--dot-transparent::after{
   border-color:#006427 !important;
 }
 
+.border--green-on-hover:hover,
+.border--green-on-active.is-active,
+.border--green-on-active.is-active:hover{
+  border-color:#01aa46 !important;
+}
+
+.border--green-light-on-hover:hover,
+.border--green-light-on-active.is-active,
+.border--green-light-on-active.is-active:hover{
+  border-color:#72c781 !important;
+}
+
 .border--green-faint-on-hover:hover,
 .border--green-faint-on-active.is-active,
 .border--green-faint-on-active.is-active:hover{
@@ -11367,6 +11691,18 @@ input:checked + .switch--dot-transparent::after{
 .border--blue-dark-on-active.is-active,
 .border--blue-dark-on-active.is-active:hover{
   border-color:#223B53 !important;
+}
+
+.border--blue-on-hover:hover,
+.border--blue-on-active.is-active,
+.border--blue-on-active.is-active:hover{
+  border-color:#3887BE !important;
+}
+
+.border--blue-light-on-hover:hover,
+.border--blue-light-on-active.is-active,
+.border--blue-light-on-active.is-active:hover{
+  border-color:#52A1D8 !important;
 }
 
 .border--blue-faint-on-hover:hover,
@@ -11381,16 +11717,88 @@ input:checked + .switch--dot-transparent::after{
   border-color:#440067 !important;
 }
 
+.border--purple-on-hover:hover,
+.border--purple-on-active.is-active,
+.border--purple-on-active.is-active:hover{
+  border-color:#8c50c7 !important;
+}
+
+.border--purple-light-on-hover:hover,
+.border--purple-light-on-active.is-active,
+.border--purple-light-on-active.is-active:hover{
+  border-color:#c299e3 !important;
+}
+
 .border--purple-faint-on-hover:hover,
 .border--purple-faint-on-active.is-active,
 .border--purple-faint-on-active.is-active:hover{
   border-color:#ede1f6 !important;
 }
 
+.border--darken10-on-hover:hover,
+.border--darken10-on-active.is-active,
+.border--darken10-on-active.is-active:hover{
+  border-color:rgba(0, 0, 0, 0.1) !important;
+}
+
+.border--darken25-on-hover:hover,
+.border--darken25-on-active.is-active,
+.border--darken25-on-active.is-active:hover{
+  border-color:rgba(0, 0, 0, 0.25) !important;
+}
+
+.border--darken50-on-hover:hover,
+.border--darken50-on-active.is-active,
+.border--darken50-on-active.is-active:hover{
+  border-color:rgba(0, 0, 0, 0.5) !important;
+}
+
+.border--darken75-on-hover:hover,
+.border--darken75-on-active.is-active,
+.border--darken75-on-active.is-active:hover{
+  border-color:rgba(0, 0, 0, 0.75) !important;
+}
+
+.border--lighten10-on-hover:hover,
+.border--lighten10-on-active.is-active,
+.border--lighten10-on-active.is-active:hover{
+  border-color:rgba(255, 255, 255, 0.1) !important;
+}
+
+.border--lighten25-on-hover:hover,
+.border--lighten25-on-active.is-active,
+.border--lighten25-on-active.is-active:hover{
+  border-color:rgba(255, 255, 255, 0.25) !important;
+}
+
+.border--lighten50-on-hover:hover,
+.border--lighten50-on-active.is-active,
+.border--lighten50-on-active.is-active:hover{
+  border-color:rgba(255, 255, 255, 0.5) !important;
+}
+
+.border--lighten75-on-hover:hover,
+.border--lighten75-on-active.is-active,
+.border--lighten75-on-active.is-active:hover{
+  border-color:rgba(255, 255, 255, 0.75) !important;
+}
+
+.border--white-on-hover:hover,
+.border--white-on-active.is-active,
+.border--white-on-active.is-active:hover{
+  border-color:#fff !important;
+}
+
 .border--black-on-hover:hover,
 .border--black-on-active.is-active,
 .border--black-on-active.is-active:hover{
   border-color:#000 !important;
+}
+
+.border--transparent-on-hover:hover,
+.border--transparent-on-active.is-active,
+.border--transparent-on-active.is-active:hover{
+  border-color:transparent !important;
 }
 
 @media screen and (min-width: 640px){
@@ -23918,6 +24326,18 @@ input:checked + .switch--dot-transparent::after{
   background-color:#2d2d2d !important;
 }
 
+.bg-gray-on-hover:hover,
+.bg-gray-on-active.is-active,
+.bg-gray-on-active.is-active:hover{
+  background-color:#666 !important;
+}
+
+.bg-gray-light-on-hover:hover,
+.bg-gray-light-on-active.is-active,
+.bg-gray-light-on-active.is-active:hover{
+  background-color:#ccc !important;
+}
+
 .bg-gray-faint-on-hover:hover,
 .bg-gray-faint-on-active.is-active,
 .bg-gray-faint-on-active.is-active:hover{
@@ -23928,6 +24348,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-pink-dark-on-active.is-active,
 .bg-pink-dark-on-active.is-active:hover{
   background-color:#ab084b !important;
+}
+
+.bg-pink-on-hover:hover,
+.bg-pink-on-active.is-active,
+.bg-pink-on-active.is-active:hover{
+  background-color:#ff3c96 !important;
+}
+
+.bg-pink-light-on-hover:hover,
+.bg-pink-light-on-active.is-active,
+.bg-pink-light-on-active.is-active:hover{
+  background-color:#ff88c0 !important;
 }
 
 .bg-pink-faint-on-hover:hover,
@@ -23942,6 +24374,18 @@ input:checked + .switch--dot-transparent::after{
   background-color:#a30003 !important;
 }
 
+.bg-red-on-hover:hover,
+.bg-red-on-active.is-active,
+.bg-red-on-active.is-active:hover{
+  background-color:#dc2b28 !important;
+}
+
+.bg-red-light-on-hover:hover,
+.bg-red-light-on-active.is-active,
+.bg-red-light-on-active.is-active:hover{
+  background-color:#ff8280 !important;
+}
+
 .bg-red-faint-on-hover:hover,
 .bg-red-faint-on-active.is-active,
 .bg-red-faint-on-active.is-active:hover{
@@ -23952,6 +24396,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-orange-dark-on-active.is-active,
 .bg-orange-dark-on-active.is-active:hover{
   background-color:#bc3a00 !important;
+}
+
+.bg-orange-on-hover:hover,
+.bg-orange-on-active.is-active,
+.bg-orange-on-active.is-active:hover{
+  background-color:#ff6e00 !important;
+}
+
+.bg-orange-light-on-hover:hover,
+.bg-orange-light-on-active.is-active,
+.bg-orange-light-on-active.is-active:hover{
+  background-color:#ffa950 !important;
 }
 
 .bg-orange-faint-on-hover:hover,
@@ -23966,6 +24422,18 @@ input:checked + .switch--dot-transparent::after{
   background-color:#d9a100 !important;
 }
 
+.bg-yellow-on-hover:hover,
+.bg-yellow-on-active.is-active,
+.bg-yellow-on-active.is-active:hover{
+  background-color:#f0dc00 !important;
+}
+
+.bg-yellow-light-on-hover:hover,
+.bg-yellow-light-on-active.is-active,
+.bg-yellow-light-on-active.is-active:hover{
+  background-color:#f0f062 !important;
+}
+
 .bg-yellow-faint-on-hover:hover,
 .bg-yellow-faint-on-active.is-active,
 .bg-yellow-faint-on-active.is-active:hover{
@@ -23976,6 +24444,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-green-dark-on-active.is-active,
 .bg-green-dark-on-active.is-active:hover{
   background-color:#006427 !important;
+}
+
+.bg-green-on-hover:hover,
+.bg-green-on-active.is-active,
+.bg-green-on-active.is-active:hover{
+  background-color:#01aa46 !important;
+}
+
+.bg-green-light-on-hover:hover,
+.bg-green-light-on-active.is-active,
+.bg-green-light-on-active.is-active:hover{
+  background-color:#72c781 !important;
 }
 
 .bg-green-faint-on-hover:hover,
@@ -23990,6 +24470,18 @@ input:checked + .switch--dot-transparent::after{
   background-color:#295b97 !important;
 }
 
+.bg-blue-on-hover:hover,
+.bg-blue-on-active.is-active,
+.bg-blue-on-active.is-active:hover{
+  background-color:#448ee4 !important;
+}
+
+.bg-blue-light-on-hover:hover,
+.bg-blue-light-on-active.is-active,
+.bg-blue-light-on-active.is-active:hover{
+  background-color:#00b1ff !important;
+}
+
 .bg-blue-faint-on-hover:hover,
 .bg-blue-faint-on-active.is-active,
 .bg-blue-faint-on-active.is-active:hover{
@@ -24000,6 +24492,18 @@ input:checked + .switch--dot-transparent::after{
 .bg-purple-dark-on-active.is-active,
 .bg-purple-dark-on-active.is-active:hover{
   background-color:#440067 !important;
+}
+
+.bg-purple-on-hover:hover,
+.bg-purple-on-active.is-active,
+.bg-purple-on-active.is-active:hover{
+  background-color:#8c50c7 !important;
+}
+
+.bg-purple-light-on-hover:hover,
+.bg-purple-light-on-active.is-active,
+.bg-purple-light-on-active.is-active:hover{
+  background-color:#c299e3 !important;
 }
 
 .bg-purple-faint-on-hover:hover,
@@ -24014,10 +24518,64 @@ input:checked + .switch--dot-transparent::after{
   background-color:rgba(0, 0, 0, 0.05) !important;
 }
 
+.bg-darken10-on-hover:hover,
+.bg-darken10-on-active.is-active,
+.bg-darken10-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.1) !important;
+}
+
+.bg-darken25-on-hover:hover,
+.bg-darken25-on-active.is-active,
+.bg-darken25-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.25) !important;
+}
+
+.bg-darken50-on-hover:hover,
+.bg-darken50-on-active.is-active,
+.bg-darken50-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.5) !important;
+}
+
+.bg-darken75-on-hover:hover,
+.bg-darken75-on-active.is-active,
+.bg-darken75-on-active.is-active:hover{
+  background-color:rgba(0, 0, 0, 0.75) !important;
+}
+
 .bg-lighten5-on-hover:hover,
 .bg-lighten5-on-active.is-active,
 .bg-lighten5-on-active.is-active:hover{
   background-color:rgba(255, 255, 255, 0.05) !important;
+}
+
+.bg-lighten10-on-hover:hover,
+.bg-lighten10-on-active.is-active,
+.bg-lighten10-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.1) !important;
+}
+
+.bg-lighten25-on-hover:hover,
+.bg-lighten25-on-active.is-active,
+.bg-lighten25-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.25) !important;
+}
+
+.bg-lighten50-on-hover:hover,
+.bg-lighten50-on-active.is-active,
+.bg-lighten50-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.5) !important;
+}
+
+.bg-lighten75-on-hover:hover,
+.bg-lighten75-on-active.is-active,
+.bg-lighten75-on-active.is-active:hover{
+  background-color:rgba(255, 255, 255, 0.75) !important;
+}
+
+.bg-white-on-hover:hover,
+.bg-white-on-active.is-active,
+.bg-white-on-active.is-active:hover{
+  background-color:#fff !important;
 }
 
 .bg-black-on-hover:hover,
@@ -24025,10 +24583,22 @@ input:checked + .switch--dot-transparent::after{
 .bg-black-on-active.is-active:hover{
   background-color:#000 !important;
 }
+
+.bg-transparent-on-hover:hover,
+.bg-transparent-on-active.is-active,
+.bg-transparent-on-active.is-active:hover{
+  background-color:transparent !important;
+}
 .color-gray-dark-on-hover:hover,
 .color-gray-dark-on-active.is-active,
 .color-gray-dark-on-active.is-active:hover{
   color:#2d2d2d !important;
+}
+
+.color-gray-on-hover:hover,
+.color-gray-on-active.is-active,
+.color-gray-on-active.is-active:hover{
+  color:#666 !important;
 }
 
 .color-gray-light-on-hover:hover,
@@ -24049,6 +24619,12 @@ input:checked + .switch--dot-transparent::after{
   color:#ab084b !important;
 }
 
+.color-pink-on-hover:hover,
+.color-pink-on-active.is-active,
+.color-pink-on-active.is-active:hover{
+  color:#ff3c96 !important;
+}
+
 .color-pink-light-on-hover:hover,
 .color-pink-light-on-active.is-active,
 .color-pink-light-on-active.is-active:hover{
@@ -24065,6 +24641,12 @@ input:checked + .switch--dot-transparent::after{
 .color-red-dark-on-active.is-active,
 .color-red-dark-on-active.is-active:hover{
   color:#a30003 !important;
+}
+
+.color-red-on-hover:hover,
+.color-red-on-active.is-active,
+.color-red-on-active.is-active:hover{
+  color:#dc2b28 !important;
 }
 
 .color-red-light-on-hover:hover,
@@ -24085,6 +24667,12 @@ input:checked + .switch--dot-transparent::after{
   color:#bc3a00 !important;
 }
 
+.color-orange-on-hover:hover,
+.color-orange-on-active.is-active,
+.color-orange-on-active.is-active:hover{
+  color:#ff6e00 !important;
+}
+
 .color-orange-light-on-hover:hover,
 .color-orange-light-on-active.is-active,
 .color-orange-light-on-active.is-active:hover{
@@ -24101,6 +24689,12 @@ input:checked + .switch--dot-transparent::after{
 .color-yellow-dark-on-active.is-active,
 .color-yellow-dark-on-active.is-active:hover{
   color:#d9a100 !important;
+}
+
+.color-yellow-on-hover:hover,
+.color-yellow-on-active.is-active,
+.color-yellow-on-active.is-active:hover{
+  color:#f0dc00 !important;
 }
 
 .color-yellow-light-on-hover:hover,
@@ -24121,6 +24715,12 @@ input:checked + .switch--dot-transparent::after{
   color:#006427 !important;
 }
 
+.color-green-on-hover:hover,
+.color-green-on-active.is-active,
+.color-green-on-active.is-active:hover{
+  color:#01aa46 !important;
+}
+
 .color-green-light-on-hover:hover,
 .color-green-light-on-active.is-active,
 .color-green-light-on-active.is-active:hover{
@@ -24137,6 +24737,12 @@ input:checked + .switch--dot-transparent::after{
 .color-blue-dark-on-active.is-active,
 .color-blue-dark-on-active.is-active:hover{
   color:#295b97 !important;
+}
+
+.color-blue-on-hover:hover,
+.color-blue-on-active.is-active,
+.color-blue-on-active.is-active:hover{
+  color:#448ee4 !important;
 }
 
 .color-blue-light-on-hover:hover,
@@ -24157,6 +24763,12 @@ input:checked + .switch--dot-transparent::after{
   color:#440067 !important;
 }
 
+.color-purple-on-hover:hover,
+.color-purple-on-active.is-active,
+.color-purple-on-active.is-active:hover{
+  color:#8c50c7 !important;
+}
+
 .color-purple-light-on-hover:hover,
 .color-purple-light-on-active.is-active,
 .color-purple-light-on-active.is-active:hover{
@@ -24175,10 +24787,52 @@ input:checked + .switch--dot-transparent::after{
   color:rgba(0, 0, 0, 0.1) !important;
 }
 
+.color-darken25-on-hover:hover,
+.color-darken25-on-active.is-active,
+.color-darken25-on-active.is-active:hover{
+  color:rgba(0, 0, 0, 0.25) !important;
+}
+
+.color-darken50-on-hover:hover,
+.color-darken50-on-active.is-active,
+.color-darken50-on-active.is-active:hover{
+  color:rgba(0, 0, 0, 0.5) !important;
+}
+
+.color-darken75-on-hover:hover,
+.color-darken75-on-active.is-active,
+.color-darken75-on-active.is-active:hover{
+  color:rgba(0, 0, 0, 0.75) !important;
+}
+
 .color-lighten10-on-hover:hover,
 .color-lighten10-on-active.is-active,
 .color-lighten10-on-active.is-active:hover{
   color:rgba(255, 255, 255, 0.1) !important;
+}
+
+.color-lighten25-on-hover:hover,
+.color-lighten25-on-active.is-active,
+.color-lighten25-on-active.is-active:hover{
+  color:rgba(255, 255, 255, 0.25) !important;
+}
+
+.color-lighten50-on-hover:hover,
+.color-lighten50-on-active.is-active,
+.color-lighten50-on-active.is-active:hover{
+  color:rgba(255, 255, 255, 0.5) !important;
+}
+
+.color-lighten75-on-hover:hover,
+.color-lighten75-on-active.is-active,
+.color-lighten75-on-active.is-active:hover{
+  color:rgba(255, 255, 255, 0.75) !important;
+}
+
+.color-white-on-hover:hover,
+.color-white-on-active.is-active,
+.color-white-on-active.is-active:hover{
+  color:#fff !important;
 }
 
 .color-black-on-hover:hover,
@@ -24186,10 +24840,28 @@ input:checked + .switch--dot-transparent::after{
 .color-black-on-active.is-active:hover{
   color:#000 !important;
 }
+
+.color-transparent-on-hover:hover,
+.color-transparent-on-active.is-active,
+.color-transparent-on-active.is-active:hover{
+  color:transparent !important;
+}
 .border--gray-dark-on-hover:hover,
 .border--gray-dark-on-active.is-active,
 .border--gray-dark-on-active.is-active:hover{
   border-color:#2d2d2d !important;
+}
+
+.border--gray-on-hover:hover,
+.border--gray-on-active.is-active,
+.border--gray-on-active.is-active:hover{
+  border-color:#666 !important;
+}
+
+.border--gray-light-on-hover:hover,
+.border--gray-light-on-active.is-active,
+.border--gray-light-on-active.is-active:hover{
+  border-color:#ccc !important;
 }
 
 .border--gray-faint-on-hover:hover,
@@ -24204,6 +24876,18 @@ input:checked + .switch--dot-transparent::after{
   border-color:#ab084b !important;
 }
 
+.border--pink-on-hover:hover,
+.border--pink-on-active.is-active,
+.border--pink-on-active.is-active:hover{
+  border-color:#ff3c96 !important;
+}
+
+.border--pink-light-on-hover:hover,
+.border--pink-light-on-active.is-active,
+.border--pink-light-on-active.is-active:hover{
+  border-color:#ff88c0 !important;
+}
+
 .border--pink-faint-on-hover:hover,
 .border--pink-faint-on-active.is-active,
 .border--pink-faint-on-active.is-active:hover{
@@ -24214,6 +24898,18 @@ input:checked + .switch--dot-transparent::after{
 .border--red-dark-on-active.is-active,
 .border--red-dark-on-active.is-active:hover{
   border-color:#a30003 !important;
+}
+
+.border--red-on-hover:hover,
+.border--red-on-active.is-active,
+.border--red-on-active.is-active:hover{
+  border-color:#dc2b28 !important;
+}
+
+.border--red-light-on-hover:hover,
+.border--red-light-on-active.is-active,
+.border--red-light-on-active.is-active:hover{
+  border-color:#ff8280 !important;
 }
 
 .border--red-faint-on-hover:hover,
@@ -24228,6 +24924,18 @@ input:checked + .switch--dot-transparent::after{
   border-color:#bc3a00 !important;
 }
 
+.border--orange-on-hover:hover,
+.border--orange-on-active.is-active,
+.border--orange-on-active.is-active:hover{
+  border-color:#ff6e00 !important;
+}
+
+.border--orange-light-on-hover:hover,
+.border--orange-light-on-active.is-active,
+.border--orange-light-on-active.is-active:hover{
+  border-color:#ffa950 !important;
+}
+
 .border--orange-faint-on-hover:hover,
 .border--orange-faint-on-active.is-active,
 .border--orange-faint-on-active.is-active:hover{
@@ -24238,6 +24946,18 @@ input:checked + .switch--dot-transparent::after{
 .border--yellow-dark-on-active.is-active,
 .border--yellow-dark-on-active.is-active:hover{
   border-color:#d9a100 !important;
+}
+
+.border--yellow-on-hover:hover,
+.border--yellow-on-active.is-active,
+.border--yellow-on-active.is-active:hover{
+  border-color:#f0dc00 !important;
+}
+
+.border--yellow-light-on-hover:hover,
+.border--yellow-light-on-active.is-active,
+.border--yellow-light-on-active.is-active:hover{
+  border-color:#f0f062 !important;
 }
 
 .border--yellow-faint-on-hover:hover,
@@ -24252,6 +24972,18 @@ input:checked + .switch--dot-transparent::after{
   border-color:#006427 !important;
 }
 
+.border--green-on-hover:hover,
+.border--green-on-active.is-active,
+.border--green-on-active.is-active:hover{
+  border-color:#01aa46 !important;
+}
+
+.border--green-light-on-hover:hover,
+.border--green-light-on-active.is-active,
+.border--green-light-on-active.is-active:hover{
+  border-color:#72c781 !important;
+}
+
 .border--green-faint-on-hover:hover,
 .border--green-faint-on-active.is-active,
 .border--green-faint-on-active.is-active:hover{
@@ -24262,6 +24994,18 @@ input:checked + .switch--dot-transparent::after{
 .border--blue-dark-on-active.is-active,
 .border--blue-dark-on-active.is-active:hover{
   border-color:#295b97 !important;
+}
+
+.border--blue-on-hover:hover,
+.border--blue-on-active.is-active,
+.border--blue-on-active.is-active:hover{
+  border-color:#448ee4 !important;
+}
+
+.border--blue-light-on-hover:hover,
+.border--blue-light-on-active.is-active,
+.border--blue-light-on-active.is-active:hover{
+  border-color:#00b1ff !important;
 }
 
 .border--blue-faint-on-hover:hover,
@@ -24276,16 +25020,88 @@ input:checked + .switch--dot-transparent::after{
   border-color:#440067 !important;
 }
 
+.border--purple-on-hover:hover,
+.border--purple-on-active.is-active,
+.border--purple-on-active.is-active:hover{
+  border-color:#8c50c7 !important;
+}
+
+.border--purple-light-on-hover:hover,
+.border--purple-light-on-active.is-active,
+.border--purple-light-on-active.is-active:hover{
+  border-color:#c299e3 !important;
+}
+
 .border--purple-faint-on-hover:hover,
 .border--purple-faint-on-active.is-active,
 .border--purple-faint-on-active.is-active:hover{
   border-color:#ede1f6 !important;
 }
 
+.border--darken10-on-hover:hover,
+.border--darken10-on-active.is-active,
+.border--darken10-on-active.is-active:hover{
+  border-color:rgba(0, 0, 0, 0.1) !important;
+}
+
+.border--darken25-on-hover:hover,
+.border--darken25-on-active.is-active,
+.border--darken25-on-active.is-active:hover{
+  border-color:rgba(0, 0, 0, 0.25) !important;
+}
+
+.border--darken50-on-hover:hover,
+.border--darken50-on-active.is-active,
+.border--darken50-on-active.is-active:hover{
+  border-color:rgba(0, 0, 0, 0.5) !important;
+}
+
+.border--darken75-on-hover:hover,
+.border--darken75-on-active.is-active,
+.border--darken75-on-active.is-active:hover{
+  border-color:rgba(0, 0, 0, 0.75) !important;
+}
+
+.border--lighten10-on-hover:hover,
+.border--lighten10-on-active.is-active,
+.border--lighten10-on-active.is-active:hover{
+  border-color:rgba(255, 255, 255, 0.1) !important;
+}
+
+.border--lighten25-on-hover:hover,
+.border--lighten25-on-active.is-active,
+.border--lighten25-on-active.is-active:hover{
+  border-color:rgba(255, 255, 255, 0.25) !important;
+}
+
+.border--lighten50-on-hover:hover,
+.border--lighten50-on-active.is-active,
+.border--lighten50-on-active.is-active:hover{
+  border-color:rgba(255, 255, 255, 0.5) !important;
+}
+
+.border--lighten75-on-hover:hover,
+.border--lighten75-on-active.is-active,
+.border--lighten75-on-active.is-active:hover{
+  border-color:rgba(255, 255, 255, 0.75) !important;
+}
+
+.border--white-on-hover:hover,
+.border--white-on-active.is-active,
+.border--white-on-active.is-active:hover{
+  border-color:#fff !important;
+}
+
 .border--black-on-hover:hover,
 .border--black-on-active.is-active,
 .border--black-on-active.is-active:hover{
   border-color:#000 !important;
+}
+
+.border--transparent-on-hover:hover,
+.border--transparent-on-active.is-active,
+.border--transparent-on-active.is-active:hover{
+  border-color:transparent !important;
 }
 
 @media screen and (min-width: 640px){


### PR DESCRIPTION
@dasulit we had some faulty logic in assembly that was generating the wrong color variants for hoverBorder, hoverColor, and hoverBackground.

This branch is a little larger, but this is expected and good:
CSS: 185 kB (minified) => 22.9 kB (gzipped)

dev-pages:
CSS: 176 kB (minified) => 22.2 kB (gzipped)
