### PR TITLE
Add hillshade icon

### DIFF
--- a/src/svgs/hillshade.svg
+++ b/src/svgs/hillshade.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<svg viewBox="0 0 18 18">
+  <path d="m 9,3.5 -7,9.5 1,1 12,0 1,-1 z M 2,4 C 1.446,4 1,4.446 1,5 1,5.554 1.446,6 2,6 2.554,6 3,5.554 3,5 3,4.446 2.554,4 2,4 Z M 5,4 C 4.446,4 4,4.446 4,5 4,5.554 4.446,6 5,6 5.554,6 6,5.554 6,5 6,4.446 5.554,4 5,4 Z M 2,7 C 1.446,7 1,7.446 1,8 1,8.554 1.446,9 2,9 2.554,9 3,8.554 3,8 3,7.446 2.554,7 2,7 Z m 5.5,1 3,4.5 -6.5,0 z"/>
+  <rect ry="0" rx="0" y="3" x="4" height="1" width="1" id="rect4913" style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+</svg>


### PR DESCRIPTION
Looks like this:

<img width="383" alt="screen shot 2018-02-08 at 11 47 50 am" src="https://user-images.githubusercontent.com/61150/35985993-eaeaca94-0cc5-11e8-907c-31470f5fc7fd.png">

This is to support the new hillshading feature type in the style editor.
