### PR TITLE
Fix align-t align-b example

### DIFF
--- a/src/typography.css
+++ b/src/typography.css
@@ -709,7 +709,7 @@ textarea {
  * @example
  * <div>
  *   <span class='align-t inline-block h12 w12 border border--gray'></span>
- *   <span class='align-t inline-block h60 border border--gray'>align-top</span>
+ *   <span class='align-t inline-block h60 border border--gray'>align-t</span>
  * </div>
  * <div class='mt3'>
  *   <span class='align-middle inline-block h12 w12 border'></span>
@@ -717,7 +717,7 @@ textarea {
  * </div>
  * <div>
  *   <span class='align-b inline-block h12 w12 border border--gray'></span>
- *   <span class='align-b inline-block h60 border border--gray'>align-top</span>
+ *   <span class='align-b inline-block h60 border border--gray'>align-b</span>
  * </div>
  */
 .align-t { vertical-align: top !important; }


### PR DESCRIPTION
Minor fix to an example.

Before (first and last examples are labelled "align-top"):

<img width="527" alt="screen shot 2017-07-18 at 11 49 11" src="https://user-images.githubusercontent.com/8495845/28327977-02381b8e-6bb3-11e7-9808-37e2a2f057b1.png">

After (first and last examples are respectively labelled "align-t" and "align-b"):

<img width="513" alt="screen shot 2017-07-18 at 12 12 40" src="https://user-images.githubusercontent.com/8495845/28328000-13fc9a0c-6bb3-11e7-87f6-677fde520a95.png">