### PR TITLE
Add font-display:swap to @font-face declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `font-display:swap` to all @font-face declarations.
 - [breaking] Update browser compatibility targets, drop IE11 support.
 - [breaking] remove `txt-spacing4` class and add `txt-spacing05` class.
 - [breaking] renamed `scroll-*` classes to `overflow-*`.

--- a/src/fonts.css
+++ b/src/fonts.css
@@ -1,8 +1,9 @@
-/* No need for inline documentationL covered by typography section */
+/* No need for inline documentation: covered by typography section */
 
 @font-face {
   font-family: 'Open Sans';
   font-weight: 400;
+  font-display: swap;
   src: url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff') format('woff');
 }
@@ -10,6 +11,7 @@
 @font-face {
   font-family: 'Open Sans';
   font-weight: 300;
+  font-display: swap;
   src: url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-light.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-light.v1.woff') format('woff');
 }
@@ -17,6 +19,7 @@
 @font-face {
   font-family: 'Open Sans';
   font-style: italic;
+  font-display: swap;
   src: url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-italic.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-italic.v1.woff') format('woff');
 }
@@ -24,6 +27,7 @@
 @font-face {
   font-family: 'Open Sans';
   font-weight: bold;
+  font-display: swap;
   src: url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bold.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bold.v1.woff') format('woff');
 }
@@ -32,6 +36,7 @@
   font-family: 'Open Sans';
   font-weight: bold;
   font-style: italic;
+  font-display: swap;
   src: url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bolditalic.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bolditalic.v1.woff') format('woff');
 }

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -163,6 +163,7 @@ legend{
 @font-face{
   font-family:'Open Sans';
   font-weight:400;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff') format('woff');
 }
@@ -170,6 +171,7 @@ legend{
 @font-face{
   font-family:'Open Sans';
   font-weight:300;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-light.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-light.v1.woff') format('woff');
 }
@@ -177,6 +179,7 @@ legend{
 @font-face{
   font-family:'Open Sans';
   font-style:italic;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-italic.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-italic.v1.woff') format('woff');
 }
@@ -184,6 +187,7 @@ legend{
 @font-face{
   font-family:'Open Sans';
   font-weight:bold;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bold.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bold.v1.woff') format('woff');
 }
@@ -192,6 +196,7 @@ legend{
   font-family:'Open Sans';
   font-weight:bold;
   font-style:italic;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bolditalic.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bolditalic.v1.woff') format('woff');
 }
@@ -12038,6 +12043,7 @@ legend{
 @font-face{
   font-family:'Open Sans';
   font-weight:400;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff') format('woff');
 }
@@ -12045,6 +12051,7 @@ legend{
 @font-face{
   font-family:'Open Sans';
   font-weight:300;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-light.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-light.v1.woff') format('woff');
 }
@@ -12052,6 +12059,7 @@ legend{
 @font-face{
   font-family:'Open Sans';
   font-style:italic;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-italic.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-italic.v1.woff') format('woff');
 }
@@ -12059,6 +12067,7 @@ legend{
 @font-face{
   font-family:'Open Sans';
   font-weight:bold;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bold.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bold.v1.woff') format('woff');
 }
@@ -12067,6 +12076,7 @@ legend{
   font-family:'Open Sans';
   font-weight:bold;
   font-style:italic;
+  font-display:swap;
   src:url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bolditalic.v1.woff2') format('woff2'),
     url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-bolditalic.v1.woff') format('woff');
 }


### PR DESCRIPTION
Add font-display:swap to @font-face declarations. Here's a GIF showing the visual impact:

![2021-03-31 11-43-59 2021-03-31 11_45_23](https://user-images.githubusercontent.com/108094/113195174-ce1ee880-9216-11eb-8309-f6e0d3be3d6d.gif)

There's a little layout shifting but the upside is we get a quicker initial render.

@katydecorah for review

closes #969