### PR TITLE
[breaking] address a variety of form related issues

### DIFF
--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -229,12 +229,12 @@ function buildColorVariants(variables, config) {
       return (result += stripIndent(`
         .textarea--border-${color},
         .input--border-${color} {
-          border-color: var(--${color});
+          box-shadow: inset 0 0 0 1px var(--${color});
         }
 
         .textarea--border-${color}:focus,
         .input--border-${color}:focus {
-          border-color: var(--${darkerShade});
+          box-shadow: inset 0 0 0 1px var(--${darkerShade});
         }
       `));
     }, '');
@@ -243,22 +243,13 @@ function buildColorVariants(variables, config) {
   variantGenerators.checkbox = function(colors) {
     return colors.reduce((result, color) => {
       if (isNotAccessibleForForms(color)) return result;
-      const darkerShade = getDarkerShade(color);
       return (result += stripIndent(`
         .checkbox--${color} {
           border-color: var(--${color});
         }
 
-        .checkbox-container:hover > .checkbox--${color} {
-          border-color: var(--${darkerShade});
-        }
-
         input:checked + .checkbox--${color} {
           background-color: var(--${color});
-        }
-
-        .checkbox-container:hover > input:checked + .checkbox--${color} {
-          background-color: var(--${darkerShade});
         }
       `));
     }, '');
@@ -267,15 +258,10 @@ function buildColorVariants(variables, config) {
   variantGenerators.radio = function(colors) {
     return colors.reduce((result, color) => {
       if (isNotAccessibleForForms(color)) return result;
-      const darkerShade = getDarkerShade(color);
       return (result += stripIndent(`
         .radio--${color},
         input:checked + .radio--${color} {
           color: var(--${color});
-        }
-
-        .radio-container:hover > .radio--${color} {
-          color: var(--${darkerShade});
         }
       `));
     }, '');
@@ -284,7 +270,6 @@ function buildColorVariants(variables, config) {
   variantGenerators.toggle = function(colors) {
     return colors.reduce((result, color) => {
       if (isNotAccessibleForForms(color)) return result;
-      const darkerShade = getDarkerShade(color);
       // Set the text color to regular when inactive.
       // Set the text color to dark when inactive on hover.
       // Set the background color to regular and text color to white when active.
@@ -292,10 +277,6 @@ function buildColorVariants(variables, config) {
       return (result += stripIndent(`
         .toggle--${color} {
           color: var(--${color});
-        }
-
-        .toggle--${color}:hover {
-          color: var(--${darkerShade});
         }
 
         input:checked + .toggle--${color} {
@@ -328,17 +309,8 @@ function buildColorVariants(variables, config) {
           color: var(--${color});
         }
 
-        .switch-container:hover > .switch--${color} {
-          color: var(--${darkerShade});
-        }
-
-        .switch--${color}:hover::after,
         input:checked + .switch--${color} {
           background-color: var(--${darkerShade});
-        }
-
-        .switch-container:hover > input:checked + .switch--${color} {
-          background-color: var(--${color});
         }
 
         input:checked + .switch--dot-${color}::after {
@@ -351,12 +323,10 @@ function buildColorVariants(variables, config) {
   variantGenerators.range = function(colors) {
     return colors.reduce((result, color) => {
       if (isNotAccessibleForForms(color)) return result;
-      const darkerShade = getDarkerShade(color);
 
       // Set the thumb color.
       return (result += stripIndent(`
         .range--${color} > input { color: var(--${color}); }
-        .range--${color}:hover > input { color: var(--${darkerShade}); }
       `));
     }, '');
   };

--- a/src/buttons.css
+++ b/src/buttons.css
@@ -27,11 +27,11 @@
  */
 .btn {
   display: inline-block;
+  font-weight: bold;
   background-color: var(--default-primary-interactive-color);
   color: var(--white);
   border-radius: 18px; /* fully round by default */
   padding: 6px 12px;
-  font-weight: bold;
   text-align: center;
   transition: background-color var(--transition),
     border-color var(--transition),
@@ -77,8 +77,9 @@
  * <button class='btn btn--s'>Small</button>
  */
 .btn--s {
-  font-size: 12px;
-  padding: 0 12px;
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
+  padding: 3px 12px;
   border-radius: 15px;
 }
 
@@ -90,8 +91,8 @@
  * <button class='btn btn--xs'>Extra small</button>
  */
 .btn--xs {
-  line-height: 18px;
-  font-size: 10px;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
   padding: 0 6px;
   border-radius: 14px;
 }

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -805,418 +805,290 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-gray,
 .input--border-gray {
-  border-color: var(--gray);
+  box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus {
-  border-color: var(--gray-dark);
+  box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
 .input--border-pink {
-  border-color: var(--pink);
+  box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus {
-  border-color: var(--pink-dark);
+  box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
 .input--border-red {
-  border-color: var(--red);
+  box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus {
-  border-color: var(--red-dark);
+  box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
 .input--border-orange {
-  border-color: var(--orange);
+  box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus {
-  border-color: var(--orange-dark);
+  box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
 .input--border-yellow {
-  border-color: var(--yellow);
+  box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus {
-  border-color: var(--yellow-dark);
+  box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
 .input--border-green {
-  border-color: var(--green);
+  box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus {
-  border-color: var(--green-dark);
+  box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
 .input--border-blue {
-  border-color: var(--blue);
+  box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus {
-  border-color: var(--blue-dark);
+  box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
 .input--border-purple {
-  border-color: var(--purple);
+  box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus {
-  border-color: var(--purple-dark);
+  box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
 .input--border-darken25 {
-  border-color: var(--darken25);
+  box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus {
-  border-color: var(--darken50);
+  box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
 .input--border-darken50 {
-  border-color: var(--darken50);
+  box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus {
-  border-color: var(--darken75);
+  box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75 {
-  border-color: var(--darken75);
+  box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus {
-  border-color: var(--black);
+  box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25 {
-  border-color: var(--lighten25);
+  box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus {
-  border-color: var(--lighten50);
+  box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50 {
-  border-color: var(--lighten50);
+  box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75 {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus {
-  border-color: var(--white);
+  box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
 .input--border-white {
-  border-color: var(--white);
+  box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent {
-  border-color: var(--transparent);
+  box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus {
-  border-color: var(--darken10);
+  box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
 .checkbox--gray {
   border-color: var(--gray);
 }
 
-.checkbox-container:hover > .checkbox--gray {
-  border-color: var(--gray-dark);
-}
-
 input:checked + .checkbox--gray {
   background-color: var(--gray);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--gray {
-  background-color: var(--gray-dark);
 }
 
 .checkbox--pink {
   border-color: var(--pink);
 }
 
-.checkbox-container:hover > .checkbox--pink {
-  border-color: var(--pink-dark);
-}
-
 input:checked + .checkbox--pink {
   background-color: var(--pink);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--pink {
-  background-color: var(--pink-dark);
 }
 
 .checkbox--red {
   border-color: var(--red);
 }
 
-.checkbox-container:hover > .checkbox--red {
-  border-color: var(--red-dark);
-}
-
 input:checked + .checkbox--red {
   background-color: var(--red);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--red {
-  background-color: var(--red-dark);
 }
 
 .checkbox--orange {
   border-color: var(--orange);
 }
 
-.checkbox-container:hover > .checkbox--orange {
-  border-color: var(--orange-dark);
-}
-
 input:checked + .checkbox--orange {
   background-color: var(--orange);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--orange {
-  background-color: var(--orange-dark);
 }
 
 .checkbox--yellow {
   border-color: var(--yellow);
 }
 
-.checkbox-container:hover > .checkbox--yellow {
-  border-color: var(--yellow-dark);
-}
-
 input:checked + .checkbox--yellow {
   background-color: var(--yellow);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--yellow {
-  background-color: var(--yellow-dark);
 }
 
 .checkbox--green {
   border-color: var(--green);
 }
 
-.checkbox-container:hover > .checkbox--green {
-  border-color: var(--green-dark);
-}
-
 input:checked + .checkbox--green {
   background-color: var(--green);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--green {
-  background-color: var(--green-dark);
 }
 
 .checkbox--blue {
   border-color: var(--blue);
 }
 
-.checkbox-container:hover > .checkbox--blue {
-  border-color: var(--blue-dark);
-}
-
 input:checked + .checkbox--blue {
   background-color: var(--blue);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--blue {
-  background-color: var(--blue-dark);
 }
 
 .checkbox--purple {
   border-color: var(--purple);
 }
 
-.checkbox-container:hover > .checkbox--purple {
-  border-color: var(--purple-dark);
-}
-
 input:checked + .checkbox--purple {
   background-color: var(--purple);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--purple {
-  background-color: var(--purple-dark);
 }
 
 .checkbox--darken25 {
   border-color: var(--darken25);
 }
 
-.checkbox-container:hover > .checkbox--darken25 {
-  border-color: var(--darken50);
-}
-
 input:checked + .checkbox--darken25 {
   background-color: var(--darken25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken25 {
-  background-color: var(--darken50);
 }
 
 .checkbox--darken50 {
   border-color: var(--darken50);
 }
 
-.checkbox-container:hover > .checkbox--darken50 {
-  border-color: var(--darken75);
-}
-
 input:checked + .checkbox--darken50 {
   background-color: var(--darken50);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken50 {
-  background-color: var(--darken75);
 }
 
 .checkbox--darken75 {
   border-color: var(--darken75);
 }
 
-.checkbox-container:hover > .checkbox--darken75 {
-  border-color: var(--black);
-}
-
 input:checked + .checkbox--darken75 {
   background-color: var(--darken75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken75 {
-  background-color: var(--black);
 }
 
 .checkbox--lighten25 {
   border-color: var(--lighten25);
 }
 
-.checkbox-container:hover > .checkbox--lighten25 {
-  border-color: var(--lighten50);
-}
-
 input:checked + .checkbox--lighten25 {
   background-color: var(--lighten25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten25 {
-  background-color: var(--lighten50);
 }
 
 .checkbox--lighten50 {
   border-color: var(--lighten50);
 }
 
-.checkbox-container:hover > .checkbox--lighten50 {
-  border-color: var(--lighten75);
-}
-
 input:checked + .checkbox--lighten50 {
   background-color: var(--lighten50);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten50 {
-  background-color: var(--lighten75);
 }
 
 .checkbox--lighten75 {
   border-color: var(--lighten75);
 }
 
-.checkbox-container:hover > .checkbox--lighten75 {
-  border-color: var(--white);
-}
-
 input:checked + .checkbox--lighten75 {
   background-color: var(--lighten75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten75 {
-  background-color: var(--white);
 }
 
 .checkbox--white {
   border-color: var(--white);
 }
 
-.checkbox-container:hover > .checkbox--white {
-  border-color: var(--lighten75);
-}
-
 input:checked + .checkbox--white {
   background-color: var(--white);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--white {
-  background-color: var(--lighten75);
 }
 
 .checkbox--transparent {
   border-color: var(--transparent);
 }
 
-.checkbox-container:hover > .checkbox--transparent {
-  border-color: var(--darken10);
-}
-
 input:checked + .checkbox--transparent {
   background-color: var(--transparent);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--transparent {
-  background-color: var(--darken10);
 }
 
 .radio--gray,
@@ -1224,17 +1096,9 @@ input:checked + .radio--gray {
   color: var(--gray);
 }
 
-.radio-container:hover > .radio--gray {
-  color: var(--gray-dark);
-}
-
 .radio--pink,
 input:checked + .radio--pink {
   color: var(--pink);
-}
-
-.radio-container:hover > .radio--pink {
-  color: var(--pink-dark);
 }
 
 .radio--red,
@@ -1242,17 +1106,9 @@ input:checked + .radio--red {
   color: var(--red);
 }
 
-.radio-container:hover > .radio--red {
-  color: var(--red-dark);
-}
-
 .radio--orange,
 input:checked + .radio--orange {
   color: var(--orange);
-}
-
-.radio-container:hover > .radio--orange {
-  color: var(--orange-dark);
 }
 
 .radio--yellow,
@@ -1260,17 +1116,9 @@ input:checked + .radio--yellow {
   color: var(--yellow);
 }
 
-.radio-container:hover > .radio--yellow {
-  color: var(--yellow-dark);
-}
-
 .radio--green,
 input:checked + .radio--green {
   color: var(--green);
-}
-
-.radio-container:hover > .radio--green {
-  color: var(--green-dark);
 }
 
 .radio--blue,
@@ -1278,17 +1126,9 @@ input:checked + .radio--blue {
   color: var(--blue);
 }
 
-.radio-container:hover > .radio--blue {
-  color: var(--blue-dark);
-}
-
 .radio--purple,
 input:checked + .radio--purple {
   color: var(--purple);
-}
-
-.radio-container:hover > .radio--purple {
-  color: var(--purple-dark);
 }
 
 .radio--darken25,
@@ -1296,17 +1136,9 @@ input:checked + .radio--darken25 {
   color: var(--darken25);
 }
 
-.radio-container:hover > .radio--darken25 {
-  color: var(--darken50);
-}
-
 .radio--darken50,
 input:checked + .radio--darken50 {
   color: var(--darken50);
-}
-
-.radio-container:hover > .radio--darken50 {
-  color: var(--darken75);
 }
 
 .radio--darken75,
@@ -1314,17 +1146,9 @@ input:checked + .radio--darken75 {
   color: var(--darken75);
 }
 
-.radio-container:hover > .radio--darken75 {
-  color: var(--black);
-}
-
 .radio--lighten25,
 input:checked + .radio--lighten25 {
   color: var(--lighten25);
-}
-
-.radio-container:hover > .radio--lighten25 {
-  color: var(--lighten50);
 }
 
 .radio--lighten50,
@@ -1332,17 +1156,9 @@ input:checked + .radio--lighten50 {
   color: var(--lighten50);
 }
 
-.radio-container:hover > .radio--lighten50 {
-  color: var(--lighten75);
-}
-
 .radio--lighten75,
 input:checked + .radio--lighten75 {
   color: var(--lighten75);
-}
-
-.radio-container:hover > .radio--lighten75 {
-  color: var(--white);
 }
 
 .radio--white,
@@ -1350,25 +1166,13 @@ input:checked + .radio--white {
   color: var(--white);
 }
 
-.radio-container:hover > .radio--white {
-  color: var(--lighten75);
-}
-
 .radio--transparent,
 input:checked + .radio--transparent {
   color: var(--transparent);
 }
 
-.radio-container:hover > .radio--transparent {
-  color: var(--darken10);
-}
-
 .toggle--gray {
   color: var(--gray);
-}
-
-.toggle--gray:hover {
-  color: var(--gray-dark);
 }
 
 input:checked + .toggle--gray {
@@ -1379,20 +1183,12 @@ input:checked + .toggle--gray {
   color: var(--pink);
 }
 
-.toggle--pink:hover {
-  color: var(--pink-dark);
-}
-
 input:checked + .toggle--pink {
   background: var(--pink);
 }
 
 .toggle--red {
   color: var(--red);
-}
-
-.toggle--red:hover {
-  color: var(--red-dark);
 }
 
 input:checked + .toggle--red {
@@ -1403,20 +1199,12 @@ input:checked + .toggle--red {
   color: var(--orange);
 }
 
-.toggle--orange:hover {
-  color: var(--orange-dark);
-}
-
 input:checked + .toggle--orange {
   background: var(--orange);
 }
 
 .toggle--yellow {
   color: var(--yellow);
-}
-
-.toggle--yellow:hover {
-  color: var(--yellow-dark);
 }
 
 input:checked + .toggle--yellow {
@@ -1427,20 +1215,12 @@ input:checked + .toggle--yellow {
   color: var(--green);
 }
 
-.toggle--green:hover {
-  color: var(--green-dark);
-}
-
 input:checked + .toggle--green {
   background: var(--green);
 }
 
 .toggle--blue {
   color: var(--blue);
-}
-
-.toggle--blue:hover {
-  color: var(--blue-dark);
 }
 
 input:checked + .toggle--blue {
@@ -1451,20 +1231,12 @@ input:checked + .toggle--blue {
   color: var(--purple);
 }
 
-.toggle--purple:hover {
-  color: var(--purple-dark);
-}
-
 input:checked + .toggle--purple {
   background: var(--purple);
 }
 
 .toggle--darken25 {
   color: var(--darken25);
-}
-
-.toggle--darken25:hover {
-  color: var(--darken50);
 }
 
 input:checked + .toggle--darken25 {
@@ -1475,20 +1247,12 @@ input:checked + .toggle--darken25 {
   color: var(--darken50);
 }
 
-.toggle--darken50:hover {
-  color: var(--darken75);
-}
-
 input:checked + .toggle--darken50 {
   background: var(--darken50);
 }
 
 .toggle--darken75 {
   color: var(--darken75);
-}
-
-.toggle--darken75:hover {
-  color: var(--black);
 }
 
 input:checked + .toggle--darken75 {
@@ -1499,20 +1263,12 @@ input:checked + .toggle--darken75 {
   color: var(--lighten25);
 }
 
-.toggle--lighten25:hover {
-  color: var(--lighten50);
-}
-
 input:checked + .toggle--lighten25 {
   background: var(--lighten25);
 }
 
 .toggle--lighten50 {
   color: var(--lighten50);
-}
-
-.toggle--lighten50:hover {
-  color: var(--lighten75);
 }
 
 input:checked + .toggle--lighten50 {
@@ -1523,10 +1279,6 @@ input:checked + .toggle--lighten50 {
   color: var(--lighten75);
 }
 
-.toggle--lighten75:hover {
-  color: var(--white);
-}
-
 input:checked + .toggle--lighten75 {
   background: var(--lighten75);
 }
@@ -1535,20 +1287,12 @@ input:checked + .toggle--lighten75 {
   color: var(--white);
 }
 
-.toggle--white:hover {
-  color: var(--lighten75);
-}
-
 input:checked + .toggle--white {
   background: var(--white);
 }
 
 .toggle--transparent {
   color: var(--transparent);
-}
-
-.toggle--transparent:hover {
-  color: var(--darken10);
 }
 
 input:checked + .toggle--transparent {
@@ -1623,17 +1367,8 @@ input:checked + .toggle--active-transparent {
   color: var(--gray);
 }
 
-.switch-container:hover > .switch--gray {
-  color: var(--gray-dark);
-}
-
-.switch--gray:hover::after,
 input:checked + .switch--gray {
   background-color: var(--gray-dark);
-}
-
-.switch-container:hover > input:checked + .switch--gray {
-  background-color: var(--gray);
 }
 
 input:checked + .switch--dot-gray::after {
@@ -1644,17 +1379,8 @@ input:checked + .switch--dot-gray::after {
   color: var(--pink);
 }
 
-.switch-container:hover > .switch--pink {
-  color: var(--pink-dark);
-}
-
-.switch--pink:hover::after,
 input:checked + .switch--pink {
   background-color: var(--pink-dark);
-}
-
-.switch-container:hover > input:checked + .switch--pink {
-  background-color: var(--pink);
 }
 
 input:checked + .switch--dot-pink::after {
@@ -1665,17 +1391,8 @@ input:checked + .switch--dot-pink::after {
   color: var(--red);
 }
 
-.switch-container:hover > .switch--red {
-  color: var(--red-dark);
-}
-
-.switch--red:hover::after,
 input:checked + .switch--red {
   background-color: var(--red-dark);
-}
-
-.switch-container:hover > input:checked + .switch--red {
-  background-color: var(--red);
 }
 
 input:checked + .switch--dot-red::after {
@@ -1686,17 +1403,8 @@ input:checked + .switch--dot-red::after {
   color: var(--orange);
 }
 
-.switch-container:hover > .switch--orange {
-  color: var(--orange-dark);
-}
-
-.switch--orange:hover::after,
 input:checked + .switch--orange {
   background-color: var(--orange-dark);
-}
-
-.switch-container:hover > input:checked + .switch--orange {
-  background-color: var(--orange);
 }
 
 input:checked + .switch--dot-orange::after {
@@ -1707,17 +1415,8 @@ input:checked + .switch--dot-orange::after {
   color: var(--yellow);
 }
 
-.switch-container:hover > .switch--yellow {
-  color: var(--yellow-dark);
-}
-
-.switch--yellow:hover::after,
 input:checked + .switch--yellow {
   background-color: var(--yellow-dark);
-}
-
-.switch-container:hover > input:checked + .switch--yellow {
-  background-color: var(--yellow);
 }
 
 input:checked + .switch--dot-yellow::after {
@@ -1728,17 +1427,8 @@ input:checked + .switch--dot-yellow::after {
   color: var(--green);
 }
 
-.switch-container:hover > .switch--green {
-  color: var(--green-dark);
-}
-
-.switch--green:hover::after,
 input:checked + .switch--green {
   background-color: var(--green-dark);
-}
-
-.switch-container:hover > input:checked + .switch--green {
-  background-color: var(--green);
 }
 
 input:checked + .switch--dot-green::after {
@@ -1749,17 +1439,8 @@ input:checked + .switch--dot-green::after {
   color: var(--blue);
 }
 
-.switch-container:hover > .switch--blue {
-  color: var(--blue-dark);
-}
-
-.switch--blue:hover::after,
 input:checked + .switch--blue {
   background-color: var(--blue-dark);
-}
-
-.switch-container:hover > input:checked + .switch--blue {
-  background-color: var(--blue);
 }
 
 input:checked + .switch--dot-blue::after {
@@ -1770,17 +1451,8 @@ input:checked + .switch--dot-blue::after {
   color: var(--purple);
 }
 
-.switch-container:hover > .switch--purple {
-  color: var(--purple-dark);
-}
-
-.switch--purple:hover::after,
 input:checked + .switch--purple {
   background-color: var(--purple-dark);
-}
-
-.switch-container:hover > input:checked + .switch--purple {
-  background-color: var(--purple);
 }
 
 input:checked + .switch--dot-purple::after {
@@ -1791,17 +1463,8 @@ input:checked + .switch--dot-purple::after {
   color: var(--darken25);
 }
 
-.switch-container:hover > .switch--darken25 {
-  color: var(--darken50);
-}
-
-.switch--darken25:hover::after,
 input:checked + .switch--darken25 {
   background-color: var(--darken50);
-}
-
-.switch-container:hover > input:checked + .switch--darken25 {
-  background-color: var(--darken25);
 }
 
 input:checked + .switch--dot-darken25::after {
@@ -1812,17 +1475,8 @@ input:checked + .switch--dot-darken25::after {
   color: var(--darken50);
 }
 
-.switch-container:hover > .switch--darken50 {
-  color: var(--darken75);
-}
-
-.switch--darken50:hover::after,
 input:checked + .switch--darken50 {
   background-color: var(--darken75);
-}
-
-.switch-container:hover > input:checked + .switch--darken50 {
-  background-color: var(--darken50);
 }
 
 input:checked + .switch--dot-darken50::after {
@@ -1833,17 +1487,8 @@ input:checked + .switch--dot-darken50::after {
   color: var(--darken75);
 }
 
-.switch-container:hover > .switch--darken75 {
-  color: var(--black);
-}
-
-.switch--darken75:hover::after,
 input:checked + .switch--darken75 {
   background-color: var(--black);
-}
-
-.switch-container:hover > input:checked + .switch--darken75 {
-  background-color: var(--darken75);
 }
 
 input:checked + .switch--dot-darken75::after {
@@ -1854,17 +1499,8 @@ input:checked + .switch--dot-darken75::after {
   color: var(--lighten25);
 }
 
-.switch-container:hover > .switch--lighten25 {
-  color: var(--lighten50);
-}
-
-.switch--lighten25:hover::after,
 input:checked + .switch--lighten25 {
   background-color: var(--lighten50);
-}
-
-.switch-container:hover > input:checked + .switch--lighten25 {
-  background-color: var(--lighten25);
 }
 
 input:checked + .switch--dot-lighten25::after {
@@ -1875,17 +1511,8 @@ input:checked + .switch--dot-lighten25::after {
   color: var(--lighten50);
 }
 
-.switch-container:hover > .switch--lighten50 {
-  color: var(--lighten75);
-}
-
-.switch--lighten50:hover::after,
 input:checked + .switch--lighten50 {
   background-color: var(--lighten75);
-}
-
-.switch-container:hover > input:checked + .switch--lighten50 {
-  background-color: var(--lighten50);
 }
 
 input:checked + .switch--dot-lighten50::after {
@@ -1896,17 +1523,8 @@ input:checked + .switch--dot-lighten50::after {
   color: var(--lighten75);
 }
 
-.switch-container:hover > .switch--lighten75 {
-  color: var(--white);
-}
-
-.switch--lighten75:hover::after,
 input:checked + .switch--lighten75 {
   background-color: var(--white);
-}
-
-.switch-container:hover > input:checked + .switch--lighten75 {
-  background-color: var(--lighten75);
 }
 
 input:checked + .switch--dot-lighten75::after {
@@ -1917,17 +1535,8 @@ input:checked + .switch--dot-lighten75::after {
   color: var(--white);
 }
 
-.switch-container:hover > .switch--white {
-  color: var(--lighten75);
-}
-
-.switch--white:hover::after,
 input:checked + .switch--white {
   background-color: var(--lighten75);
-}
-
-.switch-container:hover > input:checked + .switch--white {
-  background-color: var(--white);
 }
 
 input:checked + .switch--dot-white::after {
@@ -1938,17 +1547,8 @@ input:checked + .switch--dot-white::after {
   color: var(--transparent);
 }
 
-.switch-container:hover > .switch--transparent {
-  color: var(--darken10);
-}
-
-.switch--transparent:hover::after,
 input:checked + .switch--transparent {
   background-color: var(--darken10);
-}
-
-.switch-container:hover > input:checked + .switch--transparent {
-  background-color: var(--transparent);
 }
 
 input:checked + .switch--dot-transparent::after {
@@ -1956,52 +1556,36 @@ input:checked + .switch--dot-transparent::after {
 }
 
 .range--gray > input { color: var(--gray); }
-.range--gray:hover > input { color: var(--gray-dark); }
 
 .range--pink > input { color: var(--pink); }
-.range--pink:hover > input { color: var(--pink-dark); }
 
 .range--red > input { color: var(--red); }
-.range--red:hover > input { color: var(--red-dark); }
 
 .range--orange > input { color: var(--orange); }
-.range--orange:hover > input { color: var(--orange-dark); }
 
 .range--yellow > input { color: var(--yellow); }
-.range--yellow:hover > input { color: var(--yellow-dark); }
 
 .range--green > input { color: var(--green); }
-.range--green:hover > input { color: var(--green-dark); }
 
 .range--blue > input { color: var(--blue); }
-.range--blue:hover > input { color: var(--blue-dark); }
 
 .range--purple > input { color: var(--purple); }
-.range--purple:hover > input { color: var(--purple-dark); }
 
 .range--darken25 > input { color: var(--darken25); }
-.range--darken25:hover > input { color: var(--darken50); }
 
 .range--darken50 > input { color: var(--darken50); }
-.range--darken50:hover > input { color: var(--darken75); }
 
 .range--darken75 > input { color: var(--darken75); }
-.range--darken75:hover > input { color: var(--black); }
 
 .range--lighten25 > input { color: var(--lighten25); }
-.range--lighten25:hover > input { color: var(--lighten50); }
 
 .range--lighten50 > input { color: var(--lighten50); }
-.range--lighten50:hover > input { color: var(--lighten75); }
 
 .range--lighten75 > input { color: var(--lighten75); }
-.range--lighten75:hover > input { color: var(--white); }
 
 .range--white > input { color: var(--white); }
-.range--white:hover > input { color: var(--lighten75); }
 
 .range--transparent > input { color: var(--transparent); }
-.range--transparent:hover > input { color: var(--darken10); }
 
 /**
  * @section Text colors

--- a/src/forms.css
+++ b/src/forms.css
@@ -30,7 +30,8 @@
  */
 .input,
 .textarea {
-  border: 1px solid var(--gray-light);
+  box-shadow: inset 0 0 0 1px var(--gray-light);
+  padding: 6px 12px;
   border-radius: var(--border-radius);
   transition: background-color var(--transition),
     border-color var(--transition);
@@ -40,17 +41,12 @@
 
 .input:focus,
 .textarea:focus {
-  border-color: var(--default-primary-interactive-color);
+  box-shadow: inset 0 0 0 1px var(--default-primary-interactive-color);
 }
 
 .input::placeholder,
 .textarea::placeholder {
   color: var(--inactive-text-color);
-}
-
-/* Without this, IE always has a scrollbar */
-.textarea {
-  overflow: auto;
 }
 
 /* Remove bad padding and unique cancel button from IE and Safari inputs */
@@ -72,27 +68,36 @@
  * Style a text input. Set the color of the border with a `input--border-{color}` modifier (`*-dark` colors are not available).
  *
  * @memberof Inputs & textareas
+ * @selectors .input
  * @example
  * <input class='input' placeholder='default' />
  * <input class='input input--border-green w240' placeholder='green' />
  */
-.input {
-  height: 36px;
-  line-height: 34px; /* minus border */
-  padding: 0 12px;
-}
 
 /**
  * Make an input small.
  *
  * @memberof Inputs & textareas
  * @example
- * <input class='input input--s txt-s' placeholder='small' />
+ * <input class='input input--s' placeholder='small' />
  */
 .input--s {
-  height: 24px;
-  line-height: 22px; /* minus border */
-  padding: 0 6px;
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
+  padding: 3px 6px;
+}
+
+/**
+ * Make an input extra small.
+ *
+ * @memberof Inputs & textareas
+ * @example
+ * <input class='input input--xs' placeholder='extra small' />
+ */
+.input--xs {
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
+  padding: 0 4px;
 }
 
 /**
@@ -105,21 +110,34 @@
  */
 .textarea {
   resize: vertical;
-  padding-top: 10px; /* minus border to match input */
-  padding-bottom: 10px;
-  padding-left: 10px;
-  padding-right: 10px;
+  /* Without this, IE always has a scrollbar */
+  overflow: auto;
 }
 
 /**
- * Make a textarea small.
+ * Make a textarea extra small.
  *
  * @memberof Inputs & textareas
  * @example
- * <textarea class='textarea textarea--s txt-s'>small textarea</textarea>
+ * <textarea class='textarea textarea--s'>small textarea</textarea>
  */
 .textarea--s {
-  padding: 0 4px;
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
+  padding: 3px 6px;
+}
+
+/**
+ * Make a textarea extra small.
+ *
+ * @memberof Inputs & textareas
+ * @example
+ * <textarea class='textarea textarea--xs'>extra small textarea</textarea>
+ */
+.textarea--xs {
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
+  padding: 0 3px;
 }
 
 /**
@@ -135,7 +153,7 @@
   pointer-events: none;
   color: var(--darken50) !important;
   background-color: var(--disabled-secondary-interactive-color) !important;
-  border-color: var(--disabled-primary-interactive-color) !important;
+  box-shadow: inset 0 0 0 1px var(--disabled-primary-interactive-color) !important;
 }
 
 /* Using the attribute selector instead of the pseudo-class `:read-only`
@@ -194,8 +212,8 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 .select {
   appearance: none;
-  line-height: inherit;
-  font-size: inherit;
+  font-size: var(--font-size-m);
+  line-height: var(--line-height-m);
   font-weight: bold;
   color: currentColor;
   padding: 6px 30px 6px 12px; /* plus arrow */
@@ -322,8 +340,9 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  * </div>
  */
 .select--s {
-  font-size: 12px;
-  padding: 0 20px 0 6px; /* plus arrow */
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
+  padding: 3px 20px 3px 6px; /* plus arrow */
 }
 
 .select--s + .select-arrow {
@@ -344,8 +363,8 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  * </div>
  */
 .select--xs {
-  font-size: 10px;
-  line-height: 18px;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
   padding: 0 20px 0 6px; /* plus arrow */
 }
 
@@ -648,10 +667,6 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
     background-color var(--transition);
 }
 
-.checkbox-container:hover > .checkbox {
-  border-color: var(--default-primary-interactive-color-dark);
-}
-
 /* Ensure checkboxes inside buttons look nice */
 .btn:not(.btn--stroke) > .checkbox {
   border-color: var(--transparent);
@@ -700,10 +715,6 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-radius: 50%;
   color: var(--default-secondary-interactive-color);
   border-color: currentColor;
-}
-
-.radio-container:hover > .radio {
-  color: var(--default-primary-interactive-color-dark);
 }
 
 .radio::before {
@@ -928,15 +939,7 @@ input:checked + .checkbox {
   background-color: var(--default-primary-interactive-color);
 }
 
-.checkbox-container:hover > input:checked + .checkbox {
-  background-color: var(--default-primary-interactive-color-dark);
-}
-
 /* state management for switches */
-.switch-container:hover > .switch {
-  color: var(--default-primary-interactive-color);
-}
-
 input:checked + .switch::after {
   left: calc(50% + 1px);
   background-color: var(--white);
@@ -948,11 +951,6 @@ input:checked + .switch {
 }
 
 /* state management for toggles */
-.toggle:hover {
-  color: var(--default-primary-interactive-color);
-  border-color: var(--default-primary-interactive-color);
-}
-
 input:checked + .toggle {
   background: var(--default-primary-interactive-color);
   color: var(--white);

--- a/src/typography.css
+++ b/src/typography.css
@@ -12,8 +12,8 @@ body,
 input,
 textarea {
   color: var(--text-color);
-  font-size: 15px;
-  line-height: 24px;
+  font-size: var(--font-size-m);
+  line-height: var(--line-height-m);
   font-family: var(--font-stack-base);
   font-weight: normal;
   -webkit-font-smoothing: antialiased;
@@ -30,7 +30,7 @@ textarea {
 .prose:not(.unprose) kbd {
   font-family: var(--font-stack-mono);
   border: 1px solid var(--darken25);
-  line-height: 18px;
+  line-height: var(--line-height-s);
   border-radius: 3px;
   padding: 2px 3px;
   box-shadow: 0 1px 0 0 var(--darken10);
@@ -196,28 +196,28 @@ textarea {
  * <div class='txt-xs'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</div>
  */
 .txt-xl {
-  font-size: 30px;
-  line-height: 45px;
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-xl);
 }
 
 .txt-l {
-  font-size: 18px;
-  line-height: 30px;
+  font-size: var(--font-size-l);
+  line-height: var(--line-height-l);
 }
 
 .txt-m {
-  font-size: 15px;
-  line-height: 24px;
+  font-size: var(--font-size-m);
+  line-height: var(--line-height-m);
 }
 
 .txt-s {
-  font-size: 12px;
-  line-height: 18px;
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
 }
 
 .txt-xs {
-  font-size: 10px;
-  line-height: 15px;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
 }
 /** @endgroup */
 
@@ -644,8 +644,8 @@ textarea {
 
 .prose small:not(.unprose) {
   display: block;
-  font-size: 12px;
-  line-height: 18px;
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
   margin-bottom: 12px;
 }
 

--- a/src/variables.json
+++ b/src/variables.json
@@ -75,6 +75,18 @@
 
   "focus-shadow": "0 0 0 3px rgba(137, 199, 216, 0.65)",
 
+  "font-size-xl": "30px",
+  "font-size-l": "18px",
+  "font-size-m": "15px",
+  "font-size-s": "12px",
+  "font-size-xs": "10px",
+
+  "line-height-xl": "45px",
+  "line-height-l": "30px",
+  "line-height-m": "24px",
+  "line-height-s": "18px",
+  "line-height-xs": "15px",
+
   "font-stack-base": "'Open Sans', sans-serif",
   "font-stack-mono": "'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace"
 }

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -808,418 +808,290 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-gray,
 .input--border-gray {
-  border-color: var(--gray);
+  box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus {
-  border-color: var(--gray-dark);
+  box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
 .input--border-pink {
-  border-color: var(--pink);
+  box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus {
-  border-color: var(--pink-dark);
+  box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
 .input--border-red {
-  border-color: var(--red);
+  box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus {
-  border-color: var(--red-dark);
+  box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
 .input--border-orange {
-  border-color: var(--orange);
+  box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus {
-  border-color: var(--orange-dark);
+  box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
 .input--border-yellow {
-  border-color: var(--yellow);
+  box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus {
-  border-color: var(--yellow-dark);
+  box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
 .input--border-green {
-  border-color: var(--green);
+  box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus {
-  border-color: var(--green-dark);
+  box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
 .input--border-blue {
-  border-color: var(--blue);
+  box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus {
-  border-color: var(--blue-dark);
+  box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
 .input--border-purple {
-  border-color: var(--purple);
+  box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus {
-  border-color: var(--purple-dark);
+  box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
 .input--border-darken25 {
-  border-color: var(--darken25);
+  box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus {
-  border-color: var(--darken50);
+  box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
 .input--border-darken50 {
-  border-color: var(--darken50);
+  box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus {
-  border-color: var(--darken75);
+  box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75 {
-  border-color: var(--darken75);
+  box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus {
-  border-color: var(--black);
+  box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25 {
-  border-color: var(--lighten25);
+  box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus {
-  border-color: var(--lighten50);
+  box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50 {
-  border-color: var(--lighten50);
+  box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75 {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus {
-  border-color: var(--white);
+  box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
 .input--border-white {
-  border-color: var(--white);
+  box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent {
-  border-color: var(--transparent);
+  box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus {
-  border-color: var(--darken10);
+  box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
 .checkbox--gray {
   border-color: var(--gray);
 }
 
-.checkbox-container:hover > .checkbox--gray {
-  border-color: var(--gray-dark);
-}
-
 input:checked + .checkbox--gray {
   background-color: var(--gray);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--gray {
-  background-color: var(--gray-dark);
 }
 
 .checkbox--pink {
   border-color: var(--pink);
 }
 
-.checkbox-container:hover > .checkbox--pink {
-  border-color: var(--pink-dark);
-}
-
 input:checked + .checkbox--pink {
   background-color: var(--pink);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--pink {
-  background-color: var(--pink-dark);
 }
 
 .checkbox--red {
   border-color: var(--red);
 }
 
-.checkbox-container:hover > .checkbox--red {
-  border-color: var(--red-dark);
-}
-
 input:checked + .checkbox--red {
   background-color: var(--red);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--red {
-  background-color: var(--red-dark);
 }
 
 .checkbox--orange {
   border-color: var(--orange);
 }
 
-.checkbox-container:hover > .checkbox--orange {
-  border-color: var(--orange-dark);
-}
-
 input:checked + .checkbox--orange {
   background-color: var(--orange);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--orange {
-  background-color: var(--orange-dark);
 }
 
 .checkbox--yellow {
   border-color: var(--yellow);
 }
 
-.checkbox-container:hover > .checkbox--yellow {
-  border-color: var(--yellow-dark);
-}
-
 input:checked + .checkbox--yellow {
   background-color: var(--yellow);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--yellow {
-  background-color: var(--yellow-dark);
 }
 
 .checkbox--green {
   border-color: var(--green);
 }
 
-.checkbox-container:hover > .checkbox--green {
-  border-color: var(--green-dark);
-}
-
 input:checked + .checkbox--green {
   background-color: var(--green);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--green {
-  background-color: var(--green-dark);
 }
 
 .checkbox--blue {
   border-color: var(--blue);
 }
 
-.checkbox-container:hover > .checkbox--blue {
-  border-color: var(--blue-dark);
-}
-
 input:checked + .checkbox--blue {
   background-color: var(--blue);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--blue {
-  background-color: var(--blue-dark);
 }
 
 .checkbox--purple {
   border-color: var(--purple);
 }
 
-.checkbox-container:hover > .checkbox--purple {
-  border-color: var(--purple-dark);
-}
-
 input:checked + .checkbox--purple {
   background-color: var(--purple);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--purple {
-  background-color: var(--purple-dark);
 }
 
 .checkbox--darken25 {
   border-color: var(--darken25);
 }
 
-.checkbox-container:hover > .checkbox--darken25 {
-  border-color: var(--darken50);
-}
-
 input:checked + .checkbox--darken25 {
   background-color: var(--darken25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken25 {
-  background-color: var(--darken50);
 }
 
 .checkbox--darken50 {
   border-color: var(--darken50);
 }
 
-.checkbox-container:hover > .checkbox--darken50 {
-  border-color: var(--darken75);
-}
-
 input:checked + .checkbox--darken50 {
   background-color: var(--darken50);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken50 {
-  background-color: var(--darken75);
 }
 
 .checkbox--darken75 {
   border-color: var(--darken75);
 }
 
-.checkbox-container:hover > .checkbox--darken75 {
-  border-color: var(--black);
-}
-
 input:checked + .checkbox--darken75 {
   background-color: var(--darken75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken75 {
-  background-color: var(--black);
 }
 
 .checkbox--lighten25 {
   border-color: var(--lighten25);
 }
 
-.checkbox-container:hover > .checkbox--lighten25 {
-  border-color: var(--lighten50);
-}
-
 input:checked + .checkbox--lighten25 {
   background-color: var(--lighten25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten25 {
-  background-color: var(--lighten50);
 }
 
 .checkbox--lighten50 {
   border-color: var(--lighten50);
 }
 
-.checkbox-container:hover > .checkbox--lighten50 {
-  border-color: var(--lighten75);
-}
-
 input:checked + .checkbox--lighten50 {
   background-color: var(--lighten50);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten50 {
-  background-color: var(--lighten75);
 }
 
 .checkbox--lighten75 {
   border-color: var(--lighten75);
 }
 
-.checkbox-container:hover > .checkbox--lighten75 {
-  border-color: var(--white);
-}
-
 input:checked + .checkbox--lighten75 {
   background-color: var(--lighten75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten75 {
-  background-color: var(--white);
 }
 
 .checkbox--white {
   border-color: var(--white);
 }
 
-.checkbox-container:hover > .checkbox--white {
-  border-color: var(--lighten75);
-}
-
 input:checked + .checkbox--white {
   background-color: var(--white);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--white {
-  background-color: var(--lighten75);
 }
 
 .checkbox--transparent {
   border-color: var(--transparent);
 }
 
-.checkbox-container:hover > .checkbox--transparent {
-  border-color: var(--darken10);
-}
-
 input:checked + .checkbox--transparent {
   background-color: var(--transparent);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--transparent {
-  background-color: var(--darken10);
 }
 
 .radio--gray,
@@ -1227,17 +1099,9 @@ input:checked + .radio--gray {
   color: var(--gray);
 }
 
-.radio-container:hover > .radio--gray {
-  color: var(--gray-dark);
-}
-
 .radio--pink,
 input:checked + .radio--pink {
   color: var(--pink);
-}
-
-.radio-container:hover > .radio--pink {
-  color: var(--pink-dark);
 }
 
 .radio--red,
@@ -1245,17 +1109,9 @@ input:checked + .radio--red {
   color: var(--red);
 }
 
-.radio-container:hover > .radio--red {
-  color: var(--red-dark);
-}
-
 .radio--orange,
 input:checked + .radio--orange {
   color: var(--orange);
-}
-
-.radio-container:hover > .radio--orange {
-  color: var(--orange-dark);
 }
 
 .radio--yellow,
@@ -1263,17 +1119,9 @@ input:checked + .radio--yellow {
   color: var(--yellow);
 }
 
-.radio-container:hover > .radio--yellow {
-  color: var(--yellow-dark);
-}
-
 .radio--green,
 input:checked + .radio--green {
   color: var(--green);
-}
-
-.radio-container:hover > .radio--green {
-  color: var(--green-dark);
 }
 
 .radio--blue,
@@ -1281,17 +1129,9 @@ input:checked + .radio--blue {
   color: var(--blue);
 }
 
-.radio-container:hover > .radio--blue {
-  color: var(--blue-dark);
-}
-
 .radio--purple,
 input:checked + .radio--purple {
   color: var(--purple);
-}
-
-.radio-container:hover > .radio--purple {
-  color: var(--purple-dark);
 }
 
 .radio--darken25,
@@ -1299,17 +1139,9 @@ input:checked + .radio--darken25 {
   color: var(--darken25);
 }
 
-.radio-container:hover > .radio--darken25 {
-  color: var(--darken50);
-}
-
 .radio--darken50,
 input:checked + .radio--darken50 {
   color: var(--darken50);
-}
-
-.radio-container:hover > .radio--darken50 {
-  color: var(--darken75);
 }
 
 .radio--darken75,
@@ -1317,17 +1149,9 @@ input:checked + .radio--darken75 {
   color: var(--darken75);
 }
 
-.radio-container:hover > .radio--darken75 {
-  color: var(--black);
-}
-
 .radio--lighten25,
 input:checked + .radio--lighten25 {
   color: var(--lighten25);
-}
-
-.radio-container:hover > .radio--lighten25 {
-  color: var(--lighten50);
 }
 
 .radio--lighten50,
@@ -1335,17 +1159,9 @@ input:checked + .radio--lighten50 {
   color: var(--lighten50);
 }
 
-.radio-container:hover > .radio--lighten50 {
-  color: var(--lighten75);
-}
-
 .radio--lighten75,
 input:checked + .radio--lighten75 {
   color: var(--lighten75);
-}
-
-.radio-container:hover > .radio--lighten75 {
-  color: var(--white);
 }
 
 .radio--white,
@@ -1353,25 +1169,13 @@ input:checked + .radio--white {
   color: var(--white);
 }
 
-.radio-container:hover > .radio--white {
-  color: var(--lighten75);
-}
-
 .radio--transparent,
 input:checked + .radio--transparent {
   color: var(--transparent);
 }
 
-.radio-container:hover > .radio--transparent {
-  color: var(--darken10);
-}
-
 .toggle--gray {
   color: var(--gray);
-}
-
-.toggle--gray:hover {
-  color: var(--gray-dark);
 }
 
 input:checked + .toggle--gray {
@@ -1382,20 +1186,12 @@ input:checked + .toggle--gray {
   color: var(--pink);
 }
 
-.toggle--pink:hover {
-  color: var(--pink-dark);
-}
-
 input:checked + .toggle--pink {
   background: var(--pink);
 }
 
 .toggle--red {
   color: var(--red);
-}
-
-.toggle--red:hover {
-  color: var(--red-dark);
 }
 
 input:checked + .toggle--red {
@@ -1406,20 +1202,12 @@ input:checked + .toggle--red {
   color: var(--orange);
 }
 
-.toggle--orange:hover {
-  color: var(--orange-dark);
-}
-
 input:checked + .toggle--orange {
   background: var(--orange);
 }
 
 .toggle--yellow {
   color: var(--yellow);
-}
-
-.toggle--yellow:hover {
-  color: var(--yellow-dark);
 }
 
 input:checked + .toggle--yellow {
@@ -1430,20 +1218,12 @@ input:checked + .toggle--yellow {
   color: var(--green);
 }
 
-.toggle--green:hover {
-  color: var(--green-dark);
-}
-
 input:checked + .toggle--green {
   background: var(--green);
 }
 
 .toggle--blue {
   color: var(--blue);
-}
-
-.toggle--blue:hover {
-  color: var(--blue-dark);
 }
 
 input:checked + .toggle--blue {
@@ -1454,20 +1234,12 @@ input:checked + .toggle--blue {
   color: var(--purple);
 }
 
-.toggle--purple:hover {
-  color: var(--purple-dark);
-}
-
 input:checked + .toggle--purple {
   background: var(--purple);
 }
 
 .toggle--darken25 {
   color: var(--darken25);
-}
-
-.toggle--darken25:hover {
-  color: var(--darken50);
 }
 
 input:checked + .toggle--darken25 {
@@ -1478,20 +1250,12 @@ input:checked + .toggle--darken25 {
   color: var(--darken50);
 }
 
-.toggle--darken50:hover {
-  color: var(--darken75);
-}
-
 input:checked + .toggle--darken50 {
   background: var(--darken50);
 }
 
 .toggle--darken75 {
   color: var(--darken75);
-}
-
-.toggle--darken75:hover {
-  color: var(--black);
 }
 
 input:checked + .toggle--darken75 {
@@ -1502,20 +1266,12 @@ input:checked + .toggle--darken75 {
   color: var(--lighten25);
 }
 
-.toggle--lighten25:hover {
-  color: var(--lighten50);
-}
-
 input:checked + .toggle--lighten25 {
   background: var(--lighten25);
 }
 
 .toggle--lighten50 {
   color: var(--lighten50);
-}
-
-.toggle--lighten50:hover {
-  color: var(--lighten75);
 }
 
 input:checked + .toggle--lighten50 {
@@ -1526,10 +1282,6 @@ input:checked + .toggle--lighten50 {
   color: var(--lighten75);
 }
 
-.toggle--lighten75:hover {
-  color: var(--white);
-}
-
 input:checked + .toggle--lighten75 {
   background: var(--lighten75);
 }
@@ -1538,20 +1290,12 @@ input:checked + .toggle--lighten75 {
   color: var(--white);
 }
 
-.toggle--white:hover {
-  color: var(--lighten75);
-}
-
 input:checked + .toggle--white {
   background: var(--white);
 }
 
 .toggle--transparent {
   color: var(--transparent);
-}
-
-.toggle--transparent:hover {
-  color: var(--darken10);
 }
 
 input:checked + .toggle--transparent {
@@ -1626,17 +1370,8 @@ input:checked + .toggle--active-transparent {
   color: var(--gray);
 }
 
-.switch-container:hover > .switch--gray {
-  color: var(--gray-dark);
-}
-
-.switch--gray:hover::after,
 input:checked + .switch--gray {
   background-color: var(--gray-dark);
-}
-
-.switch-container:hover > input:checked + .switch--gray {
-  background-color: var(--gray);
 }
 
 input:checked + .switch--dot-gray::after {
@@ -1647,17 +1382,8 @@ input:checked + .switch--dot-gray::after {
   color: var(--pink);
 }
 
-.switch-container:hover > .switch--pink {
-  color: var(--pink-dark);
-}
-
-.switch--pink:hover::after,
 input:checked + .switch--pink {
   background-color: var(--pink-dark);
-}
-
-.switch-container:hover > input:checked + .switch--pink {
-  background-color: var(--pink);
 }
 
 input:checked + .switch--dot-pink::after {
@@ -1668,17 +1394,8 @@ input:checked + .switch--dot-pink::after {
   color: var(--red);
 }
 
-.switch-container:hover > .switch--red {
-  color: var(--red-dark);
-}
-
-.switch--red:hover::after,
 input:checked + .switch--red {
   background-color: var(--red-dark);
-}
-
-.switch-container:hover > input:checked + .switch--red {
-  background-color: var(--red);
 }
 
 input:checked + .switch--dot-red::after {
@@ -1689,17 +1406,8 @@ input:checked + .switch--dot-red::after {
   color: var(--orange);
 }
 
-.switch-container:hover > .switch--orange {
-  color: var(--orange-dark);
-}
-
-.switch--orange:hover::after,
 input:checked + .switch--orange {
   background-color: var(--orange-dark);
-}
-
-.switch-container:hover > input:checked + .switch--orange {
-  background-color: var(--orange);
 }
 
 input:checked + .switch--dot-orange::after {
@@ -1710,17 +1418,8 @@ input:checked + .switch--dot-orange::after {
   color: var(--yellow);
 }
 
-.switch-container:hover > .switch--yellow {
-  color: var(--yellow-dark);
-}
-
-.switch--yellow:hover::after,
 input:checked + .switch--yellow {
   background-color: var(--yellow-dark);
-}
-
-.switch-container:hover > input:checked + .switch--yellow {
-  background-color: var(--yellow);
 }
 
 input:checked + .switch--dot-yellow::after {
@@ -1731,17 +1430,8 @@ input:checked + .switch--dot-yellow::after {
   color: var(--green);
 }
 
-.switch-container:hover > .switch--green {
-  color: var(--green-dark);
-}
-
-.switch--green:hover::after,
 input:checked + .switch--green {
   background-color: var(--green-dark);
-}
-
-.switch-container:hover > input:checked + .switch--green {
-  background-color: var(--green);
 }
 
 input:checked + .switch--dot-green::after {
@@ -1752,17 +1442,8 @@ input:checked + .switch--dot-green::after {
   color: var(--blue);
 }
 
-.switch-container:hover > .switch--blue {
-  color: var(--blue-dark);
-}
-
-.switch--blue:hover::after,
 input:checked + .switch--blue {
   background-color: var(--blue-dark);
-}
-
-.switch-container:hover > input:checked + .switch--blue {
-  background-color: var(--blue);
 }
 
 input:checked + .switch--dot-blue::after {
@@ -1773,17 +1454,8 @@ input:checked + .switch--dot-blue::after {
   color: var(--purple);
 }
 
-.switch-container:hover > .switch--purple {
-  color: var(--purple-dark);
-}
-
-.switch--purple:hover::after,
 input:checked + .switch--purple {
   background-color: var(--purple-dark);
-}
-
-.switch-container:hover > input:checked + .switch--purple {
-  background-color: var(--purple);
 }
 
 input:checked + .switch--dot-purple::after {
@@ -1794,17 +1466,8 @@ input:checked + .switch--dot-purple::after {
   color: var(--darken25);
 }
 
-.switch-container:hover > .switch--darken25 {
-  color: var(--darken50);
-}
-
-.switch--darken25:hover::after,
 input:checked + .switch--darken25 {
   background-color: var(--darken50);
-}
-
-.switch-container:hover > input:checked + .switch--darken25 {
-  background-color: var(--darken25);
 }
 
 input:checked + .switch--dot-darken25::after {
@@ -1815,17 +1478,8 @@ input:checked + .switch--dot-darken25::after {
   color: var(--darken50);
 }
 
-.switch-container:hover > .switch--darken50 {
-  color: var(--darken75);
-}
-
-.switch--darken50:hover::after,
 input:checked + .switch--darken50 {
   background-color: var(--darken75);
-}
-
-.switch-container:hover > input:checked + .switch--darken50 {
-  background-color: var(--darken50);
 }
 
 input:checked + .switch--dot-darken50::after {
@@ -1836,17 +1490,8 @@ input:checked + .switch--dot-darken50::after {
   color: var(--darken75);
 }
 
-.switch-container:hover > .switch--darken75 {
-  color: var(--black);
-}
-
-.switch--darken75:hover::after,
 input:checked + .switch--darken75 {
   background-color: var(--black);
-}
-
-.switch-container:hover > input:checked + .switch--darken75 {
-  background-color: var(--darken75);
 }
 
 input:checked + .switch--dot-darken75::after {
@@ -1857,17 +1502,8 @@ input:checked + .switch--dot-darken75::after {
   color: var(--lighten25);
 }
 
-.switch-container:hover > .switch--lighten25 {
-  color: var(--lighten50);
-}
-
-.switch--lighten25:hover::after,
 input:checked + .switch--lighten25 {
   background-color: var(--lighten50);
-}
-
-.switch-container:hover > input:checked + .switch--lighten25 {
-  background-color: var(--lighten25);
 }
 
 input:checked + .switch--dot-lighten25::after {
@@ -1878,17 +1514,8 @@ input:checked + .switch--dot-lighten25::after {
   color: var(--lighten50);
 }
 
-.switch-container:hover > .switch--lighten50 {
-  color: var(--lighten75);
-}
-
-.switch--lighten50:hover::after,
 input:checked + .switch--lighten50 {
   background-color: var(--lighten75);
-}
-
-.switch-container:hover > input:checked + .switch--lighten50 {
-  background-color: var(--lighten50);
 }
 
 input:checked + .switch--dot-lighten50::after {
@@ -1899,17 +1526,8 @@ input:checked + .switch--dot-lighten50::after {
   color: var(--lighten75);
 }
 
-.switch-container:hover > .switch--lighten75 {
-  color: var(--white);
-}
-
-.switch--lighten75:hover::after,
 input:checked + .switch--lighten75 {
   background-color: var(--white);
-}
-
-.switch-container:hover > input:checked + .switch--lighten75 {
-  background-color: var(--lighten75);
 }
 
 input:checked + .switch--dot-lighten75::after {
@@ -1920,17 +1538,8 @@ input:checked + .switch--dot-lighten75::after {
   color: var(--white);
 }
 
-.switch-container:hover > .switch--white {
-  color: var(--lighten75);
-}
-
-.switch--white:hover::after,
 input:checked + .switch--white {
   background-color: var(--lighten75);
-}
-
-.switch-container:hover > input:checked + .switch--white {
-  background-color: var(--white);
 }
 
 input:checked + .switch--dot-white::after {
@@ -1941,17 +1550,8 @@ input:checked + .switch--dot-white::after {
   color: var(--transparent);
 }
 
-.switch-container:hover > .switch--transparent {
-  color: var(--darken10);
-}
-
-.switch--transparent:hover::after,
 input:checked + .switch--transparent {
   background-color: var(--darken10);
-}
-
-.switch-container:hover > input:checked + .switch--transparent {
-  background-color: var(--transparent);
 }
 
 input:checked + .switch--dot-transparent::after {
@@ -1959,52 +1559,36 @@ input:checked + .switch--dot-transparent::after {
 }
 
 .range--gray > input { color: var(--gray); }
-.range--gray:hover > input { color: var(--gray-dark); }
 
 .range--pink > input { color: var(--pink); }
-.range--pink:hover > input { color: var(--pink-dark); }
 
 .range--red > input { color: var(--red); }
-.range--red:hover > input { color: var(--red-dark); }
 
 .range--orange > input { color: var(--orange); }
-.range--orange:hover > input { color: var(--orange-dark); }
 
 .range--yellow > input { color: var(--yellow); }
-.range--yellow:hover > input { color: var(--yellow-dark); }
 
 .range--green > input { color: var(--green); }
-.range--green:hover > input { color: var(--green-dark); }
 
 .range--blue > input { color: var(--blue); }
-.range--blue:hover > input { color: var(--blue-dark); }
 
 .range--purple > input { color: var(--purple); }
-.range--purple:hover > input { color: var(--purple-dark); }
 
 .range--darken25 > input { color: var(--darken25); }
-.range--darken25:hover > input { color: var(--darken50); }
 
 .range--darken50 > input { color: var(--darken50); }
-.range--darken50:hover > input { color: var(--darken75); }
 
 .range--darken75 > input { color: var(--darken75); }
-.range--darken75:hover > input { color: var(--black); }
 
 .range--lighten25 > input { color: var(--lighten25); }
-.range--lighten25:hover > input { color: var(--lighten50); }
 
 .range--lighten50 > input { color: var(--lighten50); }
-.range--lighten50:hover > input { color: var(--lighten75); }
 
 .range--lighten75 > input { color: var(--lighten75); }
-.range--lighten75:hover > input { color: var(--white); }
 
 .range--white > input { color: var(--white); }
-.range--white:hover > input { color: var(--lighten75); }
 
 .range--transparent > input { color: var(--transparent); }
-.range--transparent:hover > input { color: var(--darken10); }
 
 /**
  * @section Text colors
@@ -4625,418 +4209,290 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-gray,
 .input--border-gray {
-  border-color: var(--gray);
+  box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus {
-  border-color: var(--gray-dark);
+  box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
 .input--border-pink {
-  border-color: var(--pink);
+  box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus {
-  border-color: var(--pink-dark);
+  box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
 .input--border-red {
-  border-color: var(--red);
+  box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus {
-  border-color: var(--red-dark);
+  box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
 .input--border-orange {
-  border-color: var(--orange);
+  box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus {
-  border-color: var(--orange-dark);
+  box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
 .input--border-yellow {
-  border-color: var(--yellow);
+  box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus {
-  border-color: var(--yellow-dark);
+  box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
 .input--border-green {
-  border-color: var(--green);
+  box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus {
-  border-color: var(--green-dark);
+  box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
 .input--border-blue {
-  border-color: var(--blue);
+  box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus {
-  border-color: var(--blue-dark);
+  box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
 .input--border-purple {
-  border-color: var(--purple);
+  box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus {
-  border-color: var(--purple-dark);
+  box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
 .input--border-darken25 {
-  border-color: var(--darken25);
+  box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus {
-  border-color: var(--darken50);
+  box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
 .input--border-darken50 {
-  border-color: var(--darken50);
+  box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus {
-  border-color: var(--darken75);
+  box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75 {
-  border-color: var(--darken75);
+  box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus {
-  border-color: var(--black);
+  box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25 {
-  border-color: var(--lighten25);
+  box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus {
-  border-color: var(--lighten50);
+  box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50 {
-  border-color: var(--lighten50);
+  box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75 {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus {
-  border-color: var(--white);
+  box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
 .input--border-white {
-  border-color: var(--white);
+  box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent {
-  border-color: var(--transparent);
+  box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus {
-  border-color: var(--darken10);
+  box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
 .checkbox--gray {
   border-color: var(--gray);
 }
 
-.checkbox-container:hover > .checkbox--gray {
-  border-color: var(--gray-dark);
-}
-
 input:checked + .checkbox--gray {
   background-color: var(--gray);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--gray {
-  background-color: var(--gray-dark);
 }
 
 .checkbox--pink {
   border-color: var(--pink);
 }
 
-.checkbox-container:hover > .checkbox--pink {
-  border-color: var(--pink-dark);
-}
-
 input:checked + .checkbox--pink {
   background-color: var(--pink);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--pink {
-  background-color: var(--pink-dark);
 }
 
 .checkbox--red {
   border-color: var(--red);
 }
 
-.checkbox-container:hover > .checkbox--red {
-  border-color: var(--red-dark);
-}
-
 input:checked + .checkbox--red {
   background-color: var(--red);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--red {
-  background-color: var(--red-dark);
 }
 
 .checkbox--orange {
   border-color: var(--orange);
 }
 
-.checkbox-container:hover > .checkbox--orange {
-  border-color: var(--orange-dark);
-}
-
 input:checked + .checkbox--orange {
   background-color: var(--orange);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--orange {
-  background-color: var(--orange-dark);
 }
 
 .checkbox--yellow {
   border-color: var(--yellow);
 }
 
-.checkbox-container:hover > .checkbox--yellow {
-  border-color: var(--yellow-dark);
-}
-
 input:checked + .checkbox--yellow {
   background-color: var(--yellow);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--yellow {
-  background-color: var(--yellow-dark);
 }
 
 .checkbox--green {
   border-color: var(--green);
 }
 
-.checkbox-container:hover > .checkbox--green {
-  border-color: var(--green-dark);
-}
-
 input:checked + .checkbox--green {
   background-color: var(--green);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--green {
-  background-color: var(--green-dark);
 }
 
 .checkbox--blue {
   border-color: var(--blue);
 }
 
-.checkbox-container:hover > .checkbox--blue {
-  border-color: var(--blue-dark);
-}
-
 input:checked + .checkbox--blue {
   background-color: var(--blue);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--blue {
-  background-color: var(--blue-dark);
 }
 
 .checkbox--purple {
   border-color: var(--purple);
 }
 
-.checkbox-container:hover > .checkbox--purple {
-  border-color: var(--purple-dark);
-}
-
 input:checked + .checkbox--purple {
   background-color: var(--purple);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--purple {
-  background-color: var(--purple-dark);
 }
 
 .checkbox--darken25 {
   border-color: var(--darken25);
 }
 
-.checkbox-container:hover > .checkbox--darken25 {
-  border-color: var(--darken50);
-}
-
 input:checked + .checkbox--darken25 {
   background-color: var(--darken25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken25 {
-  background-color: var(--darken50);
 }
 
 .checkbox--darken50 {
   border-color: var(--darken50);
 }
 
-.checkbox-container:hover > .checkbox--darken50 {
-  border-color: var(--darken75);
-}
-
 input:checked + .checkbox--darken50 {
   background-color: var(--darken50);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken50 {
-  background-color: var(--darken75);
 }
 
 .checkbox--darken75 {
   border-color: var(--darken75);
 }
 
-.checkbox-container:hover > .checkbox--darken75 {
-  border-color: var(--black);
-}
-
 input:checked + .checkbox--darken75 {
   background-color: var(--darken75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken75 {
-  background-color: var(--black);
 }
 
 .checkbox--lighten25 {
   border-color: var(--lighten25);
 }
 
-.checkbox-container:hover > .checkbox--lighten25 {
-  border-color: var(--lighten50);
-}
-
 input:checked + .checkbox--lighten25 {
   background-color: var(--lighten25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten25 {
-  background-color: var(--lighten50);
 }
 
 .checkbox--lighten50 {
   border-color: var(--lighten50);
 }
 
-.checkbox-container:hover > .checkbox--lighten50 {
-  border-color: var(--lighten75);
-}
-
 input:checked + .checkbox--lighten50 {
   background-color: var(--lighten50);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten50 {
-  background-color: var(--lighten75);
 }
 
 .checkbox--lighten75 {
   border-color: var(--lighten75);
 }
 
-.checkbox-container:hover > .checkbox--lighten75 {
-  border-color: var(--white);
-}
-
 input:checked + .checkbox--lighten75 {
   background-color: var(--lighten75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten75 {
-  background-color: var(--white);
 }
 
 .checkbox--white {
   border-color: var(--white);
 }
 
-.checkbox-container:hover > .checkbox--white {
-  border-color: var(--lighten75);
-}
-
 input:checked + .checkbox--white {
   background-color: var(--white);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--white {
-  background-color: var(--lighten75);
 }
 
 .checkbox--transparent {
   border-color: var(--transparent);
 }
 
-.checkbox-container:hover > .checkbox--transparent {
-  border-color: var(--darken10);
-}
-
 input:checked + .checkbox--transparent {
   background-color: var(--transparent);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--transparent {
-  background-color: var(--darken10);
 }
 
 .radio--gray,
@@ -5044,17 +4500,9 @@ input:checked + .radio--gray {
   color: var(--gray);
 }
 
-.radio-container:hover > .radio--gray {
-  color: var(--gray-dark);
-}
-
 .radio--pink,
 input:checked + .radio--pink {
   color: var(--pink);
-}
-
-.radio-container:hover > .radio--pink {
-  color: var(--pink-dark);
 }
 
 .radio--red,
@@ -5062,17 +4510,9 @@ input:checked + .radio--red {
   color: var(--red);
 }
 
-.radio-container:hover > .radio--red {
-  color: var(--red-dark);
-}
-
 .radio--orange,
 input:checked + .radio--orange {
   color: var(--orange);
-}
-
-.radio-container:hover > .radio--orange {
-  color: var(--orange-dark);
 }
 
 .radio--yellow,
@@ -5080,17 +4520,9 @@ input:checked + .radio--yellow {
   color: var(--yellow);
 }
 
-.radio-container:hover > .radio--yellow {
-  color: var(--yellow-dark);
-}
-
 .radio--green,
 input:checked + .radio--green {
   color: var(--green);
-}
-
-.radio-container:hover > .radio--green {
-  color: var(--green-dark);
 }
 
 .radio--blue,
@@ -5098,17 +4530,9 @@ input:checked + .radio--blue {
   color: var(--blue);
 }
 
-.radio-container:hover > .radio--blue {
-  color: var(--blue-dark);
-}
-
 .radio--purple,
 input:checked + .radio--purple {
   color: var(--purple);
-}
-
-.radio-container:hover > .radio--purple {
-  color: var(--purple-dark);
 }
 
 .radio--darken25,
@@ -5116,17 +4540,9 @@ input:checked + .radio--darken25 {
   color: var(--darken25);
 }
 
-.radio-container:hover > .radio--darken25 {
-  color: var(--darken50);
-}
-
 .radio--darken50,
 input:checked + .radio--darken50 {
   color: var(--darken50);
-}
-
-.radio-container:hover > .radio--darken50 {
-  color: var(--darken75);
 }
 
 .radio--darken75,
@@ -5134,17 +4550,9 @@ input:checked + .radio--darken75 {
   color: var(--darken75);
 }
 
-.radio-container:hover > .radio--darken75 {
-  color: var(--black);
-}
-
 .radio--lighten25,
 input:checked + .radio--lighten25 {
   color: var(--lighten25);
-}
-
-.radio-container:hover > .radio--lighten25 {
-  color: var(--lighten50);
 }
 
 .radio--lighten50,
@@ -5152,17 +4560,9 @@ input:checked + .radio--lighten50 {
   color: var(--lighten50);
 }
 
-.radio-container:hover > .radio--lighten50 {
-  color: var(--lighten75);
-}
-
 .radio--lighten75,
 input:checked + .radio--lighten75 {
   color: var(--lighten75);
-}
-
-.radio-container:hover > .radio--lighten75 {
-  color: var(--white);
 }
 
 .radio--white,
@@ -5170,25 +4570,13 @@ input:checked + .radio--white {
   color: var(--white);
 }
 
-.radio-container:hover > .radio--white {
-  color: var(--lighten75);
-}
-
 .radio--transparent,
 input:checked + .radio--transparent {
   color: var(--transparent);
 }
 
-.radio-container:hover > .radio--transparent {
-  color: var(--darken10);
-}
-
 .toggle--gray {
   color: var(--gray);
-}
-
-.toggle--gray:hover {
-  color: var(--gray-dark);
 }
 
 input:checked + .toggle--gray {
@@ -5199,20 +4587,12 @@ input:checked + .toggle--gray {
   color: var(--pink);
 }
 
-.toggle--pink:hover {
-  color: var(--pink-dark);
-}
-
 input:checked + .toggle--pink {
   background: var(--pink);
 }
 
 .toggle--red {
   color: var(--red);
-}
-
-.toggle--red:hover {
-  color: var(--red-dark);
 }
 
 input:checked + .toggle--red {
@@ -5223,20 +4603,12 @@ input:checked + .toggle--red {
   color: var(--orange);
 }
 
-.toggle--orange:hover {
-  color: var(--orange-dark);
-}
-
 input:checked + .toggle--orange {
   background: var(--orange);
 }
 
 .toggle--yellow {
   color: var(--yellow);
-}
-
-.toggle--yellow:hover {
-  color: var(--yellow-dark);
 }
 
 input:checked + .toggle--yellow {
@@ -5247,20 +4619,12 @@ input:checked + .toggle--yellow {
   color: var(--green);
 }
 
-.toggle--green:hover {
-  color: var(--green-dark);
-}
-
 input:checked + .toggle--green {
   background: var(--green);
 }
 
 .toggle--blue {
   color: var(--blue);
-}
-
-.toggle--blue:hover {
-  color: var(--blue-dark);
 }
 
 input:checked + .toggle--blue {
@@ -5271,20 +4635,12 @@ input:checked + .toggle--blue {
   color: var(--purple);
 }
 
-.toggle--purple:hover {
-  color: var(--purple-dark);
-}
-
 input:checked + .toggle--purple {
   background: var(--purple);
 }
 
 .toggle--darken25 {
   color: var(--darken25);
-}
-
-.toggle--darken25:hover {
-  color: var(--darken50);
 }
 
 input:checked + .toggle--darken25 {
@@ -5295,20 +4651,12 @@ input:checked + .toggle--darken25 {
   color: var(--darken50);
 }
 
-.toggle--darken50:hover {
-  color: var(--darken75);
-}
-
 input:checked + .toggle--darken50 {
   background: var(--darken50);
 }
 
 .toggle--darken75 {
   color: var(--darken75);
-}
-
-.toggle--darken75:hover {
-  color: var(--black);
 }
 
 input:checked + .toggle--darken75 {
@@ -5319,20 +4667,12 @@ input:checked + .toggle--darken75 {
   color: var(--lighten25);
 }
 
-.toggle--lighten25:hover {
-  color: var(--lighten50);
-}
-
 input:checked + .toggle--lighten25 {
   background: var(--lighten25);
 }
 
 .toggle--lighten50 {
   color: var(--lighten50);
-}
-
-.toggle--lighten50:hover {
-  color: var(--lighten75);
 }
 
 input:checked + .toggle--lighten50 {
@@ -5343,10 +4683,6 @@ input:checked + .toggle--lighten50 {
   color: var(--lighten75);
 }
 
-.toggle--lighten75:hover {
-  color: var(--white);
-}
-
 input:checked + .toggle--lighten75 {
   background: var(--lighten75);
 }
@@ -5355,20 +4691,12 @@ input:checked + .toggle--lighten75 {
   color: var(--white);
 }
 
-.toggle--white:hover {
-  color: var(--lighten75);
-}
-
 input:checked + .toggle--white {
   background: var(--white);
 }
 
 .toggle--transparent {
   color: var(--transparent);
-}
-
-.toggle--transparent:hover {
-  color: var(--darken10);
 }
 
 input:checked + .toggle--transparent {
@@ -5443,17 +4771,8 @@ input:checked + .toggle--active-transparent {
   color: var(--gray);
 }
 
-.switch-container:hover > .switch--gray {
-  color: var(--gray-dark);
-}
-
-.switch--gray:hover::after,
 input:checked + .switch--gray {
   background-color: var(--gray-dark);
-}
-
-.switch-container:hover > input:checked + .switch--gray {
-  background-color: var(--gray);
 }
 
 input:checked + .switch--dot-gray::after {
@@ -5464,17 +4783,8 @@ input:checked + .switch--dot-gray::after {
   color: var(--pink);
 }
 
-.switch-container:hover > .switch--pink {
-  color: var(--pink-dark);
-}
-
-.switch--pink:hover::after,
 input:checked + .switch--pink {
   background-color: var(--pink-dark);
-}
-
-.switch-container:hover > input:checked + .switch--pink {
-  background-color: var(--pink);
 }
 
 input:checked + .switch--dot-pink::after {
@@ -5485,17 +4795,8 @@ input:checked + .switch--dot-pink::after {
   color: var(--red);
 }
 
-.switch-container:hover > .switch--red {
-  color: var(--red-dark);
-}
-
-.switch--red:hover::after,
 input:checked + .switch--red {
   background-color: var(--red-dark);
-}
-
-.switch-container:hover > input:checked + .switch--red {
-  background-color: var(--red);
 }
 
 input:checked + .switch--dot-red::after {
@@ -5506,17 +4807,8 @@ input:checked + .switch--dot-red::after {
   color: var(--orange);
 }
 
-.switch-container:hover > .switch--orange {
-  color: var(--orange-dark);
-}
-
-.switch--orange:hover::after,
 input:checked + .switch--orange {
   background-color: var(--orange-dark);
-}
-
-.switch-container:hover > input:checked + .switch--orange {
-  background-color: var(--orange);
 }
 
 input:checked + .switch--dot-orange::after {
@@ -5527,17 +4819,8 @@ input:checked + .switch--dot-orange::after {
   color: var(--yellow);
 }
 
-.switch-container:hover > .switch--yellow {
-  color: var(--yellow-dark);
-}
-
-.switch--yellow:hover::after,
 input:checked + .switch--yellow {
   background-color: var(--yellow-dark);
-}
-
-.switch-container:hover > input:checked + .switch--yellow {
-  background-color: var(--yellow);
 }
 
 input:checked + .switch--dot-yellow::after {
@@ -5548,17 +4831,8 @@ input:checked + .switch--dot-yellow::after {
   color: var(--green);
 }
 
-.switch-container:hover > .switch--green {
-  color: var(--green-dark);
-}
-
-.switch--green:hover::after,
 input:checked + .switch--green {
   background-color: var(--green-dark);
-}
-
-.switch-container:hover > input:checked + .switch--green {
-  background-color: var(--green);
 }
 
 input:checked + .switch--dot-green::after {
@@ -5569,17 +4843,8 @@ input:checked + .switch--dot-green::after {
   color: var(--blue);
 }
 
-.switch-container:hover > .switch--blue {
-  color: var(--blue-dark);
-}
-
-.switch--blue:hover::after,
 input:checked + .switch--blue {
   background-color: var(--blue-dark);
-}
-
-.switch-container:hover > input:checked + .switch--blue {
-  background-color: var(--blue);
 }
 
 input:checked + .switch--dot-blue::after {
@@ -5590,17 +4855,8 @@ input:checked + .switch--dot-blue::after {
   color: var(--purple);
 }
 
-.switch-container:hover > .switch--purple {
-  color: var(--purple-dark);
-}
-
-.switch--purple:hover::after,
 input:checked + .switch--purple {
   background-color: var(--purple-dark);
-}
-
-.switch-container:hover > input:checked + .switch--purple {
-  background-color: var(--purple);
 }
 
 input:checked + .switch--dot-purple::after {
@@ -5611,17 +4867,8 @@ input:checked + .switch--dot-purple::after {
   color: var(--darken25);
 }
 
-.switch-container:hover > .switch--darken25 {
-  color: var(--darken50);
-}
-
-.switch--darken25:hover::after,
 input:checked + .switch--darken25 {
   background-color: var(--darken50);
-}
-
-.switch-container:hover > input:checked + .switch--darken25 {
-  background-color: var(--darken25);
 }
 
 input:checked + .switch--dot-darken25::after {
@@ -5632,17 +4879,8 @@ input:checked + .switch--dot-darken25::after {
   color: var(--darken50);
 }
 
-.switch-container:hover > .switch--darken50 {
-  color: var(--darken75);
-}
-
-.switch--darken50:hover::after,
 input:checked + .switch--darken50 {
   background-color: var(--darken75);
-}
-
-.switch-container:hover > input:checked + .switch--darken50 {
-  background-color: var(--darken50);
 }
 
 input:checked + .switch--dot-darken50::after {
@@ -5653,17 +4891,8 @@ input:checked + .switch--dot-darken50::after {
   color: var(--darken75);
 }
 
-.switch-container:hover > .switch--darken75 {
-  color: var(--black);
-}
-
-.switch--darken75:hover::after,
 input:checked + .switch--darken75 {
   background-color: var(--black);
-}
-
-.switch-container:hover > input:checked + .switch--darken75 {
-  background-color: var(--darken75);
 }
 
 input:checked + .switch--dot-darken75::after {
@@ -5674,17 +4903,8 @@ input:checked + .switch--dot-darken75::after {
   color: var(--lighten25);
 }
 
-.switch-container:hover > .switch--lighten25 {
-  color: var(--lighten50);
-}
-
-.switch--lighten25:hover::after,
 input:checked + .switch--lighten25 {
   background-color: var(--lighten50);
-}
-
-.switch-container:hover > input:checked + .switch--lighten25 {
-  background-color: var(--lighten25);
 }
 
 input:checked + .switch--dot-lighten25::after {
@@ -5695,17 +4915,8 @@ input:checked + .switch--dot-lighten25::after {
   color: var(--lighten50);
 }
 
-.switch-container:hover > .switch--lighten50 {
-  color: var(--lighten75);
-}
-
-.switch--lighten50:hover::after,
 input:checked + .switch--lighten50 {
   background-color: var(--lighten75);
-}
-
-.switch-container:hover > input:checked + .switch--lighten50 {
-  background-color: var(--lighten50);
 }
 
 input:checked + .switch--dot-lighten50::after {
@@ -5716,17 +4927,8 @@ input:checked + .switch--dot-lighten50::after {
   color: var(--lighten75);
 }
 
-.switch-container:hover > .switch--lighten75 {
-  color: var(--white);
-}
-
-.switch--lighten75:hover::after,
 input:checked + .switch--lighten75 {
   background-color: var(--white);
-}
-
-.switch-container:hover > input:checked + .switch--lighten75 {
-  background-color: var(--lighten75);
 }
 
 input:checked + .switch--dot-lighten75::after {
@@ -5737,17 +4939,8 @@ input:checked + .switch--dot-lighten75::after {
   color: var(--white);
 }
 
-.switch-container:hover > .switch--white {
-  color: var(--lighten75);
-}
-
-.switch--white:hover::after,
 input:checked + .switch--white {
   background-color: var(--lighten75);
-}
-
-.switch-container:hover > input:checked + .switch--white {
-  background-color: var(--white);
 }
 
 input:checked + .switch--dot-white::after {
@@ -5758,17 +4951,8 @@ input:checked + .switch--dot-white::after {
   color: var(--transparent);
 }
 
-.switch-container:hover > .switch--transparent {
-  color: var(--darken10);
-}
-
-.switch--transparent:hover::after,
 input:checked + .switch--transparent {
   background-color: var(--darken10);
-}
-
-.switch-container:hover > input:checked + .switch--transparent {
-  background-color: var(--transparent);
 }
 
 input:checked + .switch--dot-transparent::after {
@@ -5776,52 +4960,36 @@ input:checked + .switch--dot-transparent::after {
 }
 
 .range--gray > input { color: var(--gray); }
-.range--gray:hover > input { color: var(--gray-dark); }
 
 .range--pink > input { color: var(--pink); }
-.range--pink:hover > input { color: var(--pink-dark); }
 
 .range--red > input { color: var(--red); }
-.range--red:hover > input { color: var(--red-dark); }
 
 .range--orange > input { color: var(--orange); }
-.range--orange:hover > input { color: var(--orange-dark); }
 
 .range--yellow > input { color: var(--yellow); }
-.range--yellow:hover > input { color: var(--yellow-dark); }
 
 .range--green > input { color: var(--green); }
-.range--green:hover > input { color: var(--green-dark); }
 
 .range--blue > input { color: var(--blue); }
-.range--blue:hover > input { color: var(--blue-dark); }
 
 .range--purple > input { color: var(--purple); }
-.range--purple:hover > input { color: var(--purple-dark); }
 
 .range--darken25 > input { color: var(--darken25); }
-.range--darken25:hover > input { color: var(--darken50); }
 
 .range--darken50 > input { color: var(--darken50); }
-.range--darken50:hover > input { color: var(--darken75); }
 
 .range--darken75 > input { color: var(--darken75); }
-.range--darken75:hover > input { color: var(--black); }
 
 .range--lighten25 > input { color: var(--lighten25); }
-.range--lighten25:hover > input { color: var(--lighten50); }
 
 .range--lighten50 > input { color: var(--lighten50); }
-.range--lighten50:hover > input { color: var(--lighten75); }
 
 .range--lighten75 > input { color: var(--lighten75); }
-.range--lighten75:hover > input { color: var(--white); }
 
 .range--white > input { color: var(--white); }
-.range--white:hover > input { color: var(--lighten75); }
 
 .range--transparent > input { color: var(--transparent); }
-.range--transparent:hover > input { color: var(--darken10); }
 
 /**
  * @section Text colors
@@ -7743,54 +6911,38 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-red,
 .input--border-red {
-  border-color: var(--red);
+  box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus {
-  border-color: var(--red-dark);
+  box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-teal,
 .input--border-teal {
-  border-color: var(--teal);
+  box-shadow: inset 0 0 0 1px var(--teal);
 }
 
 .textarea--border-teal:focus,
 .input--border-teal:focus {
-  border-color: var(--teal-dark);
+  box-shadow: inset 0 0 0 1px var(--teal-dark);
 }
 
 .checkbox--red {
   border-color: var(--red);
 }
 
-.checkbox-container:hover > .checkbox--red {
-  border-color: var(--red-dark);
-}
-
 input:checked + .checkbox--red {
   background-color: var(--red);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--red {
-  background-color: var(--red-dark);
 }
 
 .checkbox--teal {
   border-color: var(--teal);
 }
 
-.checkbox-container:hover > .checkbox--teal {
-  border-color: var(--teal-dark);
-}
-
 input:checked + .checkbox--teal {
   background-color: var(--teal);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--teal {
-  background-color: var(--teal-dark);
 }
 
 .radio--red,
@@ -7798,25 +6950,13 @@ input:checked + .radio--red {
   color: var(--red);
 }
 
-.radio-container:hover > .radio--red {
-  color: var(--red-dark);
-}
-
 .radio--teal,
 input:checked + .radio--teal {
   color: var(--teal);
 }
 
-.radio-container:hover > .radio--teal {
-  color: var(--teal-dark);
-}
-
 .toggle--red {
   color: var(--red);
-}
-
-.toggle--red:hover {
-  color: var(--red-dark);
 }
 
 input:checked + .toggle--red {
@@ -7825,10 +6965,6 @@ input:checked + .toggle--red {
 
 .toggle--teal {
   color: var(--teal);
-}
-
-.toggle--teal:hover {
-  color: var(--teal-dark);
 }
 
 input:checked + .toggle--teal {
@@ -7847,17 +6983,8 @@ input:checked + .toggle--active-teal {
   color: var(--red);
 }
 
-.switch-container:hover > .switch--red {
-  color: var(--red-dark);
-}
-
-.switch--red:hover::after,
 input:checked + .switch--red {
   background-color: var(--red-dark);
-}
-
-.switch-container:hover > input:checked + .switch--red {
-  background-color: var(--red);
 }
 
 input:checked + .switch--dot-red::after {
@@ -7868,17 +6995,8 @@ input:checked + .switch--dot-red::after {
   color: var(--teal);
 }
 
-.switch-container:hover > .switch--teal {
-  color: var(--teal-dark);
-}
-
-.switch--teal:hover::after,
 input:checked + .switch--teal {
   background-color: var(--teal-dark);
-}
-
-.switch-container:hover > input:checked + .switch--teal {
-  background-color: var(--teal);
 }
 
 input:checked + .switch--dot-teal::after {
@@ -7886,10 +7004,8 @@ input:checked + .switch--dot-teal::after {
 }
 
 .range--red > input { color: var(--red); }
-.range--red:hover > input { color: var(--red-dark); }
 
 .range--teal > input { color: var(--teal); }
-.range--teal:hover > input { color: var(--teal-dark); }
 
 /**
  * @section Text colors
@@ -8260,80 +7376,56 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-lighten50,
 .input--border-lighten50 {
-  border-color: var(--lighten50);
+  box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus {
-  border-color: var(--lighten75);
+  box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25 {
-  border-color: var(--lighten25);
+  box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus {
-  border-color: var(--lighten50);
+  box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-gray,
 .input--border-gray {
-  border-color: var(--gray);
+  box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus {
-  border-color: var(--gray-dark);
+  box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .checkbox--lighten50 {
   border-color: var(--lighten50);
 }
 
-.checkbox-container:hover > .checkbox--lighten50 {
-  border-color: var(--lighten75);
-}
-
 input:checked + .checkbox--lighten50 {
   background-color: var(--lighten50);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten50 {
-  background-color: var(--lighten75);
 }
 
 .checkbox--lighten25 {
   border-color: var(--lighten25);
 }
 
-.checkbox-container:hover > .checkbox--lighten25 {
-  border-color: var(--lighten50);
-}
-
 input:checked + .checkbox--lighten25 {
   background-color: var(--lighten25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten25 {
-  background-color: var(--lighten50);
 }
 
 .checkbox--gray {
   border-color: var(--gray);
 }
 
-.checkbox-container:hover > .checkbox--gray {
-  border-color: var(--gray-dark);
-}
-
 input:checked + .checkbox--gray {
   background-color: var(--gray);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--gray {
-  background-color: var(--gray-dark);
 }
 
 .radio--lighten50,
@@ -8341,17 +7433,9 @@ input:checked + .radio--lighten50 {
   color: var(--lighten50);
 }
 
-.radio-container:hover > .radio--lighten50 {
-  color: var(--lighten75);
-}
-
 .radio--lighten25,
 input:checked + .radio--lighten25 {
   color: var(--lighten25);
-}
-
-.radio-container:hover > .radio--lighten25 {
-  color: var(--lighten50);
 }
 
 .radio--gray,
@@ -8359,16 +7443,8 @@ input:checked + .radio--gray {
   color: var(--gray);
 }
 
-.radio-container:hover > .radio--gray {
-  color: var(--gray-dark);
-}
-
 .toggle--lighten50 {
   color: var(--lighten50);
-}
-
-.toggle--lighten50:hover {
-  color: var(--lighten75);
 }
 
 input:checked + .toggle--lighten50 {
@@ -8379,20 +7455,12 @@ input:checked + .toggle--lighten50 {
   color: var(--lighten25);
 }
 
-.toggle--lighten25:hover {
-  color: var(--lighten50);
-}
-
 input:checked + .toggle--lighten25 {
   background: var(--lighten25);
 }
 
 .toggle--gray {
   color: var(--gray);
-}
-
-.toggle--gray:hover {
-  color: var(--gray-dark);
 }
 
 input:checked + .toggle--gray {

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -587,11 +587,11 @@ textarea{
 }
 .btn{
   display:inline-block;
+  font-weight:bold;
   background-color:#448ee4;
   color:#fff;
   border-radius:18px;
   padding:6px 12px;
-  font-weight:bold;
   text-align:center;
   transition:background-color 0.125s,
     border-color 0.125s,
@@ -607,12 +607,13 @@ textarea{
 }
 .btn--s{
   font-size:12px;
-  padding:0 12px;
+  line-height:18px;
+  padding:3px 12px;
   border-radius:15px;
 }
 .btn--xs{
-  line-height:18px;
   font-size:10px;
+  line-height:15px;
   padding:0 6px;
   border-radius:14px;
 }
@@ -745,7 +746,8 @@ textarea{
 }
 .input,
 .textarea{
-  border:1px solid #ccc;
+  box-shadow:inset 0 0 0 1px #ccc;
+  padding:6px 12px;
   border-radius:4px;
   transition:background-color 0.125s,
     border-color 0.125s;
@@ -755,7 +757,7 @@ textarea{
 
 .input:focus,
 .textarea:focus{
-  border-color:#448ee4;
+  box-shadow:inset 0 0 0 1px #448ee4;
 }
 
 .input::-webkit-input-placeholder,
@@ -771,9 +773,6 @@ textarea{
 .input::placeholder,
 .textarea::placeholder{
   color:rgba(127, 127, 127, 0.45);
-}
-.textarea{
-  overflow:auto;
 }
 .input::-ms-clear,
 .input::-ms-reveal{
@@ -791,32 +790,36 @@ textarea{
   -webkit-appearance:none;
           appearance:none;
 }
-.input{
-  height:36px;
-  line-height:34px;
-  padding:0 12px;
-}
 .input--s{
-  height:24px;
-  line-height:22px;
-  padding:0 6px;
+  font-size:12px;
+  line-height:18px;
+  padding:3px 6px;
+}
+.input--xs{
+  font-size:10px;
+  line-height:15px;
+  padding:0 4px;
 }
 .textarea{
   resize:vertical;
-  padding-top:10px;
-  padding-bottom:10px;
-  padding-left:10px;
-  padding-right:10px;
+  overflow:auto;
 }
 .textarea--s{
-  padding:0 4px;
+  font-size:12px;
+  line-height:18px;
+  padding:3px 6px;
+}
+.textarea--xs{
+  font-size:10px;
+  line-height:15px;
+  padding:0 3px;
 }
 .input:disabled,
 .textarea:disabled{
   pointer-events:none;
   color:rgba(0, 0, 0, 0.5) !important;
   background-color:rgba(127, 127, 127, 0.1) !important;
-  border-color:rgba(127, 127, 127, 0.25) !important;
+  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25) !important;
 }
 .input[readonly],
 .textarea[readonly]{
@@ -835,8 +838,8 @@ textarea{
   -webkit-appearance:none;
      -moz-appearance:none;
           appearance:none;
-  line-height:inherit;
-  font-size:inherit;
+  font-size:15px;
+  line-height:24px;
   font-weight:bold;
   color:currentColor;
   padding:6px 30px 6px 12px;
@@ -909,7 +912,8 @@ textarea{
 }
 .select--s{
   font-size:12px;
-  padding:0 20px 0 6px;
+  line-height:18px;
+  padding:3px 20px 3px 6px;
 }
 
 .select--s + .select-arrow{
@@ -917,7 +921,7 @@ textarea{
 }
 .select--xs{
   font-size:10px;
-  line-height:18px;
+  line-height:15px;
   padding:0 20px 0 6px;
 }
 
@@ -1122,10 +1126,6 @@ textarea{
     border 0.125s,
     background-color 0.125s;
 }
-
-.checkbox-container:hover > .checkbox{
-  border-color:#346db0;
-}
 .btn:not(.btn--stroke) > .checkbox{
   border-color:transparent;
   top:0;
@@ -1143,10 +1143,6 @@ textarea{
   border-radius:50%;
   color:#999;
   border-color:currentColor;
-}
-
-.radio-container:hover > .radio{
-  color:#346db0;
 }
 
 .radio::before{
@@ -1248,14 +1244,6 @@ input:checked + .checkbox{
   border:2px solid transparent;
   background-color:#448ee4;
 }
-
-.checkbox-container:hover > input:checked + .checkbox{
-  background-color:#346db0;
-}
-.switch-container:hover > .switch{
-  color:#448ee4;
-}
-
 input:checked + .switch::after{
   left:calc(50% + 1px);
   background-color:#fff;
@@ -1265,11 +1253,6 @@ input:checked + .switch{
   border-color:transparent;
   background-color:#448ee4;
 }
-.toggle:hover{
-  color:#448ee4;
-  border-color:#448ee4;
-}
-
 input:checked + .toggle{
   background:#448ee4;
   color:#fff;
@@ -9168,418 +9151,290 @@ input:checked:disabled + .toggle{
 
 .textarea--border-gray,
 .input--border-gray{
-  border-color:#666;
+  box-shadow:inset 0 0 0 1px #666;
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus{
-  border-color:#2d2d2d;
+  box-shadow:inset 0 0 0 1px #2d2d2d;
 }
 
 .textarea--border-pink,
 .input--border-pink{
-  border-color:#ff3c96;
+  box-shadow:inset 0 0 0 1px #ff3c96;
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus{
-  border-color:#ab084b;
+  box-shadow:inset 0 0 0 1px #ab084b;
 }
 
 .textarea--border-red,
 .input--border-red{
-  border-color:#dc2b28;
+  box-shadow:inset 0 0 0 1px #dc2b28;
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus{
-  border-color:#a30003;
+  box-shadow:inset 0 0 0 1px #a30003;
 }
 
 .textarea--border-orange,
 .input--border-orange{
-  border-color:#ff6e00;
+  box-shadow:inset 0 0 0 1px #ff6e00;
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus{
-  border-color:#bc3a00;
+  box-shadow:inset 0 0 0 1px #bc3a00;
 }
 
 .textarea--border-yellow,
 .input--border-yellow{
-  border-color:#f0dc00;
+  box-shadow:inset 0 0 0 1px #f0dc00;
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus{
-  border-color:#d9a100;
+  box-shadow:inset 0 0 0 1px #d9a100;
 }
 
 .textarea--border-green,
 .input--border-green{
-  border-color:#01aa46;
+  box-shadow:inset 0 0 0 1px #01aa46;
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus{
-  border-color:#006427;
+  box-shadow:inset 0 0 0 1px #006427;
 }
 
 .textarea--border-blue,
 .input--border-blue{
-  border-color:#3887BE;
+  box-shadow:inset 0 0 0 1px #3887BE;
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus{
-  border-color:#223B53;
+  box-shadow:inset 0 0 0 1px #223B53;
 }
 
 .textarea--border-purple,
 .input--border-purple{
-  border-color:#8c50c7;
+  box-shadow:inset 0 0 0 1px #8c50c7;
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus{
-  border-color:#440067;
+  box-shadow:inset 0 0 0 1px #440067;
 }
 
 .textarea--border-darken25,
 .input--border-darken25{
-  border-color:rgba(0, 0, 0, 0.25);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus{
-  border-color:rgba(0, 0, 0, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50,
 .input--border-darken50{
-  border-color:rgba(0, 0, 0, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus{
-  border-color:rgba(0, 0, 0, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75{
-  border-color:rgba(0, 0, 0, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus{
-  border-color:#000;
+  box-shadow:inset 0 0 0 1px #000;
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25{
-  border-color:rgba(255, 255, 255, 0.25);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus{
-  border-color:rgba(255, 255, 255, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50{
-  border-color:rgba(255, 255, 255, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus{
-  border-color:rgba(255, 255, 255, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75{
-  border-color:rgba(255, 255, 255, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus{
-  border-color:#fff;
+  box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white,
 .input--border-white{
-  border-color:#fff;
+  box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus{
-  border-color:rgba(255, 255, 255, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent{
-  border-color:transparent;
+  box-shadow:inset 0 0 0 1px transparent;
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus{
-  border-color:rgba(0, 0, 0, 0.1);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 
 .checkbox--gray{
   border-color:#666;
 }
 
-.checkbox-container:hover > .checkbox--gray{
-  border-color:#2d2d2d;
-}
-
 input:checked + .checkbox--gray{
   background-color:#666;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--gray{
-  background-color:#2d2d2d;
 }
 
 .checkbox--pink{
   border-color:#ff3c96;
 }
 
-.checkbox-container:hover > .checkbox--pink{
-  border-color:#ab084b;
-}
-
 input:checked + .checkbox--pink{
   background-color:#ff3c96;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--pink{
-  background-color:#ab084b;
 }
 
 .checkbox--red{
   border-color:#dc2b28;
 }
 
-.checkbox-container:hover > .checkbox--red{
-  border-color:#a30003;
-}
-
 input:checked + .checkbox--red{
   background-color:#dc2b28;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--red{
-  background-color:#a30003;
 }
 
 .checkbox--orange{
   border-color:#ff6e00;
 }
 
-.checkbox-container:hover > .checkbox--orange{
-  border-color:#bc3a00;
-}
-
 input:checked + .checkbox--orange{
   background-color:#ff6e00;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--orange{
-  background-color:#bc3a00;
 }
 
 .checkbox--yellow{
   border-color:#f0dc00;
 }
 
-.checkbox-container:hover > .checkbox--yellow{
-  border-color:#d9a100;
-}
-
 input:checked + .checkbox--yellow{
   background-color:#f0dc00;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--yellow{
-  background-color:#d9a100;
 }
 
 .checkbox--green{
   border-color:#01aa46;
 }
 
-.checkbox-container:hover > .checkbox--green{
-  border-color:#006427;
-}
-
 input:checked + .checkbox--green{
   background-color:#01aa46;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--green{
-  background-color:#006427;
 }
 
 .checkbox--blue{
   border-color:#3887BE;
 }
 
-.checkbox-container:hover > .checkbox--blue{
-  border-color:#223B53;
-}
-
 input:checked + .checkbox--blue{
   background-color:#3887BE;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--blue{
-  background-color:#223B53;
 }
 
 .checkbox--purple{
   border-color:#8c50c7;
 }
 
-.checkbox-container:hover > .checkbox--purple{
-  border-color:#440067;
-}
-
 input:checked + .checkbox--purple{
   background-color:#8c50c7;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--purple{
-  background-color:#440067;
 }
 
 .checkbox--darken25{
   border-color:rgba(0, 0, 0, 0.25);
 }
 
-.checkbox-container:hover > .checkbox--darken25{
-  border-color:rgba(0, 0, 0, 0.5);
-}
-
 input:checked + .checkbox--darken25{
   background-color:rgba(0, 0, 0, 0.25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken25{
-  background-color:rgba(0, 0, 0, 0.5);
 }
 
 .checkbox--darken50{
   border-color:rgba(0, 0, 0, 0.5);
 }
 
-.checkbox-container:hover > .checkbox--darken50{
-  border-color:rgba(0, 0, 0, 0.75);
-}
-
 input:checked + .checkbox--darken50{
   background-color:rgba(0, 0, 0, 0.5);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken50{
-  background-color:rgba(0, 0, 0, 0.75);
 }
 
 .checkbox--darken75{
   border-color:rgba(0, 0, 0, 0.75);
 }
 
-.checkbox-container:hover > .checkbox--darken75{
-  border-color:#000;
-}
-
 input:checked + .checkbox--darken75{
   background-color:rgba(0, 0, 0, 0.75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken75{
-  background-color:#000;
 }
 
 .checkbox--lighten25{
   border-color:rgba(255, 255, 255, 0.25);
 }
 
-.checkbox-container:hover > .checkbox--lighten25{
-  border-color:rgba(255, 255, 255, 0.5);
-}
-
 input:checked + .checkbox--lighten25{
   background-color:rgba(255, 255, 255, 0.25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten25{
-  background-color:rgba(255, 255, 255, 0.5);
 }
 
 .checkbox--lighten50{
   border-color:rgba(255, 255, 255, 0.5);
 }
 
-.checkbox-container:hover > .checkbox--lighten50{
-  border-color:rgba(255, 255, 255, 0.75);
-}
-
 input:checked + .checkbox--lighten50{
   background-color:rgba(255, 255, 255, 0.5);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten50{
-  background-color:rgba(255, 255, 255, 0.75);
 }
 
 .checkbox--lighten75{
   border-color:rgba(255, 255, 255, 0.75);
 }
 
-.checkbox-container:hover > .checkbox--lighten75{
-  border-color:#fff;
-}
-
 input:checked + .checkbox--lighten75{
   background-color:rgba(255, 255, 255, 0.75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten75{
-  background-color:#fff;
 }
 
 .checkbox--white{
   border-color:#fff;
 }
 
-.checkbox-container:hover > .checkbox--white{
-  border-color:rgba(255, 255, 255, 0.75);
-}
-
 input:checked + .checkbox--white{
   background-color:#fff;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--white{
-  background-color:rgba(255, 255, 255, 0.75);
 }
 
 .checkbox--transparent{
   border-color:transparent;
 }
 
-.checkbox-container:hover > .checkbox--transparent{
-  border-color:rgba(0, 0, 0, 0.1);
-}
-
 input:checked + .checkbox--transparent{
   background-color:transparent;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--transparent{
-  background-color:rgba(0, 0, 0, 0.1);
 }
 
 .radio--gray,
@@ -9587,17 +9442,9 @@ input:checked + .radio--gray{
   color:#666;
 }
 
-.radio-container:hover > .radio--gray{
-  color:#2d2d2d;
-}
-
 .radio--pink,
 input:checked + .radio--pink{
   color:#ff3c96;
-}
-
-.radio-container:hover > .radio--pink{
-  color:#ab084b;
 }
 
 .radio--red,
@@ -9605,17 +9452,9 @@ input:checked + .radio--red{
   color:#dc2b28;
 }
 
-.radio-container:hover > .radio--red{
-  color:#a30003;
-}
-
 .radio--orange,
 input:checked + .radio--orange{
   color:#ff6e00;
-}
-
-.radio-container:hover > .radio--orange{
-  color:#bc3a00;
 }
 
 .radio--yellow,
@@ -9623,17 +9462,9 @@ input:checked + .radio--yellow{
   color:#f0dc00;
 }
 
-.radio-container:hover > .radio--yellow{
-  color:#d9a100;
-}
-
 .radio--green,
 input:checked + .radio--green{
   color:#01aa46;
-}
-
-.radio-container:hover > .radio--green{
-  color:#006427;
 }
 
 .radio--blue,
@@ -9641,17 +9472,9 @@ input:checked + .radio--blue{
   color:#3887BE;
 }
 
-.radio-container:hover > .radio--blue{
-  color:#223B53;
-}
-
 .radio--purple,
 input:checked + .radio--purple{
   color:#8c50c7;
-}
-
-.radio-container:hover > .radio--purple{
-  color:#440067;
 }
 
 .radio--darken25,
@@ -9659,17 +9482,9 @@ input:checked + .radio--darken25{
   color:rgba(0, 0, 0, 0.25);
 }
 
-.radio-container:hover > .radio--darken25{
-  color:rgba(0, 0, 0, 0.5);
-}
-
 .radio--darken50,
 input:checked + .radio--darken50{
   color:rgba(0, 0, 0, 0.5);
-}
-
-.radio-container:hover > .radio--darken50{
-  color:rgba(0, 0, 0, 0.75);
 }
 
 .radio--darken75,
@@ -9677,17 +9492,9 @@ input:checked + .radio--darken75{
   color:rgba(0, 0, 0, 0.75);
 }
 
-.radio-container:hover > .radio--darken75{
-  color:#000;
-}
-
 .radio--lighten25,
 input:checked + .radio--lighten25{
   color:rgba(255, 255, 255, 0.25);
-}
-
-.radio-container:hover > .radio--lighten25{
-  color:rgba(255, 255, 255, 0.5);
 }
 
 .radio--lighten50,
@@ -9695,17 +9502,9 @@ input:checked + .radio--lighten50{
   color:rgba(255, 255, 255, 0.5);
 }
 
-.radio-container:hover > .radio--lighten50{
-  color:rgba(255, 255, 255, 0.75);
-}
-
 .radio--lighten75,
 input:checked + .radio--lighten75{
   color:rgba(255, 255, 255, 0.75);
-}
-
-.radio-container:hover > .radio--lighten75{
-  color:#fff;
 }
 
 .radio--white,
@@ -9713,25 +9512,13 @@ input:checked + .radio--white{
   color:#fff;
 }
 
-.radio-container:hover > .radio--white{
-  color:rgba(255, 255, 255, 0.75);
-}
-
 .radio--transparent,
 input:checked + .radio--transparent{
   color:transparent;
 }
 
-.radio-container:hover > .radio--transparent{
-  color:rgba(0, 0, 0, 0.1);
-}
-
 .toggle--gray{
   color:#666;
-}
-
-.toggle--gray:hover{
-  color:#2d2d2d;
 }
 
 input:checked + .toggle--gray{
@@ -9742,20 +9529,12 @@ input:checked + .toggle--gray{
   color:#ff3c96;
 }
 
-.toggle--pink:hover{
-  color:#ab084b;
-}
-
 input:checked + .toggle--pink{
   background:#ff3c96;
 }
 
 .toggle--red{
   color:#dc2b28;
-}
-
-.toggle--red:hover{
-  color:#a30003;
 }
 
 input:checked + .toggle--red{
@@ -9766,20 +9545,12 @@ input:checked + .toggle--red{
   color:#ff6e00;
 }
 
-.toggle--orange:hover{
-  color:#bc3a00;
-}
-
 input:checked + .toggle--orange{
   background:#ff6e00;
 }
 
 .toggle--yellow{
   color:#f0dc00;
-}
-
-.toggle--yellow:hover{
-  color:#d9a100;
 }
 
 input:checked + .toggle--yellow{
@@ -9790,20 +9561,12 @@ input:checked + .toggle--yellow{
   color:#01aa46;
 }
 
-.toggle--green:hover{
-  color:#006427;
-}
-
 input:checked + .toggle--green{
   background:#01aa46;
 }
 
 .toggle--blue{
   color:#3887BE;
-}
-
-.toggle--blue:hover{
-  color:#223B53;
 }
 
 input:checked + .toggle--blue{
@@ -9814,20 +9577,12 @@ input:checked + .toggle--blue{
   color:#8c50c7;
 }
 
-.toggle--purple:hover{
-  color:#440067;
-}
-
 input:checked + .toggle--purple{
   background:#8c50c7;
 }
 
 .toggle--darken25{
   color:rgba(0, 0, 0, 0.25);
-}
-
-.toggle--darken25:hover{
-  color:rgba(0, 0, 0, 0.5);
 }
 
 input:checked + .toggle--darken25{
@@ -9838,20 +9593,12 @@ input:checked + .toggle--darken25{
   color:rgba(0, 0, 0, 0.5);
 }
 
-.toggle--darken50:hover{
-  color:rgba(0, 0, 0, 0.75);
-}
-
 input:checked + .toggle--darken50{
   background:rgba(0, 0, 0, 0.5);
 }
 
 .toggle--darken75{
   color:rgba(0, 0, 0, 0.75);
-}
-
-.toggle--darken75:hover{
-  color:#000;
 }
 
 input:checked + .toggle--darken75{
@@ -9862,20 +9609,12 @@ input:checked + .toggle--darken75{
   color:rgba(255, 255, 255, 0.25);
 }
 
-.toggle--lighten25:hover{
-  color:rgba(255, 255, 255, 0.5);
-}
-
 input:checked + .toggle--lighten25{
   background:rgba(255, 255, 255, 0.25);
 }
 
 .toggle--lighten50{
   color:rgba(255, 255, 255, 0.5);
-}
-
-.toggle--lighten50:hover{
-  color:rgba(255, 255, 255, 0.75);
 }
 
 input:checked + .toggle--lighten50{
@@ -9886,10 +9625,6 @@ input:checked + .toggle--lighten50{
   color:rgba(255, 255, 255, 0.75);
 }
 
-.toggle--lighten75:hover{
-  color:#fff;
-}
-
 input:checked + .toggle--lighten75{
   background:rgba(255, 255, 255, 0.75);
 }
@@ -9898,20 +9633,12 @@ input:checked + .toggle--lighten75{
   color:#fff;
 }
 
-.toggle--white:hover{
-  color:rgba(255, 255, 255, 0.75);
-}
-
 input:checked + .toggle--white{
   background:#fff;
 }
 
 .toggle--transparent{
   color:transparent;
-}
-
-.toggle--transparent:hover{
-  color:rgba(0, 0, 0, 0.1);
 }
 
 input:checked + .toggle--transparent{
@@ -9986,17 +9713,8 @@ input:checked + .toggle--active-transparent{
   color:#666;
 }
 
-.switch-container:hover > .switch--gray{
-  color:#2d2d2d;
-}
-
-.switch--gray:hover::after,
 input:checked + .switch--gray{
   background-color:#2d2d2d;
-}
-
-.switch-container:hover > input:checked + .switch--gray{
-  background-color:#666;
 }
 
 input:checked + .switch--dot-gray::after{
@@ -10007,17 +9725,8 @@ input:checked + .switch--dot-gray::after{
   color:#ff3c96;
 }
 
-.switch-container:hover > .switch--pink{
-  color:#ab084b;
-}
-
-.switch--pink:hover::after,
 input:checked + .switch--pink{
   background-color:#ab084b;
-}
-
-.switch-container:hover > input:checked + .switch--pink{
-  background-color:#ff3c96;
 }
 
 input:checked + .switch--dot-pink::after{
@@ -10028,17 +9737,8 @@ input:checked + .switch--dot-pink::after{
   color:#dc2b28;
 }
 
-.switch-container:hover > .switch--red{
-  color:#a30003;
-}
-
-.switch--red:hover::after,
 input:checked + .switch--red{
   background-color:#a30003;
-}
-
-.switch-container:hover > input:checked + .switch--red{
-  background-color:#dc2b28;
 }
 
 input:checked + .switch--dot-red::after{
@@ -10049,17 +9749,8 @@ input:checked + .switch--dot-red::after{
   color:#ff6e00;
 }
 
-.switch-container:hover > .switch--orange{
-  color:#bc3a00;
-}
-
-.switch--orange:hover::after,
 input:checked + .switch--orange{
   background-color:#bc3a00;
-}
-
-.switch-container:hover > input:checked + .switch--orange{
-  background-color:#ff6e00;
 }
 
 input:checked + .switch--dot-orange::after{
@@ -10070,17 +9761,8 @@ input:checked + .switch--dot-orange::after{
   color:#f0dc00;
 }
 
-.switch-container:hover > .switch--yellow{
-  color:#d9a100;
-}
-
-.switch--yellow:hover::after,
 input:checked + .switch--yellow{
   background-color:#d9a100;
-}
-
-.switch-container:hover > input:checked + .switch--yellow{
-  background-color:#f0dc00;
 }
 
 input:checked + .switch--dot-yellow::after{
@@ -10091,17 +9773,8 @@ input:checked + .switch--dot-yellow::after{
   color:#01aa46;
 }
 
-.switch-container:hover > .switch--green{
-  color:#006427;
-}
-
-.switch--green:hover::after,
 input:checked + .switch--green{
   background-color:#006427;
-}
-
-.switch-container:hover > input:checked + .switch--green{
-  background-color:#01aa46;
 }
 
 input:checked + .switch--dot-green::after{
@@ -10112,17 +9785,8 @@ input:checked + .switch--dot-green::after{
   color:#3887BE;
 }
 
-.switch-container:hover > .switch--blue{
-  color:#223B53;
-}
-
-.switch--blue:hover::after,
 input:checked + .switch--blue{
   background-color:#223B53;
-}
-
-.switch-container:hover > input:checked + .switch--blue{
-  background-color:#3887BE;
 }
 
 input:checked + .switch--dot-blue::after{
@@ -10133,17 +9797,8 @@ input:checked + .switch--dot-blue::after{
   color:#8c50c7;
 }
 
-.switch-container:hover > .switch--purple{
-  color:#440067;
-}
-
-.switch--purple:hover::after,
 input:checked + .switch--purple{
   background-color:#440067;
-}
-
-.switch-container:hover > input:checked + .switch--purple{
-  background-color:#8c50c7;
 }
 
 input:checked + .switch--dot-purple::after{
@@ -10154,17 +9809,8 @@ input:checked + .switch--dot-purple::after{
   color:rgba(0, 0, 0, 0.25);
 }
 
-.switch-container:hover > .switch--darken25{
-  color:rgba(0, 0, 0, 0.5);
-}
-
-.switch--darken25:hover::after,
 input:checked + .switch--darken25{
   background-color:rgba(0, 0, 0, 0.5);
-}
-
-.switch-container:hover > input:checked + .switch--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
 }
 
 input:checked + .switch--dot-darken25::after{
@@ -10175,17 +9821,8 @@ input:checked + .switch--dot-darken25::after{
   color:rgba(0, 0, 0, 0.5);
 }
 
-.switch-container:hover > .switch--darken50{
-  color:rgba(0, 0, 0, 0.75);
-}
-
-.switch--darken50:hover::after,
 input:checked + .switch--darken50{
   background-color:rgba(0, 0, 0, 0.75);
-}
-
-.switch-container:hover > input:checked + .switch--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
 }
 
 input:checked + .switch--dot-darken50::after{
@@ -10196,17 +9833,8 @@ input:checked + .switch--dot-darken50::after{
   color:rgba(0, 0, 0, 0.75);
 }
 
-.switch-container:hover > .switch--darken75{
-  color:#000;
-}
-
-.switch--darken75:hover::after,
 input:checked + .switch--darken75{
   background-color:#000;
-}
-
-.switch-container:hover > input:checked + .switch--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
 }
 
 input:checked + .switch--dot-darken75::after{
@@ -10217,17 +9845,8 @@ input:checked + .switch--dot-darken75::after{
   color:rgba(255, 255, 255, 0.25);
 }
 
-.switch-container:hover > .switch--lighten25{
-  color:rgba(255, 255, 255, 0.5);
-}
-
-.switch--lighten25:hover::after,
 input:checked + .switch--lighten25{
   background-color:rgba(255, 255, 255, 0.5);
-}
-
-.switch-container:hover > input:checked + .switch--lighten25{
-  background-color:rgba(255, 255, 255, 0.25);
 }
 
 input:checked + .switch--dot-lighten25::after{
@@ -10238,17 +9857,8 @@ input:checked + .switch--dot-lighten25::after{
   color:rgba(255, 255, 255, 0.5);
 }
 
-.switch-container:hover > .switch--lighten50{
-  color:rgba(255, 255, 255, 0.75);
-}
-
-.switch--lighten50:hover::after,
 input:checked + .switch--lighten50{
   background-color:rgba(255, 255, 255, 0.75);
-}
-
-.switch-container:hover > input:checked + .switch--lighten50{
-  background-color:rgba(255, 255, 255, 0.5);
 }
 
 input:checked + .switch--dot-lighten50::after{
@@ -10259,17 +9869,8 @@ input:checked + .switch--dot-lighten50::after{
   color:rgba(255, 255, 255, 0.75);
 }
 
-.switch-container:hover > .switch--lighten75{
-  color:#fff;
-}
-
-.switch--lighten75:hover::after,
 input:checked + .switch--lighten75{
   background-color:#fff;
-}
-
-.switch-container:hover > input:checked + .switch--lighten75{
-  background-color:rgba(255, 255, 255, 0.75);
 }
 
 input:checked + .switch--dot-lighten75::after{
@@ -10280,17 +9881,8 @@ input:checked + .switch--dot-lighten75::after{
   color:#fff;
 }
 
-.switch-container:hover > .switch--white{
-  color:rgba(255, 255, 255, 0.75);
-}
-
-.switch--white:hover::after,
 input:checked + .switch--white{
   background-color:rgba(255, 255, 255, 0.75);
-}
-
-.switch-container:hover > input:checked + .switch--white{
-  background-color:#fff;
 }
 
 input:checked + .switch--dot-white::after{
@@ -10301,17 +9893,8 @@ input:checked + .switch--dot-white::after{
   color:transparent;
 }
 
-.switch-container:hover > .switch--transparent{
-  color:rgba(0, 0, 0, 0.1);
-}
-
-.switch--transparent:hover::after,
 input:checked + .switch--transparent{
   background-color:rgba(0, 0, 0, 0.1);
-}
-
-.switch-container:hover > input:checked + .switch--transparent{
-  background-color:transparent;
 }
 
 input:checked + .switch--dot-transparent::after{
@@ -13197,11 +12780,11 @@ textarea{
 }
 .btn{
   display:inline-block;
+  font-weight:bold;
   background-color:#448ee4;
   color:#fff;
   border-radius:18px;
   padding:6px 12px;
-  font-weight:bold;
   text-align:center;
   transition:background-color 0.125s,
     border-color 0.125s,
@@ -13217,12 +12800,13 @@ textarea{
 }
 .btn--s{
   font-size:12px;
-  padding:0 12px;
+  line-height:18px;
+  padding:3px 12px;
   border-radius:15px;
 }
 .btn--xs{
-  line-height:18px;
   font-size:10px;
+  line-height:15px;
   padding:0 6px;
   border-radius:14px;
 }
@@ -13355,7 +12939,8 @@ textarea{
 }
 .input,
 .textarea{
-  border:1px solid #ccc;
+  box-shadow:inset 0 0 0 1px #ccc;
+  padding:6px 12px;
   border-radius:4px;
   transition:background-color 0.125s,
     border-color 0.125s;
@@ -13365,7 +12950,7 @@ textarea{
 
 .input:focus,
 .textarea:focus{
-  border-color:#448ee4;
+  box-shadow:inset 0 0 0 1px #448ee4;
 }
 
 .input::-webkit-input-placeholder,
@@ -13381,9 +12966,6 @@ textarea{
 .input::placeholder,
 .textarea::placeholder{
   color:rgba(127, 127, 127, 0.45);
-}
-.textarea{
-  overflow:auto;
 }
 .input::-ms-clear,
 .input::-ms-reveal{
@@ -13401,32 +12983,36 @@ textarea{
   -webkit-appearance:none;
           appearance:none;
 }
-.input{
-  height:36px;
-  line-height:34px;
-  padding:0 12px;
-}
 .input--s{
-  height:24px;
-  line-height:22px;
-  padding:0 6px;
+  font-size:12px;
+  line-height:18px;
+  padding:3px 6px;
+}
+.input--xs{
+  font-size:10px;
+  line-height:15px;
+  padding:0 4px;
 }
 .textarea{
   resize:vertical;
-  padding-top:10px;
-  padding-bottom:10px;
-  padding-left:10px;
-  padding-right:10px;
+  overflow:auto;
 }
 .textarea--s{
-  padding:0 4px;
+  font-size:12px;
+  line-height:18px;
+  padding:3px 6px;
+}
+.textarea--xs{
+  font-size:10px;
+  line-height:15px;
+  padding:0 3px;
 }
 .input:disabled,
 .textarea:disabled{
   pointer-events:none;
   color:rgba(0, 0, 0, 0.5) !important;
   background-color:rgba(127, 127, 127, 0.1) !important;
-  border-color:rgba(127, 127, 127, 0.25) !important;
+  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25) !important;
 }
 .input[readonly],
 .textarea[readonly]{
@@ -13445,8 +13031,8 @@ textarea{
   -webkit-appearance:none;
      -moz-appearance:none;
           appearance:none;
-  line-height:inherit;
-  font-size:inherit;
+  font-size:15px;
+  line-height:24px;
   font-weight:bold;
   color:currentColor;
   padding:6px 30px 6px 12px;
@@ -13519,7 +13105,8 @@ textarea{
 }
 .select--s{
   font-size:12px;
-  padding:0 20px 0 6px;
+  line-height:18px;
+  padding:3px 20px 3px 6px;
 }
 
 .select--s + .select-arrow{
@@ -13527,7 +13114,7 @@ textarea{
 }
 .select--xs{
   font-size:10px;
-  line-height:18px;
+  line-height:15px;
   padding:0 20px 0 6px;
 }
 
@@ -13732,10 +13319,6 @@ textarea{
     border 0.125s,
     background-color 0.125s;
 }
-
-.checkbox-container:hover > .checkbox{
-  border-color:#346db0;
-}
 .btn:not(.btn--stroke) > .checkbox{
   border-color:transparent;
   top:0;
@@ -13753,10 +13336,6 @@ textarea{
   border-radius:50%;
   color:#999;
   border-color:currentColor;
-}
-
-.radio-container:hover > .radio{
-  color:#346db0;
 }
 
 .radio::before{
@@ -13858,14 +13437,6 @@ input:checked + .checkbox{
   border:2px solid transparent;
   background-color:#448ee4;
 }
-
-.checkbox-container:hover > input:checked + .checkbox{
-  background-color:#346db0;
-}
-.switch-container:hover > .switch{
-  color:#448ee4;
-}
-
 input:checked + .switch::after{
   left:calc(50% + 1px);
   background-color:#fff;
@@ -13875,11 +13446,6 @@ input:checked + .switch{
   border-color:transparent;
   background-color:#448ee4;
 }
-.toggle:hover{
-  color:#448ee4;
-  border-color:#448ee4;
-}
-
 input:checked + .toggle{
   background:#448ee4;
   color:#fff;
@@ -21764,418 +21330,290 @@ input:checked:disabled + .toggle{
 
 .textarea--border-gray,
 .input--border-gray{
-  border-color:#666;
+  box-shadow:inset 0 0 0 1px #666;
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus{
-  border-color:#2d2d2d;
+  box-shadow:inset 0 0 0 1px #2d2d2d;
 }
 
 .textarea--border-pink,
 .input--border-pink{
-  border-color:#ff3c96;
+  box-shadow:inset 0 0 0 1px #ff3c96;
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus{
-  border-color:#ab084b;
+  box-shadow:inset 0 0 0 1px #ab084b;
 }
 
 .textarea--border-red,
 .input--border-red{
-  border-color:#dc2b28;
+  box-shadow:inset 0 0 0 1px #dc2b28;
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus{
-  border-color:#a30003;
+  box-shadow:inset 0 0 0 1px #a30003;
 }
 
 .textarea--border-orange,
 .input--border-orange{
-  border-color:#ff6e00;
+  box-shadow:inset 0 0 0 1px #ff6e00;
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus{
-  border-color:#bc3a00;
+  box-shadow:inset 0 0 0 1px #bc3a00;
 }
 
 .textarea--border-yellow,
 .input--border-yellow{
-  border-color:#f0dc00;
+  box-shadow:inset 0 0 0 1px #f0dc00;
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus{
-  border-color:#d9a100;
+  box-shadow:inset 0 0 0 1px #d9a100;
 }
 
 .textarea--border-green,
 .input--border-green{
-  border-color:#01aa46;
+  box-shadow:inset 0 0 0 1px #01aa46;
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus{
-  border-color:#006427;
+  box-shadow:inset 0 0 0 1px #006427;
 }
 
 .textarea--border-blue,
 .input--border-blue{
-  border-color:#448ee4;
+  box-shadow:inset 0 0 0 1px #448ee4;
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus{
-  border-color:#295b97;
+  box-shadow:inset 0 0 0 1px #295b97;
 }
 
 .textarea--border-purple,
 .input--border-purple{
-  border-color:#8c50c7;
+  box-shadow:inset 0 0 0 1px #8c50c7;
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus{
-  border-color:#440067;
+  box-shadow:inset 0 0 0 1px #440067;
 }
 
 .textarea--border-darken25,
 .input--border-darken25{
-  border-color:rgba(0, 0, 0, 0.25);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus{
-  border-color:rgba(0, 0, 0, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50,
 .input--border-darken50{
-  border-color:rgba(0, 0, 0, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus{
-  border-color:rgba(0, 0, 0, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75{
-  border-color:rgba(0, 0, 0, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus{
-  border-color:#000;
+  box-shadow:inset 0 0 0 1px #000;
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25{
-  border-color:rgba(255, 255, 255, 0.25);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus{
-  border-color:rgba(255, 255, 255, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50{
-  border-color:rgba(255, 255, 255, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus{
-  border-color:rgba(255, 255, 255, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75{
-  border-color:rgba(255, 255, 255, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus{
-  border-color:#fff;
+  box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white,
 .input--border-white{
-  border-color:#fff;
+  box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus{
-  border-color:rgba(255, 255, 255, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent{
-  border-color:transparent;
+  box-shadow:inset 0 0 0 1px transparent;
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus{
-  border-color:rgba(0, 0, 0, 0.1);
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 
 .checkbox--gray{
   border-color:#666;
 }
 
-.checkbox-container:hover > .checkbox--gray{
-  border-color:#2d2d2d;
-}
-
 input:checked + .checkbox--gray{
   background-color:#666;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--gray{
-  background-color:#2d2d2d;
 }
 
 .checkbox--pink{
   border-color:#ff3c96;
 }
 
-.checkbox-container:hover > .checkbox--pink{
-  border-color:#ab084b;
-}
-
 input:checked + .checkbox--pink{
   background-color:#ff3c96;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--pink{
-  background-color:#ab084b;
 }
 
 .checkbox--red{
   border-color:#dc2b28;
 }
 
-.checkbox-container:hover > .checkbox--red{
-  border-color:#a30003;
-}
-
 input:checked + .checkbox--red{
   background-color:#dc2b28;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--red{
-  background-color:#a30003;
 }
 
 .checkbox--orange{
   border-color:#ff6e00;
 }
 
-.checkbox-container:hover > .checkbox--orange{
-  border-color:#bc3a00;
-}
-
 input:checked + .checkbox--orange{
   background-color:#ff6e00;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--orange{
-  background-color:#bc3a00;
 }
 
 .checkbox--yellow{
   border-color:#f0dc00;
 }
 
-.checkbox-container:hover > .checkbox--yellow{
-  border-color:#d9a100;
-}
-
 input:checked + .checkbox--yellow{
   background-color:#f0dc00;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--yellow{
-  background-color:#d9a100;
 }
 
 .checkbox--green{
   border-color:#01aa46;
 }
 
-.checkbox-container:hover > .checkbox--green{
-  border-color:#006427;
-}
-
 input:checked + .checkbox--green{
   background-color:#01aa46;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--green{
-  background-color:#006427;
 }
 
 .checkbox--blue{
   border-color:#448ee4;
 }
 
-.checkbox-container:hover > .checkbox--blue{
-  border-color:#295b97;
-}
-
 input:checked + .checkbox--blue{
   background-color:#448ee4;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--blue{
-  background-color:#295b97;
 }
 
 .checkbox--purple{
   border-color:#8c50c7;
 }
 
-.checkbox-container:hover > .checkbox--purple{
-  border-color:#440067;
-}
-
 input:checked + .checkbox--purple{
   background-color:#8c50c7;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--purple{
-  background-color:#440067;
 }
 
 .checkbox--darken25{
   border-color:rgba(0, 0, 0, 0.25);
 }
 
-.checkbox-container:hover > .checkbox--darken25{
-  border-color:rgba(0, 0, 0, 0.5);
-}
-
 input:checked + .checkbox--darken25{
   background-color:rgba(0, 0, 0, 0.25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken25{
-  background-color:rgba(0, 0, 0, 0.5);
 }
 
 .checkbox--darken50{
   border-color:rgba(0, 0, 0, 0.5);
 }
 
-.checkbox-container:hover > .checkbox--darken50{
-  border-color:rgba(0, 0, 0, 0.75);
-}
-
 input:checked + .checkbox--darken50{
   background-color:rgba(0, 0, 0, 0.5);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken50{
-  background-color:rgba(0, 0, 0, 0.75);
 }
 
 .checkbox--darken75{
   border-color:rgba(0, 0, 0, 0.75);
 }
 
-.checkbox-container:hover > .checkbox--darken75{
-  border-color:#000;
-}
-
 input:checked + .checkbox--darken75{
   background-color:rgba(0, 0, 0, 0.75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--darken75{
-  background-color:#000;
 }
 
 .checkbox--lighten25{
   border-color:rgba(255, 255, 255, 0.25);
 }
 
-.checkbox-container:hover > .checkbox--lighten25{
-  border-color:rgba(255, 255, 255, 0.5);
-}
-
 input:checked + .checkbox--lighten25{
   background-color:rgba(255, 255, 255, 0.25);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten25{
-  background-color:rgba(255, 255, 255, 0.5);
 }
 
 .checkbox--lighten50{
   border-color:rgba(255, 255, 255, 0.5);
 }
 
-.checkbox-container:hover > .checkbox--lighten50{
-  border-color:rgba(255, 255, 255, 0.75);
-}
-
 input:checked + .checkbox--lighten50{
   background-color:rgba(255, 255, 255, 0.5);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten50{
-  background-color:rgba(255, 255, 255, 0.75);
 }
 
 .checkbox--lighten75{
   border-color:rgba(255, 255, 255, 0.75);
 }
 
-.checkbox-container:hover > .checkbox--lighten75{
-  border-color:#fff;
-}
-
 input:checked + .checkbox--lighten75{
   background-color:rgba(255, 255, 255, 0.75);
-}
-
-.checkbox-container:hover > input:checked + .checkbox--lighten75{
-  background-color:#fff;
 }
 
 .checkbox--white{
   border-color:#fff;
 }
 
-.checkbox-container:hover > .checkbox--white{
-  border-color:rgba(255, 255, 255, 0.75);
-}
-
 input:checked + .checkbox--white{
   background-color:#fff;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--white{
-  background-color:rgba(255, 255, 255, 0.75);
 }
 
 .checkbox--transparent{
   border-color:transparent;
 }
 
-.checkbox-container:hover > .checkbox--transparent{
-  border-color:rgba(0, 0, 0, 0.1);
-}
-
 input:checked + .checkbox--transparent{
   background-color:transparent;
-}
-
-.checkbox-container:hover > input:checked + .checkbox--transparent{
-  background-color:rgba(0, 0, 0, 0.1);
 }
 
 .radio--gray,
@@ -22183,17 +21621,9 @@ input:checked + .radio--gray{
   color:#666;
 }
 
-.radio-container:hover > .radio--gray{
-  color:#2d2d2d;
-}
-
 .radio--pink,
 input:checked + .radio--pink{
   color:#ff3c96;
-}
-
-.radio-container:hover > .radio--pink{
-  color:#ab084b;
 }
 
 .radio--red,
@@ -22201,17 +21631,9 @@ input:checked + .radio--red{
   color:#dc2b28;
 }
 
-.radio-container:hover > .radio--red{
-  color:#a30003;
-}
-
 .radio--orange,
 input:checked + .radio--orange{
   color:#ff6e00;
-}
-
-.radio-container:hover > .radio--orange{
-  color:#bc3a00;
 }
 
 .radio--yellow,
@@ -22219,17 +21641,9 @@ input:checked + .radio--yellow{
   color:#f0dc00;
 }
 
-.radio-container:hover > .radio--yellow{
-  color:#d9a100;
-}
-
 .radio--green,
 input:checked + .radio--green{
   color:#01aa46;
-}
-
-.radio-container:hover > .radio--green{
-  color:#006427;
 }
 
 .radio--blue,
@@ -22237,17 +21651,9 @@ input:checked + .radio--blue{
   color:#448ee4;
 }
 
-.radio-container:hover > .radio--blue{
-  color:#295b97;
-}
-
 .radio--purple,
 input:checked + .radio--purple{
   color:#8c50c7;
-}
-
-.radio-container:hover > .radio--purple{
-  color:#440067;
 }
 
 .radio--darken25,
@@ -22255,17 +21661,9 @@ input:checked + .radio--darken25{
   color:rgba(0, 0, 0, 0.25);
 }
 
-.radio-container:hover > .radio--darken25{
-  color:rgba(0, 0, 0, 0.5);
-}
-
 .radio--darken50,
 input:checked + .radio--darken50{
   color:rgba(0, 0, 0, 0.5);
-}
-
-.radio-container:hover > .radio--darken50{
-  color:rgba(0, 0, 0, 0.75);
 }
 
 .radio--darken75,
@@ -22273,17 +21671,9 @@ input:checked + .radio--darken75{
   color:rgba(0, 0, 0, 0.75);
 }
 
-.radio-container:hover > .radio--darken75{
-  color:#000;
-}
-
 .radio--lighten25,
 input:checked + .radio--lighten25{
   color:rgba(255, 255, 255, 0.25);
-}
-
-.radio-container:hover > .radio--lighten25{
-  color:rgba(255, 255, 255, 0.5);
 }
 
 .radio--lighten50,
@@ -22291,17 +21681,9 @@ input:checked + .radio--lighten50{
   color:rgba(255, 255, 255, 0.5);
 }
 
-.radio-container:hover > .radio--lighten50{
-  color:rgba(255, 255, 255, 0.75);
-}
-
 .radio--lighten75,
 input:checked + .radio--lighten75{
   color:rgba(255, 255, 255, 0.75);
-}
-
-.radio-container:hover > .radio--lighten75{
-  color:#fff;
 }
 
 .radio--white,
@@ -22309,25 +21691,13 @@ input:checked + .radio--white{
   color:#fff;
 }
 
-.radio-container:hover > .radio--white{
-  color:rgba(255, 255, 255, 0.75);
-}
-
 .radio--transparent,
 input:checked + .radio--transparent{
   color:transparent;
 }
 
-.radio-container:hover > .radio--transparent{
-  color:rgba(0, 0, 0, 0.1);
-}
-
 .toggle--gray{
   color:#666;
-}
-
-.toggle--gray:hover{
-  color:#2d2d2d;
 }
 
 input:checked + .toggle--gray{
@@ -22338,20 +21708,12 @@ input:checked + .toggle--gray{
   color:#ff3c96;
 }
 
-.toggle--pink:hover{
-  color:#ab084b;
-}
-
 input:checked + .toggle--pink{
   background:#ff3c96;
 }
 
 .toggle--red{
   color:#dc2b28;
-}
-
-.toggle--red:hover{
-  color:#a30003;
 }
 
 input:checked + .toggle--red{
@@ -22362,20 +21724,12 @@ input:checked + .toggle--red{
   color:#ff6e00;
 }
 
-.toggle--orange:hover{
-  color:#bc3a00;
-}
-
 input:checked + .toggle--orange{
   background:#ff6e00;
 }
 
 .toggle--yellow{
   color:#f0dc00;
-}
-
-.toggle--yellow:hover{
-  color:#d9a100;
 }
 
 input:checked + .toggle--yellow{
@@ -22386,20 +21740,12 @@ input:checked + .toggle--yellow{
   color:#01aa46;
 }
 
-.toggle--green:hover{
-  color:#006427;
-}
-
 input:checked + .toggle--green{
   background:#01aa46;
 }
 
 .toggle--blue{
   color:#448ee4;
-}
-
-.toggle--blue:hover{
-  color:#295b97;
 }
 
 input:checked + .toggle--blue{
@@ -22410,20 +21756,12 @@ input:checked + .toggle--blue{
   color:#8c50c7;
 }
 
-.toggle--purple:hover{
-  color:#440067;
-}
-
 input:checked + .toggle--purple{
   background:#8c50c7;
 }
 
 .toggle--darken25{
   color:rgba(0, 0, 0, 0.25);
-}
-
-.toggle--darken25:hover{
-  color:rgba(0, 0, 0, 0.5);
 }
 
 input:checked + .toggle--darken25{
@@ -22434,20 +21772,12 @@ input:checked + .toggle--darken25{
   color:rgba(0, 0, 0, 0.5);
 }
 
-.toggle--darken50:hover{
-  color:rgba(0, 0, 0, 0.75);
-}
-
 input:checked + .toggle--darken50{
   background:rgba(0, 0, 0, 0.5);
 }
 
 .toggle--darken75{
   color:rgba(0, 0, 0, 0.75);
-}
-
-.toggle--darken75:hover{
-  color:#000;
 }
 
 input:checked + .toggle--darken75{
@@ -22458,20 +21788,12 @@ input:checked + .toggle--darken75{
   color:rgba(255, 255, 255, 0.25);
 }
 
-.toggle--lighten25:hover{
-  color:rgba(255, 255, 255, 0.5);
-}
-
 input:checked + .toggle--lighten25{
   background:rgba(255, 255, 255, 0.25);
 }
 
 .toggle--lighten50{
   color:rgba(255, 255, 255, 0.5);
-}
-
-.toggle--lighten50:hover{
-  color:rgba(255, 255, 255, 0.75);
 }
 
 input:checked + .toggle--lighten50{
@@ -22482,10 +21804,6 @@ input:checked + .toggle--lighten50{
   color:rgba(255, 255, 255, 0.75);
 }
 
-.toggle--lighten75:hover{
-  color:#fff;
-}
-
 input:checked + .toggle--lighten75{
   background:rgba(255, 255, 255, 0.75);
 }
@@ -22494,20 +21812,12 @@ input:checked + .toggle--lighten75{
   color:#fff;
 }
 
-.toggle--white:hover{
-  color:rgba(255, 255, 255, 0.75);
-}
-
 input:checked + .toggle--white{
   background:#fff;
 }
 
 .toggle--transparent{
   color:transparent;
-}
-
-.toggle--transparent:hover{
-  color:rgba(0, 0, 0, 0.1);
 }
 
 input:checked + .toggle--transparent{
@@ -22582,17 +21892,8 @@ input:checked + .toggle--active-transparent{
   color:#666;
 }
 
-.switch-container:hover > .switch--gray{
-  color:#2d2d2d;
-}
-
-.switch--gray:hover::after,
 input:checked + .switch--gray{
   background-color:#2d2d2d;
-}
-
-.switch-container:hover > input:checked + .switch--gray{
-  background-color:#666;
 }
 
 input:checked + .switch--dot-gray::after{
@@ -22603,17 +21904,8 @@ input:checked + .switch--dot-gray::after{
   color:#ff3c96;
 }
 
-.switch-container:hover > .switch--pink{
-  color:#ab084b;
-}
-
-.switch--pink:hover::after,
 input:checked + .switch--pink{
   background-color:#ab084b;
-}
-
-.switch-container:hover > input:checked + .switch--pink{
-  background-color:#ff3c96;
 }
 
 input:checked + .switch--dot-pink::after{
@@ -22624,17 +21916,8 @@ input:checked + .switch--dot-pink::after{
   color:#dc2b28;
 }
 
-.switch-container:hover > .switch--red{
-  color:#a30003;
-}
-
-.switch--red:hover::after,
 input:checked + .switch--red{
   background-color:#a30003;
-}
-
-.switch-container:hover > input:checked + .switch--red{
-  background-color:#dc2b28;
 }
 
 input:checked + .switch--dot-red::after{
@@ -22645,17 +21928,8 @@ input:checked + .switch--dot-red::after{
   color:#ff6e00;
 }
 
-.switch-container:hover > .switch--orange{
-  color:#bc3a00;
-}
-
-.switch--orange:hover::after,
 input:checked + .switch--orange{
   background-color:#bc3a00;
-}
-
-.switch-container:hover > input:checked + .switch--orange{
-  background-color:#ff6e00;
 }
 
 input:checked + .switch--dot-orange::after{
@@ -22666,17 +21940,8 @@ input:checked + .switch--dot-orange::after{
   color:#f0dc00;
 }
 
-.switch-container:hover > .switch--yellow{
-  color:#d9a100;
-}
-
-.switch--yellow:hover::after,
 input:checked + .switch--yellow{
   background-color:#d9a100;
-}
-
-.switch-container:hover > input:checked + .switch--yellow{
-  background-color:#f0dc00;
 }
 
 input:checked + .switch--dot-yellow::after{
@@ -22687,17 +21952,8 @@ input:checked + .switch--dot-yellow::after{
   color:#01aa46;
 }
 
-.switch-container:hover > .switch--green{
-  color:#006427;
-}
-
-.switch--green:hover::after,
 input:checked + .switch--green{
   background-color:#006427;
-}
-
-.switch-container:hover > input:checked + .switch--green{
-  background-color:#01aa46;
 }
 
 input:checked + .switch--dot-green::after{
@@ -22708,17 +21964,8 @@ input:checked + .switch--dot-green::after{
   color:#448ee4;
 }
 
-.switch-container:hover > .switch--blue{
-  color:#295b97;
-}
-
-.switch--blue:hover::after,
 input:checked + .switch--blue{
   background-color:#295b97;
-}
-
-.switch-container:hover > input:checked + .switch--blue{
-  background-color:#448ee4;
 }
 
 input:checked + .switch--dot-blue::after{
@@ -22729,17 +21976,8 @@ input:checked + .switch--dot-blue::after{
   color:#8c50c7;
 }
 
-.switch-container:hover > .switch--purple{
-  color:#440067;
-}
-
-.switch--purple:hover::after,
 input:checked + .switch--purple{
   background-color:#440067;
-}
-
-.switch-container:hover > input:checked + .switch--purple{
-  background-color:#8c50c7;
 }
 
 input:checked + .switch--dot-purple::after{
@@ -22750,17 +21988,8 @@ input:checked + .switch--dot-purple::after{
   color:rgba(0, 0, 0, 0.25);
 }
 
-.switch-container:hover > .switch--darken25{
-  color:rgba(0, 0, 0, 0.5);
-}
-
-.switch--darken25:hover::after,
 input:checked + .switch--darken25{
   background-color:rgba(0, 0, 0, 0.5);
-}
-
-.switch-container:hover > input:checked + .switch--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
 }
 
 input:checked + .switch--dot-darken25::after{
@@ -22771,17 +22000,8 @@ input:checked + .switch--dot-darken25::after{
   color:rgba(0, 0, 0, 0.5);
 }
 
-.switch-container:hover > .switch--darken50{
-  color:rgba(0, 0, 0, 0.75);
-}
-
-.switch--darken50:hover::after,
 input:checked + .switch--darken50{
   background-color:rgba(0, 0, 0, 0.75);
-}
-
-.switch-container:hover > input:checked + .switch--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
 }
 
 input:checked + .switch--dot-darken50::after{
@@ -22792,17 +22012,8 @@ input:checked + .switch--dot-darken50::after{
   color:rgba(0, 0, 0, 0.75);
 }
 
-.switch-container:hover > .switch--darken75{
-  color:#000;
-}
-
-.switch--darken75:hover::after,
 input:checked + .switch--darken75{
   background-color:#000;
-}
-
-.switch-container:hover > input:checked + .switch--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
 }
 
 input:checked + .switch--dot-darken75::after{
@@ -22813,17 +22024,8 @@ input:checked + .switch--dot-darken75::after{
   color:rgba(255, 255, 255, 0.25);
 }
 
-.switch-container:hover > .switch--lighten25{
-  color:rgba(255, 255, 255, 0.5);
-}
-
-.switch--lighten25:hover::after,
 input:checked + .switch--lighten25{
   background-color:rgba(255, 255, 255, 0.5);
-}
-
-.switch-container:hover > input:checked + .switch--lighten25{
-  background-color:rgba(255, 255, 255, 0.25);
 }
 
 input:checked + .switch--dot-lighten25::after{
@@ -22834,17 +22036,8 @@ input:checked + .switch--dot-lighten25::after{
   color:rgba(255, 255, 255, 0.5);
 }
 
-.switch-container:hover > .switch--lighten50{
-  color:rgba(255, 255, 255, 0.75);
-}
-
-.switch--lighten50:hover::after,
 input:checked + .switch--lighten50{
   background-color:rgba(255, 255, 255, 0.75);
-}
-
-.switch-container:hover > input:checked + .switch--lighten50{
-  background-color:rgba(255, 255, 255, 0.5);
 }
 
 input:checked + .switch--dot-lighten50::after{
@@ -22855,17 +22048,8 @@ input:checked + .switch--dot-lighten50::after{
   color:rgba(255, 255, 255, 0.75);
 }
 
-.switch-container:hover > .switch--lighten75{
-  color:#fff;
-}
-
-.switch--lighten75:hover::after,
 input:checked + .switch--lighten75{
   background-color:#fff;
-}
-
-.switch-container:hover > input:checked + .switch--lighten75{
-  background-color:rgba(255, 255, 255, 0.75);
 }
 
 input:checked + .switch--dot-lighten75::after{
@@ -22876,17 +22060,8 @@ input:checked + .switch--dot-lighten75::after{
   color:#fff;
 }
 
-.switch-container:hover > .switch--white{
-  color:rgba(255, 255, 255, 0.75);
-}
-
-.switch--white:hover::after,
 input:checked + .switch--white{
   background-color:rgba(255, 255, 255, 0.75);
-}
-
-.switch-container:hover > input:checked + .switch--white{
-  background-color:#fff;
 }
 
 input:checked + .switch--dot-white::after{
@@ -22897,17 +22072,8 @@ input:checked + .switch--dot-white::after{
   color:transparent;
 }
 
-.switch-container:hover > .switch--transparent{
-  color:rgba(0, 0, 0, 0.1);
-}
-
-.switch--transparent:hover::after,
 input:checked + .switch--transparent{
   background-color:rgba(0, 0, 0, 0.1);
-}
-
-.switch-container:hover > input:checked + .switch--transparent{
-  background-color:transparent;
 }
 
 input:checked + .switch--dot-transparent::after{
@@ -22915,52 +22081,36 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .range--gray > input{ color:#666; }
-.range--gray:hover > input{ color:#2d2d2d; }
 
 .range--pink > input{ color:#ff3c96; }
-.range--pink:hover > input{ color:#ab084b; }
 
 .range--red > input{ color:#dc2b28; }
-.range--red:hover > input{ color:#a30003; }
 
 .range--orange > input{ color:#ff6e00; }
-.range--orange:hover > input{ color:#bc3a00; }
 
 .range--yellow > input{ color:#f0dc00; }
-.range--yellow:hover > input{ color:#d9a100; }
 
 .range--green > input{ color:#01aa46; }
-.range--green:hover > input{ color:#006427; }
 
 .range--blue > input{ color:#448ee4; }
-.range--blue:hover > input{ color:#295b97; }
 
 .range--purple > input{ color:#8c50c7; }
-.range--purple:hover > input{ color:#440067; }
 
 .range--darken25 > input{ color:rgba(0, 0, 0, 0.25); }
-.range--darken25:hover > input{ color:rgba(0, 0, 0, 0.5); }
 
 .range--darken50 > input{ color:rgba(0, 0, 0, 0.5); }
-.range--darken50:hover > input{ color:rgba(0, 0, 0, 0.75); }
 
 .range--darken75 > input{ color:rgba(0, 0, 0, 0.75); }
-.range--darken75:hover > input{ color:#000; }
 
 .range--lighten25 > input{ color:rgba(255, 255, 255, 0.25); }
-.range--lighten25:hover > input{ color:rgba(255, 255, 255, 0.5); }
 
 .range--lighten50 > input{ color:rgba(255, 255, 255, 0.5); }
-.range--lighten50:hover > input{ color:rgba(255, 255, 255, 0.75); }
 
 .range--lighten75 > input{ color:rgba(255, 255, 255, 0.75); }
-.range--lighten75:hover > input{ color:#fff; }
 
 .range--white > input{ color:#fff; }
-.range--white:hover > input{ color:rgba(255, 255, 255, 0.75); }
 
 .range--transparent > input{ color:transparent; }
-.range--transparent:hover > input{ color:rgba(0, 0, 0, 0.1); }
 .color-gray-dark{
   color:#2d2d2d !important;
 }

--- a/test/__snapshots__/build-media-variants.jest.js.snap
+++ b/test/__snapshots__/build-media-variants.jest.js.snap
@@ -195,28 +195,28 @@ exports[`buildMediaVariants defaults 1`] = `
   line-height: 18px;
 }
 .txt-xl-mm {
-  font-size: 30px;
-  line-height: 45px;
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-xl);
 }
 
 .txt-l-mm {
-  font-size: 18px;
-  line-height: 30px;
+  font-size: var(--font-size-l);
+  line-height: var(--line-height-l);
 }
 
 .txt-m-mm {
-  font-size: 15px;
-  line-height: 24px;
+  font-size: var(--font-size-m);
+  line-height: var(--line-height-m);
 }
 
 .txt-s-mm {
-  font-size: 12px;
-  line-height: 18px;
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
 }
 
 .txt-xs-mm {
-  font-size: 10px;
-  line-height: 15px;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
 }
 }
 
@@ -414,28 +414,28 @@ exports[`buildMediaVariants defaults 1`] = `
   line-height: 18px;
 }
 .txt-xl-ml {
-  font-size: 30px;
-  line-height: 45px;
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-xl);
 }
 
 .txt-l-ml {
-  font-size: 18px;
-  line-height: 30px;
+  font-size: var(--font-size-l);
+  line-height: var(--line-height-l);
 }
 
 .txt-m-ml {
-  font-size: 15px;
-  line-height: 24px;
+  font-size: var(--font-size-m);
+  line-height: var(--line-height-m);
 }
 
 .txt-s-ml {
-  font-size: 12px;
-  line-height: 18px;
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
 }
 
 .txt-xs-ml {
-  font-size: 10px;
-  line-height: 15px;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
 }
 }
 
@@ -633,28 +633,28 @@ exports[`buildMediaVariants defaults 1`] = `
   line-height: 18px;
 }
 .txt-xl-mxl {
-  font-size: 30px;
-  line-height: 45px;
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-xl);
 }
 
 .txt-l-mxl {
-  font-size: 18px;
-  line-height: 30px;
+  font-size: var(--font-size-l);
+  line-height: var(--line-height-l);
 }
 
 .txt-m-mxl {
-  font-size: 15px;
-  line-height: 24px;
+  font-size: var(--font-size-m);
+  line-height: var(--line-height-m);
 }
 
 .txt-s-mxl {
-  font-size: 12px;
-  line-height: 18px;
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-s);
 }
 
 .txt-xs-mxl {
-  font-size: 10px;
-  line-height: 15px;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
 }
 }
 


### PR DESCRIPTION
This PR does a bunch of stuff:
- Improves styling of --xs and --s rules by default.
- Removes hover states from form elements, closes #868
- Rationalizes use of line height and font size in form elements, closes #862
- Includes line heights for all --s and --xs form modifiers, closes #855
- Changes input and select areas to use box shadow for borders, which aligns them to pixel grid -
without the need for special cased widths or line heights. Note that this does add some complexity to applying shadows and shadow-on-focus rules to line heights – but I think that trade-off is worth it.
- Adds --xs modifiers to all form elements
- Shrinks CSS to __182 kB/22.6 kB(gzipped)__ from 187 kB/23.1 kB (gzipped) 🎉 

These are obviously breaking changes, so we must proceed with caution! cc: @tristen @davidtheclark 
