### PR TITLE
Specify npm version 5 for publisher

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "npm run lint && npm run test:svgs && npm run test:jest && npm run build:site"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=4",
+    "npm": "^5.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Now that we're using npm version 5, publisher needs to know about it. https://github.com/mapbox/publisher#upgrading-npm

@davidtheclark Review?