### PR TITLE
Style selects like inputs

### DIFF
--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -185,55 +185,36 @@ function buildColorVariants(variables, config) {
     return css;
   };
 
-  variantGenerators.selectFill = function(colors) {
-    return colors.reduce((result, color) => {
-      if (isNotAccessibleExceptButtons(color)) return result;
-      const darkerShade = getDarkerShade(color);
-      return (result += stripIndent(`
-        .select--${color} {
-          background-color: var(--${color});
-        }
-
-        .select--${color}:hover {
-          background-color: var(--${darkerShade});
-        }
-      `));
-    }, '');
-  };
-
-  variantGenerators.selectStroke = function(colors) {
+  variantGenerators.select = function(colors) {
     return colors.reduce((result, color) => {
       if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return (result += stripIndent(`
-        .select--stroke-${color} {
-          color: var(--${color});
-        }
-        .select--stroke-${color} + .select-arrow {
+        .select--border-${color} + .select-arrow {
           border-top-color: var(--${color});
         }
-        .select--stroke-${color}:hover {
-          color: var(--${darkerShade});
-        }
-        .select--stroke-${color}:hover + .select-arrow {
+
+        .select--border-${color}:focus + .select-arrow {
           border-top-color: var(--${darkerShade});
         }
       `));
     }, '');
   };
 
-  variantGenerators.inputTextarea = function(colors) {
+  variantGenerators.inputTextareaSelect = function(colors) {
     return colors.reduce((result, color) => {
       if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return (result += stripIndent(`
         .textarea--border-${color},
-        .input--border-${color} {
+        .input--border-${color},
+        .select--border-${color} {
           box-shadow: inset 0 0 0 1px var(--${color});
         }
 
         .textarea--border-${color}:focus,
-        .input--border-${color}:focus {
+        .input--border-${color}:focus,
+        .select--border-${color}:focus {
           box-shadow: inset 0 0 0 1px var(--${darkerShade});
         }
       `));

--- a/site/catalog/selects.js
+++ b/site/catalog/selects.js
@@ -26,11 +26,9 @@ export class Selects extends React.Component {
 
         {colors.map(color => {
           let selectClass = 'select';
-          let selectStrokeClass = 'select select--stroke';
           const selectContainerClass = 'select-container';
           if (color !== null) {
-            selectClass += ` select--${color}`;
-            selectStrokeClass += ` select--stroke-${color}`;
+            selectClass += ` select--border-${color}`;
           }
           return (
             <div key={color} className="mb12">
@@ -74,20 +72,6 @@ export class Selects extends React.Component {
                   <div className="select-arrow" />
                 </div>
               </div>
-              {!/^(darken10|lighten10)$/.test(color) ? (
-                <span>
-                  <div className={selectContainerClass}>
-                    <select className={selectStrokeClass}>
-                      <option>firstoption</option>
-                      <option>two</option>
-                      <option>three</option>
-                    </select>
-                    <div className="select-arrow" />
-                  </div>
-                </span>
-              ) : (
-                ''
-              )}
             </div>
           );
         })}

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -387,579 +387,323 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--gray {
-  background-color: var(--gray);
-}
-
-.select--gray:hover {
-  background-color: var(--gray-dark);
-}
-
-.select--gray-light {
-  background-color: var(--gray-light);
-}
-
-.select--gray-light:hover {
-  background-color: var(--gray);
-}
-
-.select--pink {
-  background-color: var(--pink);
-}
-
-.select--pink:hover {
-  background-color: var(--pink-dark);
-}
-
-.select--pink-light {
-  background-color: var(--pink-light);
-}
-
-.select--pink-light:hover {
-  background-color: var(--pink);
-}
-
-.select--red {
-  background-color: var(--red);
-}
-
-.select--red:hover {
-  background-color: var(--red-dark);
-}
-
-.select--red-light {
-  background-color: var(--red-light);
-}
-
-.select--red-light:hover {
-  background-color: var(--red);
-}
-
-.select--orange {
-  background-color: var(--orange);
-}
-
-.select--orange:hover {
-  background-color: var(--orange-dark);
-}
-
-.select--orange-light {
-  background-color: var(--orange-light);
-}
-
-.select--orange-light:hover {
-  background-color: var(--orange);
-}
-
-.select--yellow {
-  background-color: var(--yellow);
-}
-
-.select--yellow:hover {
-  background-color: var(--yellow-dark);
-}
-
-.select--yellow-light {
-  background-color: var(--yellow-light);
-}
-
-.select--yellow-light:hover {
-  background-color: var(--yellow);
-}
-
-.select--green {
-  background-color: var(--green);
-}
-
-.select--green:hover {
-  background-color: var(--green-dark);
-}
-
-.select--green-light {
-  background-color: var(--green-light);
-}
-
-.select--green-light:hover {
-  background-color: var(--green);
-}
-
-.select--blue {
-  background-color: var(--blue);
-}
-
-.select--blue:hover {
-  background-color: var(--blue-dark);
-}
-
-.select--blue-light {
-  background-color: var(--blue-light);
-}
-
-.select--blue-light:hover {
-  background-color: var(--blue);
-}
-
-.select--purple {
-  background-color: var(--purple);
-}
-
-.select--purple:hover {
-  background-color: var(--purple-dark);
-}
-
-.select--purple-light {
-  background-color: var(--purple-light);
-}
-
-.select--purple-light:hover {
-  background-color: var(--purple);
-}
-
-.select--darken10 {
-  background-color: var(--darken10);
-}
-
-.select--darken10:hover {
-  background-color: var(--darken25);
-}
-
-.select--darken25 {
-  background-color: var(--darken25);
-}
-
-.select--darken25:hover {
-  background-color: var(--darken50);
-}
-
-.select--darken50 {
-  background-color: var(--darken50);
-}
-
-.select--darken50:hover {
-  background-color: var(--darken75);
-}
-
-.select--darken75 {
-  background-color: var(--darken75);
-}
-
-.select--darken75:hover {
-  background-color: var(--black);
-}
-
-.select--lighten10 {
-  background-color: var(--lighten10);
-}
-
-.select--lighten10:hover {
-  background-color: var(--lighten25);
-}
-
-.select--lighten25 {
-  background-color: var(--lighten25);
-}
-
-.select--lighten25:hover {
-  background-color: var(--lighten50);
-}
-
-.select--lighten50 {
-  background-color: var(--lighten50);
-}
-
-.select--lighten50:hover {
-  background-color: var(--lighten75);
-}
-
-.select--lighten75 {
-  background-color: var(--lighten75);
-}
-
-.select--lighten75:hover {
-  background-color: var(--white);
-}
-
-.select--white {
-  background-color: var(--white);
-}
-
-.select--white:hover {
-  background-color: var(--lighten75);
-}
-
-.select--transparent {
-  background-color: var(--transparent);
-}
-
-.select--transparent:hover {
-  background-color: var(--darken10);
-}
-
-.select--stroke-gray {
-  color: var(--gray);
-}
-.select--stroke-gray + .select-arrow {
+.select--border-gray + .select-arrow {
   border-top-color: var(--gray);
 }
-.select--stroke-gray:hover {
-  color: var(--gray-dark);
-}
-.select--stroke-gray:hover + .select-arrow {
+
+.select--border-gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
 }
 
-.select--stroke-pink {
-  color: var(--pink);
-}
-.select--stroke-pink + .select-arrow {
+.select--border-pink + .select-arrow {
   border-top-color: var(--pink);
 }
-.select--stroke-pink:hover {
-  color: var(--pink-dark);
-}
-.select--stroke-pink:hover + .select-arrow {
+
+.select--border-pink:focus + .select-arrow {
   border-top-color: var(--pink-dark);
 }
 
-.select--stroke-red {
-  color: var(--red);
-}
-.select--stroke-red + .select-arrow {
+.select--border-red + .select-arrow {
   border-top-color: var(--red);
 }
-.select--stroke-red:hover {
-  color: var(--red-dark);
-}
-.select--stroke-red:hover + .select-arrow {
+
+.select--border-red:focus + .select-arrow {
   border-top-color: var(--red-dark);
 }
 
-.select--stroke-orange {
-  color: var(--orange);
-}
-.select--stroke-orange + .select-arrow {
+.select--border-orange + .select-arrow {
   border-top-color: var(--orange);
 }
-.select--stroke-orange:hover {
-  color: var(--orange-dark);
-}
-.select--stroke-orange:hover + .select-arrow {
+
+.select--border-orange:focus + .select-arrow {
   border-top-color: var(--orange-dark);
 }
 
-.select--stroke-yellow {
-  color: var(--yellow);
-}
-.select--stroke-yellow + .select-arrow {
+.select--border-yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
-.select--stroke-yellow:hover {
-  color: var(--yellow-dark);
-}
-.select--stroke-yellow:hover + .select-arrow {
+
+.select--border-yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
 }
 
-.select--stroke-green {
-  color: var(--green);
-}
-.select--stroke-green + .select-arrow {
+.select--border-green + .select-arrow {
   border-top-color: var(--green);
 }
-.select--stroke-green:hover {
-  color: var(--green-dark);
-}
-.select--stroke-green:hover + .select-arrow {
+
+.select--border-green:focus + .select-arrow {
   border-top-color: var(--green-dark);
 }
 
-.select--stroke-blue {
-  color: var(--blue);
-}
-.select--stroke-blue + .select-arrow {
+.select--border-blue + .select-arrow {
   border-top-color: var(--blue);
 }
-.select--stroke-blue:hover {
-  color: var(--blue-dark);
-}
-.select--stroke-blue:hover + .select-arrow {
+
+.select--border-blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
 }
 
-.select--stroke-purple {
-  color: var(--purple);
-}
-.select--stroke-purple + .select-arrow {
+.select--border-purple + .select-arrow {
   border-top-color: var(--purple);
 }
-.select--stroke-purple:hover {
-  color: var(--purple-dark);
-}
-.select--stroke-purple:hover + .select-arrow {
+
+.select--border-purple:focus + .select-arrow {
   border-top-color: var(--purple-dark);
 }
 
-.select--stroke-darken25 {
-  color: var(--darken25);
-}
-.select--stroke-darken25 + .select-arrow {
+.select--border-darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
-.select--stroke-darken25:hover {
-  color: var(--darken50);
-}
-.select--stroke-darken25:hover + .select-arrow {
+
+.select--border-darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--stroke-darken50 {
-  color: var(--darken50);
-}
-.select--stroke-darken50 + .select-arrow {
+.select--border-darken50 + .select-arrow {
   border-top-color: var(--darken50);
 }
-.select--stroke-darken50:hover {
-  color: var(--darken75);
-}
-.select--stroke-darken50:hover + .select-arrow {
+
+.select--border-darken50:focus + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--stroke-darken75 {
-  color: var(--darken75);
-}
-.select--stroke-darken75 + .select-arrow {
+.select--border-darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
-.select--stroke-darken75:hover {
-  color: var(--black);
-}
-.select--stroke-darken75:hover + .select-arrow {
+
+.select--border-darken75:focus + .select-arrow {
   border-top-color: var(--black);
 }
 
-.select--stroke-lighten25 {
-  color: var(--lighten25);
-}
-.select--stroke-lighten25 + .select-arrow {
+.select--border-lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
-.select--stroke-lighten25:hover {
-  color: var(--lighten50);
-}
-.select--stroke-lighten25:hover + .select-arrow {
+
+.select--border-lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--stroke-lighten50 {
-  color: var(--lighten50);
-}
-.select--stroke-lighten50 + .select-arrow {
+.select--border-lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
-.select--stroke-lighten50:hover {
-  color: var(--lighten75);
-}
-.select--stroke-lighten50:hover + .select-arrow {
+
+.select--border-lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--stroke-lighten75 {
-  color: var(--lighten75);
-}
-.select--stroke-lighten75 + .select-arrow {
+.select--border-lighten75 + .select-arrow {
   border-top-color: var(--lighten75);
 }
-.select--stroke-lighten75:hover {
-  color: var(--white);
-}
-.select--stroke-lighten75:hover + .select-arrow {
+
+.select--border-lighten75:focus + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--stroke-white {
-  color: var(--white);
-}
-.select--stroke-white + .select-arrow {
+.select--border-white + .select-arrow {
   border-top-color: var(--white);
 }
-.select--stroke-white:hover {
-  color: var(--lighten75);
-}
-.select--stroke-white:hover + .select-arrow {
+
+.select--border-white:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--stroke-transparent {
-  color: var(--transparent);
-}
-.select--stroke-transparent + .select-arrow {
+.select--border-transparent + .select-arrow {
   border-top-color: var(--transparent);
 }
-.select--stroke-transparent:hover {
-  color: var(--darken10);
-}
-.select--stroke-transparent:hover + .select-arrow {
+
+.select--border-transparent:focus + .select-arrow {
   border-top-color: var(--darken10);
 }
 
 .textarea--border-gray,
-.input--border-gray {
+.input--border-gray,
+.select--border-gray {
   box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus {
+.input--border-gray:focus,
+.select--border-gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
-.input--border-pink {
+.input--border-pink,
+.select--border-pink {
   box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus {
+.input--border-pink:focus,
+.select--border-pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
-.input--border-red {
+.input--border-red,
+.select--border-red {
   box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus {
+.input--border-red:focus,
+.select--border-red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
-.input--border-orange {
+.input--border-orange,
+.select--border-orange {
   box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus {
+.input--border-orange:focus,
+.select--border-orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
-.input--border-yellow {
+.input--border-yellow,
+.select--border-yellow {
   box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus {
+.input--border-yellow:focus,
+.select--border-yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
-.input--border-green {
+.input--border-green,
+.select--border-green {
   box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus {
+.input--border-green:focus,
+.select--border-green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
-.input--border-blue {
+.input--border-blue,
+.select--border-blue {
   box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus {
+.input--border-blue:focus,
+.select--border-blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
-.input--border-purple {
+.input--border-purple,
+.select--border-purple {
   box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus {
+.input--border-purple:focus,
+.select--border-purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
-.input--border-darken25 {
+.input--border-darken25,
+.select--border-darken25 {
   box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus {
+.input--border-darken25:focus,
+.select--border-darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
-.input--border-darken50 {
+.input--border-darken50,
+.select--border-darken50 {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus {
+.input--border-darken50:focus,
+.select--border-darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
-.input--border-darken75 {
+.input--border-darken75,
+.select--border-darken75 {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus {
+.input--border-darken75:focus,
+.select--border-darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
-.input--border-lighten25 {
+.input--border-lighten25,
+.select--border-lighten25 {
   box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus {
+.input--border-lighten25:focus,
+.select--border-lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
-.input--border-lighten50 {
+.input--border-lighten50,
+.select--border-lighten50 {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus {
+.input--border-lighten50:focus,
+.select--border-lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
-.input--border-lighten75 {
+.input--border-lighten75,
+.select--border-lighten75 {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus {
+.input--border-lighten75:focus,
+.select--border-lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
-.input--border-white {
+.input--border-white,
+.select--border-white {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus {
+.input--border-white:focus,
+.select--border-white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
-.input--border-transparent {
+.input--border-transparent,
+.select--border-transparent {
   box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus {
+.input--border-transparent:focus,
+.select--border-transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 

--- a/src/forms.css
+++ b/src/forms.css
@@ -29,18 +29,20 @@
  * @memberof Forms
  */
 .input,
-.textarea {
+.textarea,
+.select {
   box-shadow: inset 0 0 0 1px var(--gray-light);
   padding: 6px 12px;
   border-radius: var(--border-radius);
   transition: background-color var(--transition),
-    border-color var(--transition);
+    box-shadow var(--transition);
   display: block;
   width: 100%;
 }
 
 .input:focus,
-.textarea:focus {
+.textarea:focus,
+.select:focus {
   box-shadow: inset 0 0 0 1px var(--default-primary-interactive-color);
 }
 
@@ -149,7 +151,8 @@
  * <textarea disabled class='textarea' placeholder='disabled' value='Disabled'>Disabled text</textarea>
  */
 .input:disabled,
-.textarea:disabled {
+.textarea:disabled,
+.select:disabled {
   pointer-events: none;
   color: var(--darken50);
   background-color: var(--disabled-secondary-interactive-color);
@@ -183,21 +186,21 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /*
  * Style a select component.
- * Set the background color by adding a `select--{color}` modifier to the `select` element (`*-dark` colors are not available).
+ * Set the border (and arrow) color by adding a `select--border-{color}` modifier to the `select` element (`*-dark` colors are not available).
  *
  * @memberof Selects
  * @group
  * @example
  * <div class='select-container'>
  *   <select class='select'>
- *     <option>one</option>
+ *     <option>default</option>
  *     <option>two</option>
  *   </select>
  *   <div class='select-arrow'></div>
  * </div>
  * <div class='select-container mt6'>
- *   <select class='select select--red'>
- *     <option>one</option>
+ *   <select class='select select--border-green'>
+ *     <option>green</option>
  *     <option>two</option>
  *   </select>
  *   <div class='select-arrow'></div>
@@ -206,33 +209,27 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 .select-container {
   display: inline-flex;
   position: relative;
-  color: var(--white);
   align-items: center;
 }
 
 .select {
   appearance: none;
+  background-color: var(--transparent);
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
-  font-weight: bold;
   color: currentColor;
   padding: 6px 30px 6px 12px; /* plus arrow */
   cursor: pointer;
-  display: inline-block;
-  transition: color var(--transition),
-    background-color var(--transition);
-  border-radius: var(--border-radius);
-  background-color: var(--default-primary-interactive-color); /* match btn default state */
 }
 
 .select-arrow {
   position: absolute;
   right: 12px;
-  top: 50%;
+  top: calc(50% - 1px);
   pointer-events: none;
   border-left: 4px solid var(--transparent);
   border-right: 4px solid var(--transparent);
-  border-top: 5px solid currentColor;
+  border-top: 5px solid var(--gray-light);
   width: 8px;
   height: 8px;
   margin-top: -1px;
@@ -241,9 +238,8 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /** @endgroup */
 
-/* default hover state */
-.select:hover {
-  background-color: var(--default-primary-interactive-color-dark);
+.select:focus + .select-arrow {
+  border-top-color: var(--default-primary-interactive-color);
 }
 
 /* Some browsers color the option text and background, so reset that */
@@ -275,56 +271,6 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   }
 }
 /* End IE overrides */
-
-/**
- * Modify a select component so its text and borders are colored and its background transparent.
- * You can still change the color by adding a `select--{color}` modifier to the `select` element (`*-dark` colors are not available).
- *
- * @memberof Selects
- * @example
- * <div class='select-container'>
- *   <select class='select select--stroke'>
- *     <option>one</option>
- *     <option>two</option>
- *   </select>
- *   <div class='select-arrow'></div>
- * </div>
- */
-.select--stroke {
-  color: var(--gray);
-  background-color: var(--transparent);
-  box-shadow: inset 0 0 0 1px currentColor;
-}
-
-/**
- * Modify the `select--stroke` modifier to be 2 px wide instead of 1 px wide. This class will have no effect if not combined with `select--stroke`.
- *
- * @memberof Selects
- * @example
- * <div class='select-container'>
- *   <select class='select select--stroke select--stroke--2'>
- *     <option>one</option>
- *     <option>two</option>
- *   </select>
- *   <div class='select-arrow'></div>
- * </div>
- */
-.select--stroke--2 {
-  box-shadow: inset 0 0 0 2px currentColor;
-}
-
-.select--stroke + .select-arrow {
-  color: var(--gray);
-}
-
-.select--stroke:hover {
-  background-color: var(--transparent);
-  color: var(--gray-dark);
-}
-
-.select--stroke:hover + .select-arrow {
-  border-top-color: currentColor;
-}
 
 /**
  * Make a select component small.

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -390,579 +390,323 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--gray {
-  background-color: var(--gray);
-}
-
-.select--gray:hover {
-  background-color: var(--gray-dark);
-}
-
-.select--gray-light {
-  background-color: var(--gray-light);
-}
-
-.select--gray-light:hover {
-  background-color: var(--gray);
-}
-
-.select--pink {
-  background-color: var(--pink);
-}
-
-.select--pink:hover {
-  background-color: var(--pink-dark);
-}
-
-.select--pink-light {
-  background-color: var(--pink-light);
-}
-
-.select--pink-light:hover {
-  background-color: var(--pink);
-}
-
-.select--red {
-  background-color: var(--red);
-}
-
-.select--red:hover {
-  background-color: var(--red-dark);
-}
-
-.select--red-light {
-  background-color: var(--red-light);
-}
-
-.select--red-light:hover {
-  background-color: var(--red);
-}
-
-.select--orange {
-  background-color: var(--orange);
-}
-
-.select--orange:hover {
-  background-color: var(--orange-dark);
-}
-
-.select--orange-light {
-  background-color: var(--orange-light);
-}
-
-.select--orange-light:hover {
-  background-color: var(--orange);
-}
-
-.select--yellow {
-  background-color: var(--yellow);
-}
-
-.select--yellow:hover {
-  background-color: var(--yellow-dark);
-}
-
-.select--yellow-light {
-  background-color: var(--yellow-light);
-}
-
-.select--yellow-light:hover {
-  background-color: var(--yellow);
-}
-
-.select--green {
-  background-color: var(--green);
-}
-
-.select--green:hover {
-  background-color: var(--green-dark);
-}
-
-.select--green-light {
-  background-color: var(--green-light);
-}
-
-.select--green-light:hover {
-  background-color: var(--green);
-}
-
-.select--blue {
-  background-color: var(--blue);
-}
-
-.select--blue:hover {
-  background-color: var(--blue-dark);
-}
-
-.select--blue-light {
-  background-color: var(--blue-light);
-}
-
-.select--blue-light:hover {
-  background-color: var(--blue);
-}
-
-.select--purple {
-  background-color: var(--purple);
-}
-
-.select--purple:hover {
-  background-color: var(--purple-dark);
-}
-
-.select--purple-light {
-  background-color: var(--purple-light);
-}
-
-.select--purple-light:hover {
-  background-color: var(--purple);
-}
-
-.select--darken10 {
-  background-color: var(--darken10);
-}
-
-.select--darken10:hover {
-  background-color: var(--darken25);
-}
-
-.select--darken25 {
-  background-color: var(--darken25);
-}
-
-.select--darken25:hover {
-  background-color: var(--darken50);
-}
-
-.select--darken50 {
-  background-color: var(--darken50);
-}
-
-.select--darken50:hover {
-  background-color: var(--darken75);
-}
-
-.select--darken75 {
-  background-color: var(--darken75);
-}
-
-.select--darken75:hover {
-  background-color: var(--black);
-}
-
-.select--lighten10 {
-  background-color: var(--lighten10);
-}
-
-.select--lighten10:hover {
-  background-color: var(--lighten25);
-}
-
-.select--lighten25 {
-  background-color: var(--lighten25);
-}
-
-.select--lighten25:hover {
-  background-color: var(--lighten50);
-}
-
-.select--lighten50 {
-  background-color: var(--lighten50);
-}
-
-.select--lighten50:hover {
-  background-color: var(--lighten75);
-}
-
-.select--lighten75 {
-  background-color: var(--lighten75);
-}
-
-.select--lighten75:hover {
-  background-color: var(--white);
-}
-
-.select--white {
-  background-color: var(--white);
-}
-
-.select--white:hover {
-  background-color: var(--lighten75);
-}
-
-.select--transparent {
-  background-color: var(--transparent);
-}
-
-.select--transparent:hover {
-  background-color: var(--darken10);
-}
-
-.select--stroke-gray {
-  color: var(--gray);
-}
-.select--stroke-gray + .select-arrow {
+.select--border-gray + .select-arrow {
   border-top-color: var(--gray);
 }
-.select--stroke-gray:hover {
-  color: var(--gray-dark);
-}
-.select--stroke-gray:hover + .select-arrow {
+
+.select--border-gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
 }
 
-.select--stroke-pink {
-  color: var(--pink);
-}
-.select--stroke-pink + .select-arrow {
+.select--border-pink + .select-arrow {
   border-top-color: var(--pink);
 }
-.select--stroke-pink:hover {
-  color: var(--pink-dark);
-}
-.select--stroke-pink:hover + .select-arrow {
+
+.select--border-pink:focus + .select-arrow {
   border-top-color: var(--pink-dark);
 }
 
-.select--stroke-red {
-  color: var(--red);
-}
-.select--stroke-red + .select-arrow {
+.select--border-red + .select-arrow {
   border-top-color: var(--red);
 }
-.select--stroke-red:hover {
-  color: var(--red-dark);
-}
-.select--stroke-red:hover + .select-arrow {
+
+.select--border-red:focus + .select-arrow {
   border-top-color: var(--red-dark);
 }
 
-.select--stroke-orange {
-  color: var(--orange);
-}
-.select--stroke-orange + .select-arrow {
+.select--border-orange + .select-arrow {
   border-top-color: var(--orange);
 }
-.select--stroke-orange:hover {
-  color: var(--orange-dark);
-}
-.select--stroke-orange:hover + .select-arrow {
+
+.select--border-orange:focus + .select-arrow {
   border-top-color: var(--orange-dark);
 }
 
-.select--stroke-yellow {
-  color: var(--yellow);
-}
-.select--stroke-yellow + .select-arrow {
+.select--border-yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
-.select--stroke-yellow:hover {
-  color: var(--yellow-dark);
-}
-.select--stroke-yellow:hover + .select-arrow {
+
+.select--border-yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
 }
 
-.select--stroke-green {
-  color: var(--green);
-}
-.select--stroke-green + .select-arrow {
+.select--border-green + .select-arrow {
   border-top-color: var(--green);
 }
-.select--stroke-green:hover {
-  color: var(--green-dark);
-}
-.select--stroke-green:hover + .select-arrow {
+
+.select--border-green:focus + .select-arrow {
   border-top-color: var(--green-dark);
 }
 
-.select--stroke-blue {
-  color: var(--blue);
-}
-.select--stroke-blue + .select-arrow {
+.select--border-blue + .select-arrow {
   border-top-color: var(--blue);
 }
-.select--stroke-blue:hover {
-  color: var(--blue-dark);
-}
-.select--stroke-blue:hover + .select-arrow {
+
+.select--border-blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
 }
 
-.select--stroke-purple {
-  color: var(--purple);
-}
-.select--stroke-purple + .select-arrow {
+.select--border-purple + .select-arrow {
   border-top-color: var(--purple);
 }
-.select--stroke-purple:hover {
-  color: var(--purple-dark);
-}
-.select--stroke-purple:hover + .select-arrow {
+
+.select--border-purple:focus + .select-arrow {
   border-top-color: var(--purple-dark);
 }
 
-.select--stroke-darken25 {
-  color: var(--darken25);
-}
-.select--stroke-darken25 + .select-arrow {
+.select--border-darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
-.select--stroke-darken25:hover {
-  color: var(--darken50);
-}
-.select--stroke-darken25:hover + .select-arrow {
+
+.select--border-darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--stroke-darken50 {
-  color: var(--darken50);
-}
-.select--stroke-darken50 + .select-arrow {
+.select--border-darken50 + .select-arrow {
   border-top-color: var(--darken50);
 }
-.select--stroke-darken50:hover {
-  color: var(--darken75);
-}
-.select--stroke-darken50:hover + .select-arrow {
+
+.select--border-darken50:focus + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--stroke-darken75 {
-  color: var(--darken75);
-}
-.select--stroke-darken75 + .select-arrow {
+.select--border-darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
-.select--stroke-darken75:hover {
-  color: var(--black);
-}
-.select--stroke-darken75:hover + .select-arrow {
+
+.select--border-darken75:focus + .select-arrow {
   border-top-color: var(--black);
 }
 
-.select--stroke-lighten25 {
-  color: var(--lighten25);
-}
-.select--stroke-lighten25 + .select-arrow {
+.select--border-lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
-.select--stroke-lighten25:hover {
-  color: var(--lighten50);
-}
-.select--stroke-lighten25:hover + .select-arrow {
+
+.select--border-lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--stroke-lighten50 {
-  color: var(--lighten50);
-}
-.select--stroke-lighten50 + .select-arrow {
+.select--border-lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
-.select--stroke-lighten50:hover {
-  color: var(--lighten75);
-}
-.select--stroke-lighten50:hover + .select-arrow {
+
+.select--border-lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--stroke-lighten75 {
-  color: var(--lighten75);
-}
-.select--stroke-lighten75 + .select-arrow {
+.select--border-lighten75 + .select-arrow {
   border-top-color: var(--lighten75);
 }
-.select--stroke-lighten75:hover {
-  color: var(--white);
-}
-.select--stroke-lighten75:hover + .select-arrow {
+
+.select--border-lighten75:focus + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--stroke-white {
-  color: var(--white);
-}
-.select--stroke-white + .select-arrow {
+.select--border-white + .select-arrow {
   border-top-color: var(--white);
 }
-.select--stroke-white:hover {
-  color: var(--lighten75);
-}
-.select--stroke-white:hover + .select-arrow {
+
+.select--border-white:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--stroke-transparent {
-  color: var(--transparent);
-}
-.select--stroke-transparent + .select-arrow {
+.select--border-transparent + .select-arrow {
   border-top-color: var(--transparent);
 }
-.select--stroke-transparent:hover {
-  color: var(--darken10);
-}
-.select--stroke-transparent:hover + .select-arrow {
+
+.select--border-transparent:focus + .select-arrow {
   border-top-color: var(--darken10);
 }
 
 .textarea--border-gray,
-.input--border-gray {
+.input--border-gray,
+.select--border-gray {
   box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus {
+.input--border-gray:focus,
+.select--border-gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
-.input--border-pink {
+.input--border-pink,
+.select--border-pink {
   box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus {
+.input--border-pink:focus,
+.select--border-pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
-.input--border-red {
+.input--border-red,
+.select--border-red {
   box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus {
+.input--border-red:focus,
+.select--border-red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
-.input--border-orange {
+.input--border-orange,
+.select--border-orange {
   box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus {
+.input--border-orange:focus,
+.select--border-orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
-.input--border-yellow {
+.input--border-yellow,
+.select--border-yellow {
   box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus {
+.input--border-yellow:focus,
+.select--border-yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
-.input--border-green {
+.input--border-green,
+.select--border-green {
   box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus {
+.input--border-green:focus,
+.select--border-green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
-.input--border-blue {
+.input--border-blue,
+.select--border-blue {
   box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus {
+.input--border-blue:focus,
+.select--border-blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
-.input--border-purple {
+.input--border-purple,
+.select--border-purple {
   box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus {
+.input--border-purple:focus,
+.select--border-purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
-.input--border-darken25 {
+.input--border-darken25,
+.select--border-darken25 {
   box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus {
+.input--border-darken25:focus,
+.select--border-darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
-.input--border-darken50 {
+.input--border-darken50,
+.select--border-darken50 {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus {
+.input--border-darken50:focus,
+.select--border-darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
-.input--border-darken75 {
+.input--border-darken75,
+.select--border-darken75 {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus {
+.input--border-darken75:focus,
+.select--border-darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
-.input--border-lighten25 {
+.input--border-lighten25,
+.select--border-lighten25 {
   box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus {
+.input--border-lighten25:focus,
+.select--border-lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
-.input--border-lighten50 {
+.input--border-lighten50,
+.select--border-lighten50 {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus {
+.input--border-lighten50:focus,
+.select--border-lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
-.input--border-lighten75 {
+.input--border-lighten75,
+.select--border-lighten75 {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus {
+.input--border-lighten75:focus,
+.select--border-lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
-.input--border-white {
+.input--border-white,
+.select--border-white {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus {
+.input--border-white:focus,
+.select--border-white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
-.input--border-transparent {
+.input--border-transparent,
+.select--border-transparent {
   box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus {
+.input--border-transparent:focus,
+.select--border-transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
@@ -3791,579 +3535,323 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--gray {
-  background-color: var(--gray);
-}
-
-.select--gray:hover {
-  background-color: var(--gray-dark);
-}
-
-.select--gray-light {
-  background-color: var(--gray-light);
-}
-
-.select--gray-light:hover {
-  background-color: var(--gray);
-}
-
-.select--pink {
-  background-color: var(--pink);
-}
-
-.select--pink:hover {
-  background-color: var(--pink-dark);
-}
-
-.select--pink-light {
-  background-color: var(--pink-light);
-}
-
-.select--pink-light:hover {
-  background-color: var(--pink);
-}
-
-.select--red {
-  background-color: var(--red);
-}
-
-.select--red:hover {
-  background-color: var(--red-dark);
-}
-
-.select--red-light {
-  background-color: var(--red-light);
-}
-
-.select--red-light:hover {
-  background-color: var(--red);
-}
-
-.select--orange {
-  background-color: var(--orange);
-}
-
-.select--orange:hover {
-  background-color: var(--orange-dark);
-}
-
-.select--orange-light {
-  background-color: var(--orange-light);
-}
-
-.select--orange-light:hover {
-  background-color: var(--orange);
-}
-
-.select--yellow {
-  background-color: var(--yellow);
-}
-
-.select--yellow:hover {
-  background-color: var(--yellow-dark);
-}
-
-.select--yellow-light {
-  background-color: var(--yellow-light);
-}
-
-.select--yellow-light:hover {
-  background-color: var(--yellow);
-}
-
-.select--green {
-  background-color: var(--green);
-}
-
-.select--green:hover {
-  background-color: var(--green-dark);
-}
-
-.select--green-light {
-  background-color: var(--green-light);
-}
-
-.select--green-light:hover {
-  background-color: var(--green);
-}
-
-.select--blue {
-  background-color: var(--blue);
-}
-
-.select--blue:hover {
-  background-color: var(--blue-dark);
-}
-
-.select--blue-light {
-  background-color: var(--blue-light);
-}
-
-.select--blue-light:hover {
-  background-color: var(--blue);
-}
-
-.select--purple {
-  background-color: var(--purple);
-}
-
-.select--purple:hover {
-  background-color: var(--purple-dark);
-}
-
-.select--purple-light {
-  background-color: var(--purple-light);
-}
-
-.select--purple-light:hover {
-  background-color: var(--purple);
-}
-
-.select--darken10 {
-  background-color: var(--darken10);
-}
-
-.select--darken10:hover {
-  background-color: var(--darken25);
-}
-
-.select--darken25 {
-  background-color: var(--darken25);
-}
-
-.select--darken25:hover {
-  background-color: var(--darken50);
-}
-
-.select--darken50 {
-  background-color: var(--darken50);
-}
-
-.select--darken50:hover {
-  background-color: var(--darken75);
-}
-
-.select--darken75 {
-  background-color: var(--darken75);
-}
-
-.select--darken75:hover {
-  background-color: var(--black);
-}
-
-.select--lighten10 {
-  background-color: var(--lighten10);
-}
-
-.select--lighten10:hover {
-  background-color: var(--lighten25);
-}
-
-.select--lighten25 {
-  background-color: var(--lighten25);
-}
-
-.select--lighten25:hover {
-  background-color: var(--lighten50);
-}
-
-.select--lighten50 {
-  background-color: var(--lighten50);
-}
-
-.select--lighten50:hover {
-  background-color: var(--lighten75);
-}
-
-.select--lighten75 {
-  background-color: var(--lighten75);
-}
-
-.select--lighten75:hover {
-  background-color: var(--white);
-}
-
-.select--white {
-  background-color: var(--white);
-}
-
-.select--white:hover {
-  background-color: var(--lighten75);
-}
-
-.select--transparent {
-  background-color: var(--transparent);
-}
-
-.select--transparent:hover {
-  background-color: var(--darken10);
-}
-
-.select--stroke-gray {
-  color: var(--gray);
-}
-.select--stroke-gray + .select-arrow {
+.select--border-gray + .select-arrow {
   border-top-color: var(--gray);
 }
-.select--stroke-gray:hover {
-  color: var(--gray-dark);
-}
-.select--stroke-gray:hover + .select-arrow {
+
+.select--border-gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
 }
 
-.select--stroke-pink {
-  color: var(--pink);
-}
-.select--stroke-pink + .select-arrow {
+.select--border-pink + .select-arrow {
   border-top-color: var(--pink);
 }
-.select--stroke-pink:hover {
-  color: var(--pink-dark);
-}
-.select--stroke-pink:hover + .select-arrow {
+
+.select--border-pink:focus + .select-arrow {
   border-top-color: var(--pink-dark);
 }
 
-.select--stroke-red {
-  color: var(--red);
-}
-.select--stroke-red + .select-arrow {
+.select--border-red + .select-arrow {
   border-top-color: var(--red);
 }
-.select--stroke-red:hover {
-  color: var(--red-dark);
-}
-.select--stroke-red:hover + .select-arrow {
+
+.select--border-red:focus + .select-arrow {
   border-top-color: var(--red-dark);
 }
 
-.select--stroke-orange {
-  color: var(--orange);
-}
-.select--stroke-orange + .select-arrow {
+.select--border-orange + .select-arrow {
   border-top-color: var(--orange);
 }
-.select--stroke-orange:hover {
-  color: var(--orange-dark);
-}
-.select--stroke-orange:hover + .select-arrow {
+
+.select--border-orange:focus + .select-arrow {
   border-top-color: var(--orange-dark);
 }
 
-.select--stroke-yellow {
-  color: var(--yellow);
-}
-.select--stroke-yellow + .select-arrow {
+.select--border-yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
-.select--stroke-yellow:hover {
-  color: var(--yellow-dark);
-}
-.select--stroke-yellow:hover + .select-arrow {
+
+.select--border-yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
 }
 
-.select--stroke-green {
-  color: var(--green);
-}
-.select--stroke-green + .select-arrow {
+.select--border-green + .select-arrow {
   border-top-color: var(--green);
 }
-.select--stroke-green:hover {
-  color: var(--green-dark);
-}
-.select--stroke-green:hover + .select-arrow {
+
+.select--border-green:focus + .select-arrow {
   border-top-color: var(--green-dark);
 }
 
-.select--stroke-blue {
-  color: var(--blue);
-}
-.select--stroke-blue + .select-arrow {
+.select--border-blue + .select-arrow {
   border-top-color: var(--blue);
 }
-.select--stroke-blue:hover {
-  color: var(--blue-dark);
-}
-.select--stroke-blue:hover + .select-arrow {
+
+.select--border-blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
 }
 
-.select--stroke-purple {
-  color: var(--purple);
-}
-.select--stroke-purple + .select-arrow {
+.select--border-purple + .select-arrow {
   border-top-color: var(--purple);
 }
-.select--stroke-purple:hover {
-  color: var(--purple-dark);
-}
-.select--stroke-purple:hover + .select-arrow {
+
+.select--border-purple:focus + .select-arrow {
   border-top-color: var(--purple-dark);
 }
 
-.select--stroke-darken25 {
-  color: var(--darken25);
-}
-.select--stroke-darken25 + .select-arrow {
+.select--border-darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
-.select--stroke-darken25:hover {
-  color: var(--darken50);
-}
-.select--stroke-darken25:hover + .select-arrow {
+
+.select--border-darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--stroke-darken50 {
-  color: var(--darken50);
-}
-.select--stroke-darken50 + .select-arrow {
+.select--border-darken50 + .select-arrow {
   border-top-color: var(--darken50);
 }
-.select--stroke-darken50:hover {
-  color: var(--darken75);
-}
-.select--stroke-darken50:hover + .select-arrow {
+
+.select--border-darken50:focus + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--stroke-darken75 {
-  color: var(--darken75);
-}
-.select--stroke-darken75 + .select-arrow {
+.select--border-darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
-.select--stroke-darken75:hover {
-  color: var(--black);
-}
-.select--stroke-darken75:hover + .select-arrow {
+
+.select--border-darken75:focus + .select-arrow {
   border-top-color: var(--black);
 }
 
-.select--stroke-lighten25 {
-  color: var(--lighten25);
-}
-.select--stroke-lighten25 + .select-arrow {
+.select--border-lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
-.select--stroke-lighten25:hover {
-  color: var(--lighten50);
-}
-.select--stroke-lighten25:hover + .select-arrow {
+
+.select--border-lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--stroke-lighten50 {
-  color: var(--lighten50);
-}
-.select--stroke-lighten50 + .select-arrow {
+.select--border-lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
-.select--stroke-lighten50:hover {
-  color: var(--lighten75);
-}
-.select--stroke-lighten50:hover + .select-arrow {
+
+.select--border-lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--stroke-lighten75 {
-  color: var(--lighten75);
-}
-.select--stroke-lighten75 + .select-arrow {
+.select--border-lighten75 + .select-arrow {
   border-top-color: var(--lighten75);
 }
-.select--stroke-lighten75:hover {
-  color: var(--white);
-}
-.select--stroke-lighten75:hover + .select-arrow {
+
+.select--border-lighten75:focus + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--stroke-white {
-  color: var(--white);
-}
-.select--stroke-white + .select-arrow {
+.select--border-white + .select-arrow {
   border-top-color: var(--white);
 }
-.select--stroke-white:hover {
-  color: var(--lighten75);
-}
-.select--stroke-white:hover + .select-arrow {
+
+.select--border-white:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--stroke-transparent {
-  color: var(--transparent);
-}
-.select--stroke-transparent + .select-arrow {
+.select--border-transparent + .select-arrow {
   border-top-color: var(--transparent);
 }
-.select--stroke-transparent:hover {
-  color: var(--darken10);
-}
-.select--stroke-transparent:hover + .select-arrow {
+
+.select--border-transparent:focus + .select-arrow {
   border-top-color: var(--darken10);
 }
 
 .textarea--border-gray,
-.input--border-gray {
+.input--border-gray,
+.select--border-gray {
   box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus {
+.input--border-gray:focus,
+.select--border-gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
-.input--border-pink {
+.input--border-pink,
+.select--border-pink {
   box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus {
+.input--border-pink:focus,
+.select--border-pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
-.input--border-red {
+.input--border-red,
+.select--border-red {
   box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus {
+.input--border-red:focus,
+.select--border-red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
-.input--border-orange {
+.input--border-orange,
+.select--border-orange {
   box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus {
+.input--border-orange:focus,
+.select--border-orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
-.input--border-yellow {
+.input--border-yellow,
+.select--border-yellow {
   box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus {
+.input--border-yellow:focus,
+.select--border-yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
-.input--border-green {
+.input--border-green,
+.select--border-green {
   box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus {
+.input--border-green:focus,
+.select--border-green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
-.input--border-blue {
+.input--border-blue,
+.select--border-blue {
   box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus {
+.input--border-blue:focus,
+.select--border-blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
-.input--border-purple {
+.input--border-purple,
+.select--border-purple {
   box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus {
+.input--border-purple:focus,
+.select--border-purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
-.input--border-darken25 {
+.input--border-darken25,
+.select--border-darken25 {
   box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus {
+.input--border-darken25:focus,
+.select--border-darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
-.input--border-darken50 {
+.input--border-darken50,
+.select--border-darken50 {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus {
+.input--border-darken50:focus,
+.select--border-darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
-.input--border-darken75 {
+.input--border-darken75,
+.select--border-darken75 {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus {
+.input--border-darken75:focus,
+.select--border-darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
-.input--border-lighten25 {
+.input--border-lighten25,
+.select--border-lighten25 {
   box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus {
+.input--border-lighten25:focus,
+.select--border-lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
-.input--border-lighten50 {
+.input--border-lighten50,
+.select--border-lighten50 {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus {
+.input--border-lighten50:focus,
+.select--border-lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
-.input--border-lighten75 {
+.input--border-lighten75,
+.select--border-lighten75 {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus {
+.input--border-lighten75:focus,
+.select--border-lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
-.input--border-white {
+.input--border-white,
+.select--border-white {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus {
+.input--border-white:focus,
+.select--border-white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
-.input--border-transparent {
+.input--border-transparent,
+.select--border-transparent {
   box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus {
+.input--border-transparent:focus,
+.select--border-transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
@@ -6859,73 +6347,43 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--red {
-  background-color: var(--red);
-}
-
-.select--red:hover {
-  background-color: var(--red-dark);
-}
-
-.select--teal {
-  background-color: var(--teal);
-}
-
-.select--teal:hover {
-  background-color: var(--teal-dark);
-}
-
-.select--green-light {
-  background-color: var(--green-light);
-}
-
-.select--green-light:hover {
-  background-color: var(--green);
-}
-
-.select--stroke-red {
-  color: var(--red);
-}
-.select--stroke-red + .select-arrow {
+.select--border-red + .select-arrow {
   border-top-color: var(--red);
 }
-.select--stroke-red:hover {
-  color: var(--red-dark);
-}
-.select--stroke-red:hover + .select-arrow {
+
+.select--border-red:focus + .select-arrow {
   border-top-color: var(--red-dark);
 }
 
-.select--stroke-teal {
-  color: var(--teal);
-}
-.select--stroke-teal + .select-arrow {
+.select--border-teal + .select-arrow {
   border-top-color: var(--teal);
 }
-.select--stroke-teal:hover {
-  color: var(--teal-dark);
-}
-.select--stroke-teal:hover + .select-arrow {
+
+.select--border-teal:focus + .select-arrow {
   border-top-color: var(--teal-dark);
 }
 
 .textarea--border-red,
-.input--border-red {
+.input--border-red,
+.select--border-red {
   box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus {
+.input--border-red:focus,
+.select--border-red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-teal,
-.input--border-teal {
+.input--border-teal,
+.select--border-teal {
   box-shadow: inset 0 0 0 1px var(--teal);
 }
 
 .textarea--border-teal:focus,
-.input--border-teal:focus {
+.input--border-teal:focus,
+.select--border-teal:focus {
   box-shadow: inset 0 0 0 1px var(--teal-dark);
 }
 
@@ -7327,80 +6785,63 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--green {
-  background-color: var(--green);
-}
-
-.select--green:hover {
-  background-color: var(--green-dark);
-}
-
-.select--stroke-lighten50 {
-  color: var(--lighten50);
-}
-.select--stroke-lighten50 + .select-arrow {
+.select--border-lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
-.select--stroke-lighten50:hover {
-  color: var(--lighten75);
-}
-.select--stroke-lighten50:hover + .select-arrow {
+
+.select--border-lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--stroke-lighten25 {
-  color: var(--lighten25);
-}
-.select--stroke-lighten25 + .select-arrow {
+.select--border-lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
-.select--stroke-lighten25:hover {
-  color: var(--lighten50);
-}
-.select--stroke-lighten25:hover + .select-arrow {
+
+.select--border-lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--stroke-gray {
-  color: var(--gray);
-}
-.select--stroke-gray + .select-arrow {
+.select--border-gray + .select-arrow {
   border-top-color: var(--gray);
 }
-.select--stroke-gray:hover {
-  color: var(--gray-dark);
-}
-.select--stroke-gray:hover + .select-arrow {
+
+.select--border-gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
 }
 
 .textarea--border-lighten50,
-.input--border-lighten50 {
+.input--border-lighten50,
+.select--border-lighten50 {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus {
+.input--border-lighten50:focus,
+.select--border-lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten25,
-.input--border-lighten25 {
+.input--border-lighten25,
+.select--border-lighten25 {
   box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus {
+.input--border-lighten25:focus,
+.select--border-lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-gray,
-.input--border-gray {
+.input--border-gray,
+.select--border-gray {
   box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus {
+.input--border-gray:focus,
+.select--border-gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -766,18 +766,20 @@ textarea{
   box-shadow:none;
 }
 .input,
-.textarea{
+.textarea,
+.select{
   box-shadow:inset 0 0 0 1px #ccc;
   padding:6px 12px;
   border-radius:4px;
   transition:background-color 0.125s,
-    border-color 0.125s;
+    box-shadow 0.125s;
   display:block;
   width:100%;
 }
 
 .input:focus,
-.textarea:focus{
+.textarea:focus,
+.select:focus{
   box-shadow:inset 0 0 0 1px #448ee4;
 }
 
@@ -836,7 +838,8 @@ textarea{
   padding:0 3px;
 }
 .input:disabled,
-.textarea:disabled{
+.textarea:disabled,
+.select:disabled{
   pointer-events:none;
   color:rgba(0, 0, 0, 0.5);
   background-color:rgba(127, 127, 127, 0.1);
@@ -850,7 +853,6 @@ textarea{
   display:-webkit-inline-flex;
   display:inline-flex;
   position:relative;
-  color:#fff;
   -webkit-align-items:center;
           align-items:center;
 }
@@ -859,34 +861,30 @@ textarea{
   -webkit-appearance:none;
      -moz-appearance:none;
           appearance:none;
+  background-color:transparent;
   font-size:15px;
   line-height:24px;
-  font-weight:bold;
   color:currentColor;
   padding:6px 30px 6px 12px;
   cursor:pointer;
-  display:inline-block;
-  transition:color 0.125s,
-    background-color 0.125s;
-  border-radius:4px;
-  background-color:#448ee4;
 }
 
 .select-arrow{
   position:absolute;
   right:12px;
-  top:50%;
+  top:calc(50% - 1px);
   pointer-events:none;
   border-left:4px solid transparent;
   border-right:4px solid transparent;
-  border-top:5px solid currentColor;
+  border-top:5px solid #ccc;
   width:8px;
   height:8px;
   margin-top:-1px;
   transition:border-top-color 0.125s;
 }
-.select:hover{
-  background-color:#346db0;
+
+.select:focus + .select-arrow{
+  border-top-color:#448ee4;
 }
 .select option{
   background-color:#fff;
@@ -909,27 +907,6 @@ textarea{
     background-color:transparent;
     color:inherit;
   }
-}
-.select--stroke{
-  color:#666;
-  background-color:transparent;
-  box-shadow:inset 0 0 0 1px currentColor;
-}
-.select--stroke--2{
-  box-shadow:inset 0 0 0 2px currentColor;
-}
-
-.select--stroke + .select-arrow{
-  color:#666;
-}
-
-.select--stroke:hover{
-  background-color:transparent;
-  color:#2d2d2d;
-}
-
-.select--stroke:hover + .select-arrow{
-  border-top-color:currentColor;
 }
 .select--s{
   font-size:12px;
@@ -8775,579 +8752,323 @@ input:checked:disabled + .toggle{
   background-color:transparent;
 }
 
-.select--gray{
-  background-color:#666;
-}
-
-.select--gray:hover{
-  background-color:#2d2d2d;
-}
-
-.select--gray-light{
-  background-color:#ccc;
-}
-
-.select--gray-light:hover{
-  background-color:#666;
-}
-
-.select--pink{
-  background-color:#ff3c96;
-}
-
-.select--pink:hover{
-  background-color:#ab084b;
-}
-
-.select--pink-light{
-  background-color:#ff88c0;
-}
-
-.select--pink-light:hover{
-  background-color:#ff3c96;
-}
-
-.select--red{
-  background-color:#dc2b28;
-}
-
-.select--red:hover{
-  background-color:#a30003;
-}
-
-.select--red-light{
-  background-color:#ff8280;
-}
-
-.select--red-light:hover{
-  background-color:#dc2b28;
-}
-
-.select--orange{
-  background-color:#ff6e00;
-}
-
-.select--orange:hover{
-  background-color:#bc3a00;
-}
-
-.select--orange-light{
-  background-color:#ffa950;
-}
-
-.select--orange-light:hover{
-  background-color:#ff6e00;
-}
-
-.select--yellow{
-  background-color:#f0dc00;
-}
-
-.select--yellow:hover{
-  background-color:#d9a100;
-}
-
-.select--yellow-light{
-  background-color:#f0f062;
-}
-
-.select--yellow-light:hover{
-  background-color:#f0dc00;
-}
-
-.select--green{
-  background-color:#01aa46;
-}
-
-.select--green:hover{
-  background-color:#006427;
-}
-
-.select--green-light{
-  background-color:#72c781;
-}
-
-.select--green-light:hover{
-  background-color:#01aa46;
-}
-
-.select--blue{
-  background-color:#3887BE;
-}
-
-.select--blue:hover{
-  background-color:#223B53;
-}
-
-.select--blue-light{
-  background-color:#52A1D8;
-}
-
-.select--blue-light:hover{
-  background-color:#3887BE;
-}
-
-.select--purple{
-  background-color:#8c50c7;
-}
-
-.select--purple:hover{
-  background-color:#440067;
-}
-
-.select--purple-light{
-  background-color:#c299e3;
-}
-
-.select--purple-light:hover{
-  background-color:#8c50c7;
-}
-
-.select--darken10{
-  background-color:rgba(0, 0, 0, 0.1);
-}
-
-.select--darken10:hover{
-  background-color:rgba(0, 0, 0, 0.25);
-}
-
-.select--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
-}
-
-.select--darken25:hover{
-  background-color:rgba(0, 0, 0, 0.5);
-}
-
-.select--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
-}
-
-.select--darken50:hover{
-  background-color:rgba(0, 0, 0, 0.75);
-}
-
-.select--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
-}
-
-.select--darken75:hover{
-  background-color:#000;
-}
-
-.select--lighten10{
-  background-color:rgba(255, 255, 255, 0.1);
-}
-
-.select--lighten10:hover{
-  background-color:rgba(255, 255, 255, 0.25);
-}
-
-.select--lighten25{
-  background-color:rgba(255, 255, 255, 0.25);
-}
-
-.select--lighten25:hover{
-  background-color:rgba(255, 255, 255, 0.5);
-}
-
-.select--lighten50{
-  background-color:rgba(255, 255, 255, 0.5);
-}
-
-.select--lighten50:hover{
-  background-color:rgba(255, 255, 255, 0.75);
-}
-
-.select--lighten75{
-  background-color:rgba(255, 255, 255, 0.75);
-}
-
-.select--lighten75:hover{
-  background-color:#fff;
-}
-
-.select--white{
-  background-color:#fff;
-}
-
-.select--white:hover{
-  background-color:rgba(255, 255, 255, 0.75);
-}
-
-.select--transparent{
-  background-color:transparent;
-}
-
-.select--transparent:hover{
-  background-color:rgba(0, 0, 0, 0.1);
-}
-
-.select--stroke-gray{
-  color:#666;
-}
-.select--stroke-gray + .select-arrow{
+.select--border-gray + .select-arrow{
   border-top-color:#666;
 }
-.select--stroke-gray:hover{
-  color:#2d2d2d;
-}
-.select--stroke-gray:hover + .select-arrow{
+
+.select--border-gray:focus + .select-arrow{
   border-top-color:#2d2d2d;
 }
 
-.select--stroke-pink{
-  color:#ff3c96;
-}
-.select--stroke-pink + .select-arrow{
+.select--border-pink + .select-arrow{
   border-top-color:#ff3c96;
 }
-.select--stroke-pink:hover{
-  color:#ab084b;
-}
-.select--stroke-pink:hover + .select-arrow{
+
+.select--border-pink:focus + .select-arrow{
   border-top-color:#ab084b;
 }
 
-.select--stroke-red{
-  color:#dc2b28;
-}
-.select--stroke-red + .select-arrow{
+.select--border-red + .select-arrow{
   border-top-color:#dc2b28;
 }
-.select--stroke-red:hover{
-  color:#a30003;
-}
-.select--stroke-red:hover + .select-arrow{
+
+.select--border-red:focus + .select-arrow{
   border-top-color:#a30003;
 }
 
-.select--stroke-orange{
-  color:#ff6e00;
-}
-.select--stroke-orange + .select-arrow{
+.select--border-orange + .select-arrow{
   border-top-color:#ff6e00;
 }
-.select--stroke-orange:hover{
-  color:#bc3a00;
-}
-.select--stroke-orange:hover + .select-arrow{
+
+.select--border-orange:focus + .select-arrow{
   border-top-color:#bc3a00;
 }
 
-.select--stroke-yellow{
-  color:#f0dc00;
-}
-.select--stroke-yellow + .select-arrow{
+.select--border-yellow + .select-arrow{
   border-top-color:#f0dc00;
 }
-.select--stroke-yellow:hover{
-  color:#d9a100;
-}
-.select--stroke-yellow:hover + .select-arrow{
+
+.select--border-yellow:focus + .select-arrow{
   border-top-color:#d9a100;
 }
 
-.select--stroke-green{
-  color:#01aa46;
-}
-.select--stroke-green + .select-arrow{
+.select--border-green + .select-arrow{
   border-top-color:#01aa46;
 }
-.select--stroke-green:hover{
-  color:#006427;
-}
-.select--stroke-green:hover + .select-arrow{
+
+.select--border-green:focus + .select-arrow{
   border-top-color:#006427;
 }
 
-.select--stroke-blue{
-  color:#3887BE;
-}
-.select--stroke-blue + .select-arrow{
+.select--border-blue + .select-arrow{
   border-top-color:#3887BE;
 }
-.select--stroke-blue:hover{
-  color:#223B53;
-}
-.select--stroke-blue:hover + .select-arrow{
+
+.select--border-blue:focus + .select-arrow{
   border-top-color:#223B53;
 }
 
-.select--stroke-purple{
-  color:#8c50c7;
-}
-.select--stroke-purple + .select-arrow{
+.select--border-purple + .select-arrow{
   border-top-color:#8c50c7;
 }
-.select--stroke-purple:hover{
-  color:#440067;
-}
-.select--stroke-purple:hover + .select-arrow{
+
+.select--border-purple:focus + .select-arrow{
   border-top-color:#440067;
 }
 
-.select--stroke-darken25{
-  color:rgba(0, 0, 0, 0.25);
-}
-.select--stroke-darken25 + .select-arrow{
+.select--border-darken25 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.25);
 }
-.select--stroke-darken25:hover{
-  color:rgba(0, 0, 0, 0.5);
-}
-.select--stroke-darken25:hover + .select-arrow{
+
+.select--border-darken25:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
 }
 
-.select--stroke-darken50{
-  color:rgba(0, 0, 0, 0.5);
-}
-.select--stroke-darken50 + .select-arrow{
+.select--border-darken50 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
 }
-.select--stroke-darken50:hover{
-  color:rgba(0, 0, 0, 0.75);
-}
-.select--stroke-darken50:hover + .select-arrow{
+
+.select--border-darken50:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
-.select--stroke-darken75{
-  color:rgba(0, 0, 0, 0.75);
-}
-.select--stroke-darken75 + .select-arrow{
+.select--border-darken75 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
-.select--stroke-darken75:hover{
-  color:#000;
-}
-.select--stroke-darken75:hover + .select-arrow{
+
+.select--border-darken75:focus + .select-arrow{
   border-top-color:#000;
 }
 
-.select--stroke-lighten25{
-  color:rgba(255, 255, 255, 0.25);
-}
-.select--stroke-lighten25 + .select-arrow{
+.select--border-lighten25 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.25);
 }
-.select--stroke-lighten25:hover{
-  color:rgba(255, 255, 255, 0.5);
-}
-.select--stroke-lighten25:hover + .select-arrow{
+
+.select--border-lighten25:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
-.select--stroke-lighten50{
-  color:rgba(255, 255, 255, 0.5);
-}
-.select--stroke-lighten50 + .select-arrow{
+.select--border-lighten50 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
-.select--stroke-lighten50:hover{
-  color:rgba(255, 255, 255, 0.75);
-}
-.select--stroke-lighten50:hover + .select-arrow{
+
+.select--border-lighten50:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--stroke-lighten75{
-  color:rgba(255, 255, 255, 0.75);
-}
-.select--stroke-lighten75 + .select-arrow{
+.select--border-lighten75 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
-.select--stroke-lighten75:hover{
-  color:#fff;
-}
-.select--stroke-lighten75:hover + .select-arrow{
+
+.select--border-lighten75:focus + .select-arrow{
   border-top-color:#fff;
 }
 
-.select--stroke-white{
-  color:#fff;
-}
-.select--stroke-white + .select-arrow{
+.select--border-white + .select-arrow{
   border-top-color:#fff;
 }
-.select--stroke-white:hover{
-  color:rgba(255, 255, 255, 0.75);
-}
-.select--stroke-white:hover + .select-arrow{
+
+.select--border-white:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--stroke-transparent{
-  color:transparent;
-}
-.select--stroke-transparent + .select-arrow{
+.select--border-transparent + .select-arrow{
   border-top-color:transparent;
 }
-.select--stroke-transparent:hover{
-  color:rgba(0, 0, 0, 0.1);
-}
-.select--stroke-transparent:hover + .select-arrow{
+
+.select--border-transparent:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.1);
 }
 
 .textarea--border-gray,
-.input--border-gray{
+.input--border-gray,
+.select--border-gray{
   box-shadow:inset 0 0 0 1px #666;
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus{
+.input--border-gray:focus,
+.select--border-gray:focus{
   box-shadow:inset 0 0 0 1px #2d2d2d;
 }
 
 .textarea--border-pink,
-.input--border-pink{
+.input--border-pink,
+.select--border-pink{
   box-shadow:inset 0 0 0 1px #ff3c96;
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus{
+.input--border-pink:focus,
+.select--border-pink:focus{
   box-shadow:inset 0 0 0 1px #ab084b;
 }
 
 .textarea--border-red,
-.input--border-red{
+.input--border-red,
+.select--border-red{
   box-shadow:inset 0 0 0 1px #dc2b28;
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus{
+.input--border-red:focus,
+.select--border-red:focus{
   box-shadow:inset 0 0 0 1px #a30003;
 }
 
 .textarea--border-orange,
-.input--border-orange{
+.input--border-orange,
+.select--border-orange{
   box-shadow:inset 0 0 0 1px #ff6e00;
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus{
+.input--border-orange:focus,
+.select--border-orange:focus{
   box-shadow:inset 0 0 0 1px #bc3a00;
 }
 
 .textarea--border-yellow,
-.input--border-yellow{
+.input--border-yellow,
+.select--border-yellow{
   box-shadow:inset 0 0 0 1px #f0dc00;
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus{
+.input--border-yellow:focus,
+.select--border-yellow:focus{
   box-shadow:inset 0 0 0 1px #d9a100;
 }
 
 .textarea--border-green,
-.input--border-green{
+.input--border-green,
+.select--border-green{
   box-shadow:inset 0 0 0 1px #01aa46;
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus{
+.input--border-green:focus,
+.select--border-green:focus{
   box-shadow:inset 0 0 0 1px #006427;
 }
 
 .textarea--border-blue,
-.input--border-blue{
+.input--border-blue,
+.select--border-blue{
   box-shadow:inset 0 0 0 1px #3887BE;
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus{
+.input--border-blue:focus,
+.select--border-blue:focus{
   box-shadow:inset 0 0 0 1px #223B53;
 }
 
 .textarea--border-purple,
-.input--border-purple{
+.input--border-purple,
+.select--border-purple{
   box-shadow:inset 0 0 0 1px #8c50c7;
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus{
+.input--border-purple:focus,
+.select--border-purple:focus{
   box-shadow:inset 0 0 0 1px #440067;
 }
 
 .textarea--border-darken25,
-.input--border-darken25{
+.input--border-darken25,
+.select--border-darken25{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus{
+.input--border-darken25:focus,
+.select--border-darken25:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50,
-.input--border-darken50{
+.input--border-darken50,
+.select--border-darken50{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus{
+.input--border-darken50:focus,
+.select--border-darken50:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75,
-.input--border-darken75{
+.input--border-darken75,
+.select--border-darken75{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus{
+.input--border-darken75:focus,
+.select--border-darken75:focus{
   box-shadow:inset 0 0 0 1px #000;
 }
 
 .textarea--border-lighten25,
-.input--border-lighten25{
+.input--border-lighten25,
+.select--border-lighten25{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.25);
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus{
+.input--border-lighten25:focus,
+.select--border-lighten25:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50,
-.input--border-lighten50{
+.input--border-lighten50,
+.select--border-lighten50{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus{
+.input--border-lighten50:focus,
+.select--border-lighten50:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75,
-.input--border-lighten75{
+.input--border-lighten75,
+.select--border-lighten75{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus{
+.input--border-lighten75:focus,
+.select--border-lighten75:focus{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white,
-.input--border-white{
+.input--border-white,
+.select--border-white{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus{
+.input--border-white:focus,
+.select--border-white:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-transparent,
-.input--border-transparent{
+.input--border-transparent,
+.select--border-transparent{
   box-shadow:inset 0 0 0 1px transparent;
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus{
+.input--border-transparent:focus,
+.select--border-transparent:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 
@@ -13046,18 +12767,20 @@ textarea{
   box-shadow:none;
 }
 .input,
-.textarea{
+.textarea,
+.select{
   box-shadow:inset 0 0 0 1px #ccc;
   padding:6px 12px;
   border-radius:4px;
   transition:background-color 0.125s,
-    border-color 0.125s;
+    box-shadow 0.125s;
   display:block;
   width:100%;
 }
 
 .input:focus,
-.textarea:focus{
+.textarea:focus,
+.select:focus{
   box-shadow:inset 0 0 0 1px #448ee4;
 }
 
@@ -13116,7 +12839,8 @@ textarea{
   padding:0 3px;
 }
 .input:disabled,
-.textarea:disabled{
+.textarea:disabled,
+.select:disabled{
   pointer-events:none;
   color:rgba(0, 0, 0, 0.5);
   background-color:rgba(127, 127, 127, 0.1);
@@ -13130,7 +12854,6 @@ textarea{
   display:-webkit-inline-flex;
   display:inline-flex;
   position:relative;
-  color:#fff;
   -webkit-align-items:center;
           align-items:center;
 }
@@ -13139,34 +12862,30 @@ textarea{
   -webkit-appearance:none;
      -moz-appearance:none;
           appearance:none;
+  background-color:transparent;
   font-size:15px;
   line-height:24px;
-  font-weight:bold;
   color:currentColor;
   padding:6px 30px 6px 12px;
   cursor:pointer;
-  display:inline-block;
-  transition:color 0.125s,
-    background-color 0.125s;
-  border-radius:4px;
-  background-color:#448ee4;
 }
 
 .select-arrow{
   position:absolute;
   right:12px;
-  top:50%;
+  top:calc(50% - 1px);
   pointer-events:none;
   border-left:4px solid transparent;
   border-right:4px solid transparent;
-  border-top:5px solid currentColor;
+  border-top:5px solid #ccc;
   width:8px;
   height:8px;
   margin-top:-1px;
   transition:border-top-color 0.125s;
 }
-.select:hover{
-  background-color:#346db0;
+
+.select:focus + .select-arrow{
+  border-top-color:#448ee4;
 }
 .select option{
   background-color:#fff;
@@ -13189,27 +12908,6 @@ textarea{
     background-color:transparent;
     color:inherit;
   }
-}
-.select--stroke{
-  color:#666;
-  background-color:transparent;
-  box-shadow:inset 0 0 0 1px currentColor;
-}
-.select--stroke--2{
-  box-shadow:inset 0 0 0 2px currentColor;
-}
-
-.select--stroke + .select-arrow{
-  color:#666;
-}
-
-.select--stroke:hover{
-  background-color:transparent;
-  color:#2d2d2d;
-}
-
-.select--stroke:hover + .select-arrow{
-  border-top-color:currentColor;
 }
 .select--s{
   font-size:12px;
@@ -21041,579 +20739,323 @@ input:checked:disabled + .toggle{
   background-color:transparent;
 }
 
-.select--gray{
-  background-color:#666;
-}
-
-.select--gray:hover{
-  background-color:#2d2d2d;
-}
-
-.select--gray-light{
-  background-color:#ccc;
-}
-
-.select--gray-light:hover{
-  background-color:#666;
-}
-
-.select--pink{
-  background-color:#ff3c96;
-}
-
-.select--pink:hover{
-  background-color:#ab084b;
-}
-
-.select--pink-light{
-  background-color:#ff88c0;
-}
-
-.select--pink-light:hover{
-  background-color:#ff3c96;
-}
-
-.select--red{
-  background-color:#dc2b28;
-}
-
-.select--red:hover{
-  background-color:#a30003;
-}
-
-.select--red-light{
-  background-color:#ff8280;
-}
-
-.select--red-light:hover{
-  background-color:#dc2b28;
-}
-
-.select--orange{
-  background-color:#ff6e00;
-}
-
-.select--orange:hover{
-  background-color:#bc3a00;
-}
-
-.select--orange-light{
-  background-color:#ffa950;
-}
-
-.select--orange-light:hover{
-  background-color:#ff6e00;
-}
-
-.select--yellow{
-  background-color:#f0dc00;
-}
-
-.select--yellow:hover{
-  background-color:#d9a100;
-}
-
-.select--yellow-light{
-  background-color:#f0f062;
-}
-
-.select--yellow-light:hover{
-  background-color:#f0dc00;
-}
-
-.select--green{
-  background-color:#01aa46;
-}
-
-.select--green:hover{
-  background-color:#006427;
-}
-
-.select--green-light{
-  background-color:#72c781;
-}
-
-.select--green-light:hover{
-  background-color:#01aa46;
-}
-
-.select--blue{
-  background-color:#448ee4;
-}
-
-.select--blue:hover{
-  background-color:#295b97;
-}
-
-.select--blue-light{
-  background-color:#00b1ff;
-}
-
-.select--blue-light:hover{
-  background-color:#448ee4;
-}
-
-.select--purple{
-  background-color:#8c50c7;
-}
-
-.select--purple:hover{
-  background-color:#440067;
-}
-
-.select--purple-light{
-  background-color:#c299e3;
-}
-
-.select--purple-light:hover{
-  background-color:#8c50c7;
-}
-
-.select--darken10{
-  background-color:rgba(0, 0, 0, 0.1);
-}
-
-.select--darken10:hover{
-  background-color:rgba(0, 0, 0, 0.25);
-}
-
-.select--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
-}
-
-.select--darken25:hover{
-  background-color:rgba(0, 0, 0, 0.5);
-}
-
-.select--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
-}
-
-.select--darken50:hover{
-  background-color:rgba(0, 0, 0, 0.75);
-}
-
-.select--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
-}
-
-.select--darken75:hover{
-  background-color:#000;
-}
-
-.select--lighten10{
-  background-color:rgba(255, 255, 255, 0.1);
-}
-
-.select--lighten10:hover{
-  background-color:rgba(255, 255, 255, 0.25);
-}
-
-.select--lighten25{
-  background-color:rgba(255, 255, 255, 0.25);
-}
-
-.select--lighten25:hover{
-  background-color:rgba(255, 255, 255, 0.5);
-}
-
-.select--lighten50{
-  background-color:rgba(255, 255, 255, 0.5);
-}
-
-.select--lighten50:hover{
-  background-color:rgba(255, 255, 255, 0.75);
-}
-
-.select--lighten75{
-  background-color:rgba(255, 255, 255, 0.75);
-}
-
-.select--lighten75:hover{
-  background-color:#fff;
-}
-
-.select--white{
-  background-color:#fff;
-}
-
-.select--white:hover{
-  background-color:rgba(255, 255, 255, 0.75);
-}
-
-.select--transparent{
-  background-color:transparent;
-}
-
-.select--transparent:hover{
-  background-color:rgba(0, 0, 0, 0.1);
-}
-
-.select--stroke-gray{
-  color:#666;
-}
-.select--stroke-gray + .select-arrow{
+.select--border-gray + .select-arrow{
   border-top-color:#666;
 }
-.select--stroke-gray:hover{
-  color:#2d2d2d;
-}
-.select--stroke-gray:hover + .select-arrow{
+
+.select--border-gray:focus + .select-arrow{
   border-top-color:#2d2d2d;
 }
 
-.select--stroke-pink{
-  color:#ff3c96;
-}
-.select--stroke-pink + .select-arrow{
+.select--border-pink + .select-arrow{
   border-top-color:#ff3c96;
 }
-.select--stroke-pink:hover{
-  color:#ab084b;
-}
-.select--stroke-pink:hover + .select-arrow{
+
+.select--border-pink:focus + .select-arrow{
   border-top-color:#ab084b;
 }
 
-.select--stroke-red{
-  color:#dc2b28;
-}
-.select--stroke-red + .select-arrow{
+.select--border-red + .select-arrow{
   border-top-color:#dc2b28;
 }
-.select--stroke-red:hover{
-  color:#a30003;
-}
-.select--stroke-red:hover + .select-arrow{
+
+.select--border-red:focus + .select-arrow{
   border-top-color:#a30003;
 }
 
-.select--stroke-orange{
-  color:#ff6e00;
-}
-.select--stroke-orange + .select-arrow{
+.select--border-orange + .select-arrow{
   border-top-color:#ff6e00;
 }
-.select--stroke-orange:hover{
-  color:#bc3a00;
-}
-.select--stroke-orange:hover + .select-arrow{
+
+.select--border-orange:focus + .select-arrow{
   border-top-color:#bc3a00;
 }
 
-.select--stroke-yellow{
-  color:#f0dc00;
-}
-.select--stroke-yellow + .select-arrow{
+.select--border-yellow + .select-arrow{
   border-top-color:#f0dc00;
 }
-.select--stroke-yellow:hover{
-  color:#d9a100;
-}
-.select--stroke-yellow:hover + .select-arrow{
+
+.select--border-yellow:focus + .select-arrow{
   border-top-color:#d9a100;
 }
 
-.select--stroke-green{
-  color:#01aa46;
-}
-.select--stroke-green + .select-arrow{
+.select--border-green + .select-arrow{
   border-top-color:#01aa46;
 }
-.select--stroke-green:hover{
-  color:#006427;
-}
-.select--stroke-green:hover + .select-arrow{
+
+.select--border-green:focus + .select-arrow{
   border-top-color:#006427;
 }
 
-.select--stroke-blue{
-  color:#448ee4;
-}
-.select--stroke-blue + .select-arrow{
+.select--border-blue + .select-arrow{
   border-top-color:#448ee4;
 }
-.select--stroke-blue:hover{
-  color:#295b97;
-}
-.select--stroke-blue:hover + .select-arrow{
+
+.select--border-blue:focus + .select-arrow{
   border-top-color:#295b97;
 }
 
-.select--stroke-purple{
-  color:#8c50c7;
-}
-.select--stroke-purple + .select-arrow{
+.select--border-purple + .select-arrow{
   border-top-color:#8c50c7;
 }
-.select--stroke-purple:hover{
-  color:#440067;
-}
-.select--stroke-purple:hover + .select-arrow{
+
+.select--border-purple:focus + .select-arrow{
   border-top-color:#440067;
 }
 
-.select--stroke-darken25{
-  color:rgba(0, 0, 0, 0.25);
-}
-.select--stroke-darken25 + .select-arrow{
+.select--border-darken25 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.25);
 }
-.select--stroke-darken25:hover{
-  color:rgba(0, 0, 0, 0.5);
-}
-.select--stroke-darken25:hover + .select-arrow{
+
+.select--border-darken25:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
 }
 
-.select--stroke-darken50{
-  color:rgba(0, 0, 0, 0.5);
-}
-.select--stroke-darken50 + .select-arrow{
+.select--border-darken50 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
 }
-.select--stroke-darken50:hover{
-  color:rgba(0, 0, 0, 0.75);
-}
-.select--stroke-darken50:hover + .select-arrow{
+
+.select--border-darken50:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
-.select--stroke-darken75{
-  color:rgba(0, 0, 0, 0.75);
-}
-.select--stroke-darken75 + .select-arrow{
+.select--border-darken75 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
-.select--stroke-darken75:hover{
-  color:#000;
-}
-.select--stroke-darken75:hover + .select-arrow{
+
+.select--border-darken75:focus + .select-arrow{
   border-top-color:#000;
 }
 
-.select--stroke-lighten25{
-  color:rgba(255, 255, 255, 0.25);
-}
-.select--stroke-lighten25 + .select-arrow{
+.select--border-lighten25 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.25);
 }
-.select--stroke-lighten25:hover{
-  color:rgba(255, 255, 255, 0.5);
-}
-.select--stroke-lighten25:hover + .select-arrow{
+
+.select--border-lighten25:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
-.select--stroke-lighten50{
-  color:rgba(255, 255, 255, 0.5);
-}
-.select--stroke-lighten50 + .select-arrow{
+.select--border-lighten50 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
-.select--stroke-lighten50:hover{
-  color:rgba(255, 255, 255, 0.75);
-}
-.select--stroke-lighten50:hover + .select-arrow{
+
+.select--border-lighten50:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--stroke-lighten75{
-  color:rgba(255, 255, 255, 0.75);
-}
-.select--stroke-lighten75 + .select-arrow{
+.select--border-lighten75 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
-.select--stroke-lighten75:hover{
-  color:#fff;
-}
-.select--stroke-lighten75:hover + .select-arrow{
+
+.select--border-lighten75:focus + .select-arrow{
   border-top-color:#fff;
 }
 
-.select--stroke-white{
-  color:#fff;
-}
-.select--stroke-white + .select-arrow{
+.select--border-white + .select-arrow{
   border-top-color:#fff;
 }
-.select--stroke-white:hover{
-  color:rgba(255, 255, 255, 0.75);
-}
-.select--stroke-white:hover + .select-arrow{
+
+.select--border-white:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--stroke-transparent{
-  color:transparent;
-}
-.select--stroke-transparent + .select-arrow{
+.select--border-transparent + .select-arrow{
   border-top-color:transparent;
 }
-.select--stroke-transparent:hover{
-  color:rgba(0, 0, 0, 0.1);
-}
-.select--stroke-transparent:hover + .select-arrow{
+
+.select--border-transparent:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.1);
 }
 
 .textarea--border-gray,
-.input--border-gray{
+.input--border-gray,
+.select--border-gray{
   box-shadow:inset 0 0 0 1px #666;
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus{
+.input--border-gray:focus,
+.select--border-gray:focus{
   box-shadow:inset 0 0 0 1px #2d2d2d;
 }
 
 .textarea--border-pink,
-.input--border-pink{
+.input--border-pink,
+.select--border-pink{
   box-shadow:inset 0 0 0 1px #ff3c96;
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus{
+.input--border-pink:focus,
+.select--border-pink:focus{
   box-shadow:inset 0 0 0 1px #ab084b;
 }
 
 .textarea--border-red,
-.input--border-red{
+.input--border-red,
+.select--border-red{
   box-shadow:inset 0 0 0 1px #dc2b28;
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus{
+.input--border-red:focus,
+.select--border-red:focus{
   box-shadow:inset 0 0 0 1px #a30003;
 }
 
 .textarea--border-orange,
-.input--border-orange{
+.input--border-orange,
+.select--border-orange{
   box-shadow:inset 0 0 0 1px #ff6e00;
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus{
+.input--border-orange:focus,
+.select--border-orange:focus{
   box-shadow:inset 0 0 0 1px #bc3a00;
 }
 
 .textarea--border-yellow,
-.input--border-yellow{
+.input--border-yellow,
+.select--border-yellow{
   box-shadow:inset 0 0 0 1px #f0dc00;
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus{
+.input--border-yellow:focus,
+.select--border-yellow:focus{
   box-shadow:inset 0 0 0 1px #d9a100;
 }
 
 .textarea--border-green,
-.input--border-green{
+.input--border-green,
+.select--border-green{
   box-shadow:inset 0 0 0 1px #01aa46;
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus{
+.input--border-green:focus,
+.select--border-green:focus{
   box-shadow:inset 0 0 0 1px #006427;
 }
 
 .textarea--border-blue,
-.input--border-blue{
+.input--border-blue,
+.select--border-blue{
   box-shadow:inset 0 0 0 1px #448ee4;
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus{
+.input--border-blue:focus,
+.select--border-blue:focus{
   box-shadow:inset 0 0 0 1px #295b97;
 }
 
 .textarea--border-purple,
-.input--border-purple{
+.input--border-purple,
+.select--border-purple{
   box-shadow:inset 0 0 0 1px #8c50c7;
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus{
+.input--border-purple:focus,
+.select--border-purple:focus{
   box-shadow:inset 0 0 0 1px #440067;
 }
 
 .textarea--border-darken25,
-.input--border-darken25{
+.input--border-darken25,
+.select--border-darken25{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus{
+.input--border-darken25:focus,
+.select--border-darken25:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50,
-.input--border-darken50{
+.input--border-darken50,
+.select--border-darken50{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus{
+.input--border-darken50:focus,
+.select--border-darken50:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75,
-.input--border-darken75{
+.input--border-darken75,
+.select--border-darken75{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus{
+.input--border-darken75:focus,
+.select--border-darken75:focus{
   box-shadow:inset 0 0 0 1px #000;
 }
 
 .textarea--border-lighten25,
-.input--border-lighten25{
+.input--border-lighten25,
+.select--border-lighten25{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.25);
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus{
+.input--border-lighten25:focus,
+.select--border-lighten25:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50,
-.input--border-lighten50{
+.input--border-lighten50,
+.select--border-lighten50{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus{
+.input--border-lighten50:focus,
+.select--border-lighten50:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75,
-.input--border-lighten75{
+.input--border-lighten75,
+.select--border-lighten75{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus{
+.input--border-lighten75:focus,
+.select--border-lighten75:focus{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white,
-.input--border-white{
+.input--border-white,
+.select--border-white{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus{
+.input--border-white:focus,
+.select--border-white:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-transparent,
-.input--border-transparent{
+.input--border-transparent,
+.select--border-transparent{
   box-shadow:inset 0 0 0 1px transparent;
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus{
+.input--border-transparent:focus,
+.select--border-transparent:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
Proposal!

Selects are used like inputs more than buttons. Often they are used right *next to* inputs, and their buttony styling makes them stand out much more than is desirable. Also: I can't find any public usage of the button-style select: seems that we always use `select--stroke` and then adjust some more to make it look kind of like an input.

So: what if we just make selects look like inputs, instead of buttons? That's what this PR does. Selects get the same border styling as inputs — the coloring also translates to their arrows.

Here's what we end up with:

<img width="1128" alt="screen shot 2018-08-02 at 7 44 02 pm" src="https://user-images.githubusercontent.com/628431/43621545-01681050-968d-11e8-819a-6ac33f57714f.png">

<img width="508" alt="screen shot 2018-08-02 at 7 41 31 pm" src="https://user-images.githubusercontent.com/628431/43621549-076656e2-968d-11e8-9c7e-72e265cc0b06.png">

I know @jseppi wanted something like this (I just can't find the issue).

What do the rest of you think, @mapbox/frontend?

@samanpwbb for review, please.

(Still need to add a changelog entry, if people are in agreement.)