### PR TITLE
Use labs.mapbox.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A CSS framework that makes the hard parts of building anything on the web easy. We define the hard parts as: managing class specificity, designing cross-browser form components that work well with each other, creating a harmonious typographic scale, maintaining a baseline grid, and keeping responsive designs simple.
 
-For usage guidelines and documentation, check out https://www.mapbox.com/assembly/.
+For usage guidelines and documentation, check out https://labs.mapbox.com/assembly/.
 
 [![Build Status](https://travis-ci.com/mapbox/assembly.svg?token=FB2dZNVWaGo68KZnwz9M&branch=dev-pages)](https://travis-ci.com/mapbox/assembly)
 

--- a/src/icons.css
+++ b/src/icons.css
@@ -1,5 +1,5 @@
 /**
- * Assembly uses an SVG icon sprite. To load the sprite, you must must include [`assembly.js`](https://www.mapbox.com/assembly/assembly.js) on your page.
+ * Assembly uses an SVG icon sprite. To load the sprite, you must must include [`assembly.js`](https://labs.mapbox.com/assembly/) on your page.
  *
  * **Please read [the Icons page](/assembly/icons) to learn more about the available icons and how to use them.**
  *


### PR DESCRIPTION
This updates the existing links to the new `labs.mapbox.com/assembly`.

cc @davidtheclark