### PR TITLE
remove importants from non-utility size classes and disabled classes

### DIFF
--- a/src/buttons.css
+++ b/src/buttons.css
@@ -128,9 +128,20 @@
  */
 .btn:disabled {
   pointer-events: none;
-  color: var(--inactive-text-color) !important;
-  background-color: var(--disabled-primary-interactive-color) !important;
-  box-shadow: none !important;
+  color: var(--inactive-text-color);
+  background-color: var(--disabled-primary-interactive-color);
+  box-shadow: none;
+}
+
+.btn.btn--stroke:disabled {
+  pointer-events: none;
+  background-color: transparent;
+  box-shadow: inset 0 0 0 1px var(--inactive-text-color);
+  color: var(--inactive-text-color);
+}
+
+.btn.btn--stroke--2:disabled {
+  box-shadow: inset 0 0 0 2px var(--inactive-text-color);
 }
 
 /**

--- a/src/forms.css
+++ b/src/forms.css
@@ -151,9 +151,9 @@
 .input:disabled,
 .textarea:disabled {
   pointer-events: none;
-  color: var(--darken50) !important;
-  background-color: var(--disabled-secondary-interactive-color) !important;
-  box-shadow: inset 0 0 0 1px var(--disabled-primary-interactive-color) !important;
+  color: var(--darken50);
+  background-color: var(--disabled-secondary-interactive-color);
+  box-shadow: inset 0 0 0 1px var(--disabled-primary-interactive-color);
 }
 
 /* Using the attribute selector instead of the pseudo-class `:read-only`
@@ -168,7 +168,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .input[readonly],
 .textarea[readonly] {
-  background-color: var(--disabled-secondary-interactive-color) !important;
+  background-color: var(--disabled-secondary-interactive-color);
 }
 
 /**
@@ -387,9 +387,9 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .select:disabled {
   pointer-events: none;
-  color: var(--darken25) !important;
-  background-color: var(--disabled-primary-interactive-color) !important;
-  border-color: var(--transparent) !important;
+  color: var(--darken25);
+  background-color: var(--disabled-primary-interactive-color);
+  border-color: var(--transparent);
 }
 
 .select:disabled + .select-arrow {
@@ -913,15 +913,18 @@ input:disabled {
 
 input:disabled + .checkbox,
 input:disabled + .radio,
-input:disabled + .switch {
+input:disabled + .switch,
+input:checked:disabled + .checkbox,
+input:checked:disabled + .radio,
+input:checked:disabled + .switch {
   pointer-events: none;
-  color: var(--darken25) !important;
-  background-color: var(--disabled-primary-interactive-color) !important;
-  border-color: var(--transparent) !important;
+  color: var(--darken25);
+  background-color: var(--disabled-primary-interactive-color);
+  border-color: var(--transparent);
 }
 
 input:disabled + .switch::after {
-  background-color: var(--darken25) !important;
+  background-color: var(--darken25);
 }
 
 /* State management for checkboxes and radio inputs */
@@ -974,11 +977,11 @@ input:checked + .toggle {
  */
 input:disabled + .toggle {
   pointer-events: none;
-  color: var(--darken25) !important;
-  border-color: var(--transparent) !important;
+  color: var(--darken25);
+  border-color: var(--transparent);
 }
 
 input:checked:disabled + .toggle {
-  background-color: var(--disabled-primary-interactive-color) !important;
-  color: var(--darken25) !important;
+  background-color: var(--disabled-primary-interactive-color);
+  color: var(--darken25);
 }

--- a/src/icons.css
+++ b/src/icons.css
@@ -36,8 +36,8 @@
  * <svg class='icon icon--s'><use xlink:href='#icon-document'/></svg>
  */
 .icon--s {
-  height: 15px !important;
-  width: 15px !important;
+  height: 15px;
+  width: 15px;
 }
 
 /**
@@ -48,8 +48,8 @@
  * <svg class='icon icon--l'><use xlink:href='#icon-star'/></svg>
  */
 .icon--l {
-  height: 36px !important;
-  width: 36px !important;
+  height: 36px;
+  width: 36px;
 }
 
 /**

--- a/src/links.css
+++ b/src/links.css
@@ -38,7 +38,7 @@
 
 /**
  * When a form element like `button` includes both the `link` class and the `disabled` attribute, it will be styled accordingly.
- * The disabled property has no effect on `a` elements.
+ * The disabled property has no visual effect on `a` elements.
  *
  * @memberof Links
  * @example
@@ -46,6 +46,7 @@
  * <button href='#Links' disabled class='link link--red'>A disabled red link</button>
  */
 .link:disabled {
+  pointer-events: none;
   cursor: default;
-  color: var(--inactive-text-color) !important;
+  color: var(--inactive-text-color);
 }

--- a/src/miscellaneous.css
+++ b/src/miscellaneous.css
@@ -71,8 +71,8 @@
   animation: spin 0.8s infinite cubic-bezier(0.45, 0.05, 0.55, 0.95);
 }
 .loading--s::after {
-  height: 18px !important;
-  width: 18px !important;
+  height: 18px;
+  width: 18px;
 }
 .loading::after {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='36' height='36' viewBox='0 0 36 36'%3E%3Cdefs%3E%3Cstyle%3E.a%7Bfill:%23333;%7D.b%7Bopacity:0.1;%7D%3C/style%3E%3C/defs%3E%3Cpath class='a' d='M5.2721,5.2721,7.3934,7.3934a15,15,0,0,1,21.2132,0l2.1213-2.1213A18,18,0,0,0,5.2721,5.2721Z'/%3E%3Cg class='b'%3E%3Cpath d='M28.6066,28.6066A15,15,0,0,1,7.3934,7.3934L5.2721,5.2721a18,18,0,1,0,25.4558,0L28.6066,7.3934A15,15,0,0,1,28.6066,28.6066Z'/%3E%3C/g%3E%3C/svg%3E"); /* stylelint-disable-line string-quotes */

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -633,9 +633,20 @@ textarea{
 }
 .btn:disabled{
   pointer-events:none;
-  color:rgba(127, 127, 127, 0.45) !important;
-  background-color:rgba(127, 127, 127, 0.25) !important;
-  box-shadow:none !important;
+  color:rgba(127, 127, 127, 0.45);
+  background-color:rgba(127, 127, 127, 0.25);
+  box-shadow:none;
+}
+
+.btn.btn--stroke:disabled{
+  pointer-events:none;
+  background-color:transparent;
+  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.45);
+  color:rgba(127, 127, 127, 0.45);
+}
+
+.btn.btn--stroke--2:disabled{
+  box-shadow:inset 0 0 0 2px rgba(127, 127, 127, 0.45);
 }
 .btn--pill-stroke{
   position:relative;
@@ -734,8 +745,9 @@ textarea{
   color:#346db0;
 }
 .link:disabled{
+  pointer-events:none;
   cursor:default;
-  color:rgba(127, 127, 127, 0.45) !important;
+  color:rgba(127, 127, 127, 0.45);
 }
 
 .fieldset,
@@ -825,13 +837,13 @@ textarea{
 .input:disabled,
 .textarea:disabled{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.5) !important;
-  background-color:rgba(127, 127, 127, 0.1) !important;
-  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25) !important;
+  color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(127, 127, 127, 0.1);
+  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25);
 }
 .input[readonly],
 .textarea[readonly]{
-  background-color:rgba(127, 127, 127, 0.1) !important;
+  background-color:rgba(127, 127, 127, 0.1);
 }
 .select-container{
   display:-webkit-inline-flex;
@@ -938,9 +950,9 @@ textarea{
 }
 .select:disabled{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25) !important;
-  background-color:rgba(127, 127, 127, 0.25) !important;
-  border-color:transparent !important;
+  color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(127, 127, 127, 0.25);
+  border-color:transparent;
 }
 
 .select:disabled + .select-arrow{
@@ -1229,15 +1241,18 @@ input:disabled{
 
 input:disabled + .checkbox,
 input:disabled + .radio,
-input:disabled + .switch{
+input:disabled + .switch,
+input:checked:disabled + .checkbox,
+input:checked:disabled + .radio,
+input:checked:disabled + .switch{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25) !important;
-  background-color:rgba(127, 127, 127, 0.25) !important;
-  border-color:transparent !important;
+  color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(127, 127, 127, 0.25);
+  border-color:transparent;
 }
 
 input:disabled + .switch::after{
-  background-color:rgba(0, 0, 0, 0.25) !important;
+  background-color:rgba(0, 0, 0, 0.25);
 }
 input:checked + .checkbox > .icon,
 input:checked + .radio::before{
@@ -1267,13 +1282,13 @@ input:checked + .toggle{
 }
 input:disabled + .toggle{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25) !important;
-  border-color:transparent !important;
+  color:rgba(0, 0, 0, 0.25);
+  border-color:transparent;
 }
 
 input:checked:disabled + .toggle{
-  background-color:rgba(127, 127, 127, 0.25) !important;
-  color:rgba(0, 0, 0, 0.25) !important;
+  background-color:rgba(127, 127, 127, 0.25);
+  color:rgba(0, 0, 0, 0.25);
 }
 .border{
   border-style:solid;
@@ -1370,12 +1385,12 @@ input:checked:disabled + .toggle{
   width:18px;
 }
 .icon--s{
-  height:15px !important;
-  width:15px !important;
+  height:15px;
+  width:15px;
 }
 .icon--l{
-  height:36px !important;
-  width:36px !important;
+  height:36px;
+  width:36px;
 }
 .icon-inliner{
   position:relative;
@@ -8236,8 +8251,8 @@ input:checked:disabled + .toggle{
           animation:spin 0.8s infinite cubic-bezier(0.45, 0.05, 0.55, 0.95);
 }
 .loading--s::after{
-  height:18px !important;
-  width:18px !important;
+  height:18px;
+  width:18px;
 }
 .loading::after{
   background-image:url(\\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='36' height='36' viewBox='0 0 36 36'%3E%3Cdefs%3E%3Cstyle%3E.a%7Bfill:%23333;%7D.b%7Bopacity:0.1;%7D%3C/style%3E%3C/defs%3E%3Cpath class='a' d='M5.2721,5.2721,7.3934,7.3934a15,15,0,0,1,21.2132,0l2.1213-2.1213A18,18,0,0,0,5.2721,5.2721Z'/%3E%3Cg class='b'%3E%3Cpath d='M28.6066,28.6066A15,15,0,0,1,7.3934,7.3934L5.2721,5.2721a18,18,0,1,0,25.4558,0L28.6066,7.3934A15,15,0,0,1,28.6066,28.6066Z'/%3E%3C/g%3E%3C/svg%3E\\");
@@ -12904,9 +12919,20 @@ textarea{
 }
 .btn:disabled{
   pointer-events:none;
-  color:rgba(127, 127, 127, 0.45) !important;
-  background-color:rgba(127, 127, 127, 0.25) !important;
-  box-shadow:none !important;
+  color:rgba(127, 127, 127, 0.45);
+  background-color:rgba(127, 127, 127, 0.25);
+  box-shadow:none;
+}
+
+.btn.btn--stroke:disabled{
+  pointer-events:none;
+  background-color:transparent;
+  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.45);
+  color:rgba(127, 127, 127, 0.45);
+}
+
+.btn.btn--stroke--2:disabled{
+  box-shadow:inset 0 0 0 2px rgba(127, 127, 127, 0.45);
 }
 .btn--pill-stroke{
   position:relative;
@@ -13005,8 +13031,9 @@ textarea{
   color:#346db0;
 }
 .link:disabled{
+  pointer-events:none;
   cursor:default;
-  color:rgba(127, 127, 127, 0.45) !important;
+  color:rgba(127, 127, 127, 0.45);
 }
 
 .fieldset,
@@ -13096,13 +13123,13 @@ textarea{
 .input:disabled,
 .textarea:disabled{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.5) !important;
-  background-color:rgba(127, 127, 127, 0.1) !important;
-  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25) !important;
+  color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(127, 127, 127, 0.1);
+  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25);
 }
 .input[readonly],
 .textarea[readonly]{
-  background-color:rgba(127, 127, 127, 0.1) !important;
+  background-color:rgba(127, 127, 127, 0.1);
 }
 .select-container{
   display:-webkit-inline-flex;
@@ -13209,9 +13236,9 @@ textarea{
 }
 .select:disabled{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25) !important;
-  background-color:rgba(127, 127, 127, 0.25) !important;
-  border-color:transparent !important;
+  color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(127, 127, 127, 0.25);
+  border-color:transparent;
 }
 
 .select:disabled + .select-arrow{
@@ -13500,15 +13527,18 @@ input:disabled{
 
 input:disabled + .checkbox,
 input:disabled + .radio,
-input:disabled + .switch{
+input:disabled + .switch,
+input:checked:disabled + .checkbox,
+input:checked:disabled + .radio,
+input:checked:disabled + .switch{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25) !important;
-  background-color:rgba(127, 127, 127, 0.25) !important;
-  border-color:transparent !important;
+  color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(127, 127, 127, 0.25);
+  border-color:transparent;
 }
 
 input:disabled + .switch::after{
-  background-color:rgba(0, 0, 0, 0.25) !important;
+  background-color:rgba(0, 0, 0, 0.25);
 }
 input:checked + .checkbox > .icon,
 input:checked + .radio::before{
@@ -13538,13 +13568,13 @@ input:checked + .toggle{
 }
 input:disabled + .toggle{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25) !important;
-  border-color:transparent !important;
+  color:rgba(0, 0, 0, 0.25);
+  border-color:transparent;
 }
 
 input:checked:disabled + .toggle{
-  background-color:rgba(127, 127, 127, 0.25) !important;
-  color:rgba(0, 0, 0, 0.25) !important;
+  background-color:rgba(127, 127, 127, 0.25);
+  color:rgba(0, 0, 0, 0.25);
 }
 .border{
   border-style:solid;
@@ -13641,12 +13671,12 @@ input:checked:disabled + .toggle{
   width:18px;
 }
 .icon--s{
-  height:15px !important;
-  width:15px !important;
+  height:15px;
+  width:15px;
 }
 .icon--l{
-  height:36px !important;
-  width:36px !important;
+  height:36px;
+  width:36px;
 }
 .icon-inliner{
   position:relative;
@@ -20507,8 +20537,8 @@ input:checked:disabled + .toggle{
           animation:spin 0.8s infinite cubic-bezier(0.45, 0.05, 0.55, 0.95);
 }
 .loading--s::after{
-  height:18px !important;
-  width:18px !important;
+  height:18px;
+  width:18px;
 }
 .loading::after{
   background-image:url(\\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' version='1.1' width='36' height='36' viewBox='0 0 36 36'%3E%3Cdefs%3E%3Cstyle%3E.a%7Bfill:%23333;%7D.b%7Bopacity:0.1;%7D%3C/style%3E%3C/defs%3E%3Cpath class='a' d='M5.2721,5.2721,7.3934,7.3934a15,15,0,0,1,21.2132,0l2.1213-2.1213A18,18,0,0,0,5.2721,5.2721Z'/%3E%3Cg class='b'%3E%3Cpath d='M28.6066,28.6066A15,15,0,0,1,7.3934,7.3934L5.2721,5.2721a18,18,0,1,0,25.4558,0L28.6066,7.3934A15,15,0,0,1,28.6066,28.6066Z'/%3E%3C/g%3E%3C/svg%3E\\");


### PR DESCRIPTION
@davidtheclark for review. Does two things:

- Remove `!important` declarations from disabled component classes. Component modifiers _cannot_ override disabled state, but color / background utility classes (as well as inline styles) _can_ override disabled state. 
- Remove `!important` from size declarations on icons and loading classes.

Note that one contentious place where we continue to use `!important` after this PR is on triangles. Triangles should be `!important`, because the classes break in weird ways if any of the properties on the `triangle` class is overriden. 

closes #860, closes #873