### PR TITLE
Set border: 0 in reset.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## HEAD
+
+- [fix] Set `border: 0` in `reset.css`, instead of `border: none`.
+  Fixes an obscure bug where if you used the unminified CSS and set a `border-{side}` class on a `btn`, you'd see unwanted thick borders on all sides except the one you specified.
+
 ## 0.21.2
 
 - [fix] Avoid a PostCSS warning about `from` not being set.

--- a/src/reset.css
+++ b/src/reset.css
@@ -62,7 +62,7 @@ html {
 
 button {
   background: transparent;
-  border: none;
+  border: 0;
   color: inherit;
   font: inherit;
   margin: 0;

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -61,7 +61,7 @@ html{
 
 button{
   background:transparent;
-  border:none;
+  border:0;
   color:inherit;
   font:inherit;
   margin:0;
@@ -12341,7 +12341,7 @@ html{
 
 button{
   background:transparent;
-  border:none;
+  border:0;
   color:inherit;
   font:inherit;
   margin:0;


### PR DESCRIPTION
Instead of `border: none`, which doesn't actually reset `border-width`, I discovered, just `border-style`.
Minification has covered this up by replacing `border: none` with `border: 0`.

Fixes an obscure bug where if you used the unminified CSS and set a `border-{side}` class on a `btn`, you'd see unwanted thick borders on all sides except the one you specified.

Weeeeeeird.