### PR TITLE
Fix a few details after switching domains

### DIFF
--- a/batfish.config.js
+++ b/batfish.config.js
@@ -7,7 +7,7 @@ const navigationStructure = require('./_tmp_assembly/navigation.json');
 module.exports = () => {
   return {
     siteBasePath: '/assembly/',
-    siteOrigin: 'https://www.mapbox.com',
+    siteOrigin: 'https://labs.mapbox.com',
     outputDirectory: path.join(__dirname, '_site'),
     stylesheets: [
       path.join(__dirname, './site/css/hljs.css'),

--- a/site/page.js
+++ b/site/page.js
@@ -2,7 +2,10 @@ import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Navigation } from './navigation';
-import { prefixUrl } from '@mapbox/batfish/modules/prefix-url';
+import {
+  prefixUrl,
+  prefixUrlAbsolute
+} from '@mapbox/batfish/modules/prefix-url';
 import 'highlight.js';
 
 class Page extends React.Component {
@@ -21,6 +24,7 @@ class Page extends React.Component {
             rel="icon"
             type="image/x-icon"
           />
+          <link rel="canonical" href={prefixUrlAbsolute(this.props.path)} />
         </Helmet>
         <div className="scroll-auto viewport-full-mm w180-mm fixed-mm top left flex-parent-mm flex-parent--stretch-cross-mm">
           <Navigation />
@@ -34,7 +38,9 @@ class Page extends React.Component {
 }
 
 Page.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  // Should start and end with a slash.
+  path: PropTypes.string.isRequired
 };
 
 export { Page };

--- a/site/pages/catalog.js
+++ b/site/pages/catalog.js
@@ -23,7 +23,7 @@ import { Flexbox } from '../catalog/flexbox';
 export default class Catalog extends React.Component {
   render() {
     return (
-      <Page>
+      <Page path="/catalog/">
         <div className="pt24">
           <h1 className="txt-h2 txt-bold mb18">Catalog</h1>
           <p className="col col--6-ml">

--- a/site/pages/documentation.js
+++ b/site/pages/documentation.js
@@ -36,6 +36,6 @@ export default class Documentation extends React.Component {
       addEntryAndMembers(entry, 1)
     );
 
-    return <Page>{entryEls}</Page>;
+    return <Page path="/documentation/">{entryEls}</Page>;
   }
 }

--- a/site/pages/examples/index.js
+++ b/site/pages/examples/index.js
@@ -17,7 +17,7 @@ export default class Examples extends React.Component {
 
   render() {
     return (
-      <Page>
+      <Page path="/examples/">
         <div className="py24">
           <h1 className="txt-h2 txt-bold mb18">Examples</h1>
           <p className="col col--6-ml">

--- a/site/pages/icons.js
+++ b/site/pages/icons.js
@@ -21,7 +21,7 @@ export default class Icons extends React.Component {
     });
 
     return (
-      <Page>
+      <Page path="/icons/">
         <h1 className="txt-h2 mb12 txt-bold pt24">Icons</h1>
         <div className="mb36 prose">
           <p>

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -24,7 +24,7 @@ Lowlight.registerLanguage('html', xmlLanguage);
 export default class Home extends React.Component {
   render() {
     return (
-      <Page>
+      <Page path="/">
         <div className="pt24">
           <div className="flex-parent-ml flex-parent--wrap-ml">
             <h1 className="flex-child-ml flex-child--grow-ml txt-h2 txt-bold">

--- a/site/pages/layout-scales.js
+++ b/site/pages/layout-scales.js
@@ -78,7 +78,7 @@ export default class LayoutScales extends React.Component {
     });
 
     return (
-      <Page>
+      <Page path="/layout-scales/">
         <div className="mb24">
           <h1 className="txt-h2 txt-bold pt24 mb18">Layout Scales</h1>
           <p className="col col--6-ml mb36">


### PR DESCRIPTION
Each page should have its own `<link rel="canonical>` that points to *its* URL, not the homepage of the site. This should fix that, and also get us to deploy those tags to the new staging & production.

@kepta for review, please. cc @danswick as an FYI.