### PR TITLE
Add "from" option to a PostCSS invocation to avoid warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.21.2
+
+- [fix] Avoid a PostCSS warning about `from` not being set.
+
 ## 0.21.1
 
 - [fix] Clean up and update dependencies.

--- a/scripts/build-media-variants.js
+++ b/scripts/build-media-variants.js
@@ -197,7 +197,7 @@ function buildMediaVariants() {
     return pify(fs.readFile)(filePath, 'utf8').then(css => {
       return postcss()
         .use(findRules)
-        .process(css);
+        .process(css, { from: filePath, to: filePath });
     });
   });
 


### PR DESCRIPTION
With a very recent version of PostCSS, I started seeing this warning when running `buildUserAssets`:

> Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.

With this small change, that warning goes away.

@tristen for review.