### PR TITLE
Add canonical link to www.mapbox.com/labs

### DIFF
--- a/.artifacts.yml
+++ b/.artifacts.yml
@@ -1,0 +1,3 @@
+version: v1
+defaults:
+  - publisher

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 _tmp_assembly
 _batfish*
+_site

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Assembly
 
-<img width='200px' src='https://rawgit.com/mapbox/assembly/dev-pages/assembly-logo.svg?v1'>
+<img width='200px' src='https://rawgit.com/mapbox/assembly/publisher-staging/assembly-logo.svg?v1'>
 
 A CSS framework that makes the hard parts of building anything on the web easy. We define the hard parts as: managing class specificity, designing cross-browser form components that work well with each other, creating a harmonious typographic scale, maintaining a baseline grid, and keeping responsive designs simple.
 
 For usage guidelines and documentation, check out https://labs.mapbox.com/assembly/.
 
-[![Build Status](https://travis-ci.com/mapbox/assembly.svg?token=FB2dZNVWaGo68KZnwz9M&branch=dev-pages)](https://travis-ci.com/mapbox/assembly)
+[![Build Status](https://travis-ci.com/mapbox/assembly.svg?token=FB2dZNVWaGo68KZnwz9M&branch=publisher-staging)](https://travis-ci.com/mapbox/assembly)
 
 ## Browser support
 
@@ -139,14 +139,14 @@ For other scripts, look in `package.json`.
 
 ### Releasing
 
-Development is done in the `dev-pages` branch, but releases are made from the `mb-pages` branch. Here's how you cut a release:
+Development is done in the `publisher-staging` branch, but releases are made from the `publisher-production` branch. Here's how you cut a release:
 
-- From `dev-pages`:
-  - Document changes in the [`CHANGELOG`](https://github.com/mapbox/assembly/blob/dev-pages/CHANGELOG.md).
+- From `publisher-staging`:
+  - Document changes in the [`CHANGELOG`](https://github.com/mapbox/assembly/blob/publisher-staging/CHANGELOG.md).
   - Increment the version key in `package.json` and `package-lock.json`.
   - Make sure all this is committed, typically with a commit message like `Prepare 0.8.0`.
-  - Merge these changes into the `mb-pages` branch. *Conduct the following steps from `mb-pages`*.
-- From `mb-pages`:
+  - Merge these changes into the `publisher-production` branch. *Conduct the following steps from `publisher-production`*.
+- From `publisher-production`:
   - Create a tag. No message is necessary, since the changelog includes explanations of changes. For example: `git tag -a 0.8.0 -m ""`.
   - Push the tag: `git push --tags`.
   - Publish the new version on npm.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A CSS framework that makes the hard parts of building anything on the web easy. We define the hard parts as: managing class specificity, designing cross-browser form components that work well with each other, creating a harmonious typographic scale, maintaining a baseline grid, and keeping responsive designs simple.
 
-For usage guidelines and documentation, check out https://www.mapbox.com/assembly/.
+For usage guidelines and documentation, check out https://labs.mapbox.com/assembly/.
 
 [![Build Status](https://travis-ci.com/mapbox/assembly.svg?token=FB2dZNVWaGo68KZnwz9M&branch=dev-pages)](https://travis-ci.com/mapbox/assembly)
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-source: _batfish_site

--- a/batfish.config.js
+++ b/batfish.config.js
@@ -8,6 +8,7 @@ module.exports = () => {
   return {
     siteBasePath: '/assembly/',
     siteOrigin: 'https://www.mapbox.com',
+    outputDirectory: path.join(__dirname, '_site'),
     stylesheets: [
       path.join(__dirname, './site/css/hljs.css'),
       path.join(__dirname, './dist/assembly.css')

--- a/site/page.js
+++ b/site/page.js
@@ -15,6 +15,7 @@ class Page extends React.Component {
       <div>
         <Helmet>
           <title>Assembly.css</title>
+          <link rel="canonical" href="https://labs.mapbox.com/assembly/" />
           <meta name="viewport" content="initial-scale=1.0 maximum-scale=1.0" />
           <link
             href={prefixUrl('favicon.ico')}

--- a/src/icons.css
+++ b/src/icons.css
@@ -1,5 +1,5 @@
 /**
- * Assembly uses an SVG icon sprite. To load the sprite, you must must include [`assembly.js`](https://www.mapbox.com/assembly/assembly.js) on your page.
+ * Assembly uses an SVG icon sprite. To load the sprite, you must must include [`assembly.js`](https://labs.mapbox.com/assembly/) on your page.
  *
  * **Please read [the Icons page](/assembly/icons) to learn more about the available icons and how to use them.**
  *


### PR DESCRIPTION
This would add a canonical link to the `mapbox.com/labs` assembly page. 

@davidtheclark for review, please.

Once this is approved and `labs.mapbox.com/assembly` is working fine, I would go ahead merge to `mb-pages` and deploy.