### PR TITLE
Add alternative txt-strong rule

### DIFF
--- a/src/typography.css
+++ b/src/typography.css
@@ -132,7 +132,8 @@ textarea {
  * @example
  * <div class='txt-bold'>txt-bold</div>
  */
-.txt-bold {
+.txt-bold,
+.txt-strong {
   font-weight: bold !important;
 }
 

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -1003,7 +1003,8 @@ textarea{
   font-family:'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace;
   font-size:90%;
 }
-.txt-bold{
+.txt-bold,
+.txt-strong{
   font-weight:bold !important;
 }
 .txt-h1{
@@ -12995,7 +12996,8 @@ textarea{
   font-family:'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace;
   font-size:90%;
 }
-.txt-bold{
+.txt-bold,
+.txt-strong{
   font-weight:bold !important;
 }
 .txt-h1{


### PR DESCRIPTION
I am constantly forgetting that a bold style is not `txt-strong` but `txt-bold`. I think we should include this as It's cheap to support both and [aligns with the HTML tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong#:~:text=The%20HTML%20Strong%20Importance%20Element,the%20contents%20in%20bold%20type.) in the same way that `txt-em` does.