### PR TITLE
Drop custom build support for Node 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- [breaking] Drop support for Node 4 in custom build. **This has no effect on the client-side CSS or JS.**
+
 ## 0.22.0
 
 - [breaking] Fonts are no longer distributed with each version. Instead, fonts are served from `https://api.mapbox.com/mapbox-assembly/fonts/*` and referenced from the CSS with absolute URLs.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "npm run lint && npm run test:svgs && npm run test:jest && npm run build:site"
   },
   "engines": {
-    "node": ">=4",
+    "node": ">=6",
     "npm": "^5.0.0"
   },
   "repository": {


### PR DESCRIPTION
I was looking into updating some dependencies and realized that many of the updates involve dropping support for Node 4. I don't think we have good reason to hang onto that, so let's drop it.

@danswick for review.