### PR TITLE
964 shadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove grow, and add y offset to `shadow` classes.
 - Update browser compatibility targets, drop IE11 support.
 - [breaking] renamed `scroll-*` classes to `overflow-*`.
 - [add] `sticky` position rule.

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -428,7 +428,7 @@ function buildColorVariants(variables, config) {
         return result;
       return (result += stripIndent(`
         .shadow-${color} {
-          box-shadow: 0 0 10px 2px var(--${color}) !important;
+          box-shadow: 0 2px 10px 0 var(--${color}) !important;
         }
       `));
     }, '');
@@ -441,14 +441,14 @@ function buildColorVariants(variables, config) {
        * @group
        * @memberof Shadows
        * @example
-       * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+       * <div class='shadow-darken25-bold'>shadow-darken25-bold</div>
        */`);
     css += colors.reduce((result, color) => {
       if (!isSemitransparent(color) || isNotAccessibleExceptBg(color))
         return result;
       return (result += stripIndent(`
         .shadow-${color}-bold {
-          box-shadow: 0 0 30px 6px var(--${color}) !important;
+          box-shadow: 0 6px 30px 0 var(--${color}) !important;
         }
       `));
     }, '');
@@ -476,12 +476,12 @@ function buildColorVariants(variables, config) {
         .shadow-${color}-on-hover:hover,
         .shadow-${color}-on-active.is-active,
         .shadow-${color}-on-active.is-active:hover {
-          box-shadow: 0 0 10px 2px var(--${color}) !important;
+          box-shadow: 0 2px 10px 0 var(--${color}) !important;
         }
         .shadow-${color}-bold-on-hover:hover,
         .shadow-${color}-bold-on-active.is-active,
         .shadow-${color}-bold-on-active.is-active:hover {
-          box-shadow: 0 0 30px 6px var(--${color}) !important;
+          box-shadow: 0 6px 30px 0 var(--${color}) !important;
         }
       `));
     }, '');

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -2143,35 +2143,35 @@ input:checked + .switch--dot-transparent::after {
  * <div class='shadow-darken25'>shadow-darken25</div>
  */
 .shadow-darken10 {
-  box-shadow: 0 2px 10px 0px var(--darken10) !important;
+  box-shadow: 0 2px 10px 0 var(--darken10) !important;
 }
 
 .shadow-darken25 {
-  box-shadow: 0 2px 10px 0px var(--darken25) !important;
+  box-shadow: 0 2px 10px 0 var(--darken25) !important;
 }
 
 .shadow-darken50 {
-  box-shadow: 0 2px 10px 0px var(--darken50) !important;
+  box-shadow: 0 2px 10px 0 var(--darken50) !important;
 }
 
 .shadow-darken75 {
-  box-shadow: 0 2px 10px 0px var(--darken75) !important;
+  box-shadow: 0 2px 10px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10 {
-  box-shadow: 0 2px 10px 0px var(--lighten10) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25 {
-  box-shadow: 0 2px 10px 0px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50 {
-  box-shadow: 0 2px 10px 0px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75 {
-  box-shadow: 0 2px 10px 0px var(--lighten75) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -2185,35 +2185,35 @@ input:checked + .switch--dot-transparent::after {
  * <div class='shadow-darken25-bold'>shadow-darken25-bold</div>
  */
 .shadow-darken10-bold {
-  box-shadow: 0 6px 30px 0px var(--darken10) !important;
+  box-shadow: 0 6px 30px 0 var(--darken10) !important;
 }
 
 .shadow-darken25-bold {
-  box-shadow: 0 6px 30px 0px var(--darken25) !important;
+  box-shadow: 0 6px 30px 0 var(--darken25) !important;
 }
 
 .shadow-darken50-bold {
-  box-shadow: 0 6px 30px 0px var(--darken50) !important;
+  box-shadow: 0 6px 30px 0 var(--darken50) !important;
 }
 
 .shadow-darken75-bold {
-  box-shadow: 0 6px 30px 0px var(--darken75) !important;
+  box-shadow: 0 6px 30px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10-bold {
-  box-shadow: 0 6px 30px 0px var(--lighten10) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25-bold {
-  box-shadow: 0 6px 30px 0px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50-bold {
-  box-shadow: 0 6px 30px 0px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75-bold {
-  box-shadow: 0 6px 30px 0px var(--lighten75) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -2231,89 +2231,89 @@ input:checked + .switch--dot-transparent::after {
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
 .shadow-darken10-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0px var(--darken10) !important;
+  box-shadow: 0 2px 10px 0 var(--darken10) !important;
 }
 .shadow-darken10-bold-on-hover:hover,
 .shadow-darken10-bold-on-active.is-active,
 .shadow-darken10-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0px var(--darken10) !important;
+  box-shadow: 0 6px 30px 0 var(--darken10) !important;
 }
 
 .shadow-darken25-on-hover:hover,
 .shadow-darken25-on-active.is-active,
 .shadow-darken25-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0px var(--darken25) !important;
+  box-shadow: 0 2px 10px 0 var(--darken25) !important;
 }
 .shadow-darken25-bold-on-hover:hover,
 .shadow-darken25-bold-on-active.is-active,
 .shadow-darken25-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0px var(--darken25) !important;
+  box-shadow: 0 6px 30px 0 var(--darken25) !important;
 }
 
 .shadow-darken50-on-hover:hover,
 .shadow-darken50-on-active.is-active,
 .shadow-darken50-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0px var(--darken50) !important;
+  box-shadow: 0 2px 10px 0 var(--darken50) !important;
 }
 .shadow-darken50-bold-on-hover:hover,
 .shadow-darken50-bold-on-active.is-active,
 .shadow-darken50-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0px var(--darken50) !important;
+  box-shadow: 0 6px 30px 0 var(--darken50) !important;
 }
 
 .shadow-darken75-on-hover:hover,
 .shadow-darken75-on-active.is-active,
 .shadow-darken75-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0px var(--darken75) !important;
+  box-shadow: 0 2px 10px 0 var(--darken75) !important;
 }
 .shadow-darken75-bold-on-hover:hover,
 .shadow-darken75-bold-on-active.is-active,
 .shadow-darken75-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0px var(--darken75) !important;
+  box-shadow: 0 6px 30px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10-on-hover:hover,
 .shadow-lighten10-on-active.is-active,
 .shadow-lighten10-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0px var(--lighten10) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten10) !important;
 }
 .shadow-lighten10-bold-on-hover:hover,
 .shadow-lighten10-bold-on-active.is-active,
 .shadow-lighten10-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0px var(--lighten10) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25-on-hover:hover,
 .shadow-lighten25-on-active.is-active,
 .shadow-lighten25-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten25) !important;
 }
 .shadow-lighten25-bold-on-hover:hover,
 .shadow-lighten25-bold-on-active.is-active,
 .shadow-lighten25-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50-on-hover:hover,
 .shadow-lighten50-on-active.is-active,
 .shadow-lighten50-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten50) !important;
 }
 .shadow-lighten50-bold-on-hover:hover,
 .shadow-lighten50-bold-on-active.is-active,
 .shadow-lighten50-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75-on-hover:hover,
 .shadow-lighten75-on-active.is-active,
 .shadow-lighten75-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0px var(--lighten75) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 .shadow-lighten75-bold-on-hover:hover,
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0px var(--lighten75) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -2143,35 +2143,35 @@ input:checked + .switch--dot-transparent::after {
  * <div class='shadow-darken25'>shadow-darken25</div>
  */
 .shadow-darken10 {
-  box-shadow: 0 0 10px 2px var(--darken10) !important;
+  box-shadow: 0 2px 10px 0px var(--darken10) !important;
 }
 
 .shadow-darken25 {
-  box-shadow: 0 0 10px 2px var(--darken25) !important;
+  box-shadow: 0 2px 10px 0px var(--darken25) !important;
 }
 
 .shadow-darken50 {
-  box-shadow: 0 0 10px 2px var(--darken50) !important;
+  box-shadow: 0 2px 10px 0px var(--darken50) !important;
 }
 
 .shadow-darken75 {
-  box-shadow: 0 0 10px 2px var(--darken75) !important;
+  box-shadow: 0 2px 10px 0px var(--darken75) !important;
 }
 
 .shadow-lighten10 {
-  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+  box-shadow: 0 2px 10px 0px var(--lighten10) !important;
 }
 
 .shadow-lighten25 {
-  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0px var(--lighten25) !important;
 }
 
 .shadow-lighten50 {
-  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0px var(--lighten50) !important;
 }
 
 .shadow-lighten75 {
-  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+  box-shadow: 0 2px 10px 0px var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -2182,38 +2182,38 @@ input:checked + .switch--dot-transparent::after {
  * @group
  * @memberof Shadows
  * @example
- * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ * <div class='shadow-darken25-bold'>shadow-darken25-bold</div>
  */
 .shadow-darken10-bold {
-  box-shadow: 0 0 30px 6px var(--darken10) !important;
+  box-shadow: 0 6px 30px 0px var(--darken10) !important;
 }
 
 .shadow-darken25-bold {
-  box-shadow: 0 0 30px 6px var(--darken25) !important;
+  box-shadow: 0 6px 30px 0px var(--darken25) !important;
 }
 
 .shadow-darken50-bold {
-  box-shadow: 0 0 30px 6px var(--darken50) !important;
+  box-shadow: 0 6px 30px 0px var(--darken50) !important;
 }
 
 .shadow-darken75-bold {
-  box-shadow: 0 0 30px 6px var(--darken75) !important;
+  box-shadow: 0 6px 30px 0px var(--darken75) !important;
 }
 
 .shadow-lighten10-bold {
-  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+  box-shadow: 0 6px 30px 0px var(--lighten10) !important;
 }
 
 .shadow-lighten25-bold {
-  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0px var(--lighten25) !important;
 }
 
 .shadow-lighten50-bold {
-  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0px var(--lighten50) !important;
 }
 
 .shadow-lighten75-bold {
-  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+  box-shadow: 0 6px 30px 0px var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -2231,89 +2231,89 @@ input:checked + .switch--dot-transparent::after {
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
 .shadow-darken10-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken10) !important;
+  box-shadow: 0 2px 10px 0px var(--darken10) !important;
 }
 .shadow-darken10-bold-on-hover:hover,
 .shadow-darken10-bold-on-active.is-active,
 .shadow-darken10-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken10) !important;
+  box-shadow: 0 6px 30px 0px var(--darken10) !important;
 }
 
 .shadow-darken25-on-hover:hover,
 .shadow-darken25-on-active.is-active,
 .shadow-darken25-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken25) !important;
+  box-shadow: 0 2px 10px 0px var(--darken25) !important;
 }
 .shadow-darken25-bold-on-hover:hover,
 .shadow-darken25-bold-on-active.is-active,
 .shadow-darken25-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken25) !important;
+  box-shadow: 0 6px 30px 0px var(--darken25) !important;
 }
 
 .shadow-darken50-on-hover:hover,
 .shadow-darken50-on-active.is-active,
 .shadow-darken50-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken50) !important;
+  box-shadow: 0 2px 10px 0px var(--darken50) !important;
 }
 .shadow-darken50-bold-on-hover:hover,
 .shadow-darken50-bold-on-active.is-active,
 .shadow-darken50-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken50) !important;
+  box-shadow: 0 6px 30px 0px var(--darken50) !important;
 }
 
 .shadow-darken75-on-hover:hover,
 .shadow-darken75-on-active.is-active,
 .shadow-darken75-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken75) !important;
+  box-shadow: 0 2px 10px 0px var(--darken75) !important;
 }
 .shadow-darken75-bold-on-hover:hover,
 .shadow-darken75-bold-on-active.is-active,
 .shadow-darken75-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken75) !important;
+  box-shadow: 0 6px 30px 0px var(--darken75) !important;
 }
 
 .shadow-lighten10-on-hover:hover,
 .shadow-lighten10-on-active.is-active,
 .shadow-lighten10-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+  box-shadow: 0 2px 10px 0px var(--lighten10) !important;
 }
 .shadow-lighten10-bold-on-hover:hover,
 .shadow-lighten10-bold-on-active.is-active,
 .shadow-lighten10-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+  box-shadow: 0 6px 30px 0px var(--lighten10) !important;
 }
 
 .shadow-lighten25-on-hover:hover,
 .shadow-lighten25-on-active.is-active,
 .shadow-lighten25-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0px var(--lighten25) !important;
 }
 .shadow-lighten25-bold-on-hover:hover,
 .shadow-lighten25-bold-on-active.is-active,
 .shadow-lighten25-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0px var(--lighten25) !important;
 }
 
 .shadow-lighten50-on-hover:hover,
 .shadow-lighten50-on-active.is-active,
 .shadow-lighten50-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0px var(--lighten50) !important;
 }
 .shadow-lighten50-bold-on-hover:hover,
 .shadow-lighten50-bold-on-active.is-active,
 .shadow-lighten50-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0px var(--lighten50) !important;
 }
 
 .shadow-lighten75-on-hover:hover,
 .shadow-lighten75-on-active.is-active,
 .shadow-lighten75-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+  box-shadow: 0 2px 10px 0px var(--lighten75) !important;
 }
 .shadow-lighten75-bold-on-hover:hover,
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+  box-shadow: 0 6px 30px 0px var(--lighten75) !important;
 }
 
 /** @endgroup */

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -2146,35 +2146,35 @@ input:checked + .switch--dot-transparent::after {
  * <div class='shadow-darken25'>shadow-darken25</div>
  */
 .shadow-darken10 {
-  box-shadow: 0 0 10px 2px var(--darken10) !important;
+  box-shadow: 0 2px 10px 0 var(--darken10) !important;
 }
 
 .shadow-darken25 {
-  box-shadow: 0 0 10px 2px var(--darken25) !important;
+  box-shadow: 0 2px 10px 0 var(--darken25) !important;
 }
 
 .shadow-darken50 {
-  box-shadow: 0 0 10px 2px var(--darken50) !important;
+  box-shadow: 0 2px 10px 0 var(--darken50) !important;
 }
 
 .shadow-darken75 {
-  box-shadow: 0 0 10px 2px var(--darken75) !important;
+  box-shadow: 0 2px 10px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10 {
-  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25 {
-  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50 {
-  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75 {
-  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -2185,38 +2185,38 @@ input:checked + .switch--dot-transparent::after {
  * @group
  * @memberof Shadows
  * @example
- * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ * <div class='shadow-darken25-bold'>shadow-darken25-bold</div>
  */
 .shadow-darken10-bold {
-  box-shadow: 0 0 30px 6px var(--darken10) !important;
+  box-shadow: 0 6px 30px 0 var(--darken10) !important;
 }
 
 .shadow-darken25-bold {
-  box-shadow: 0 0 30px 6px var(--darken25) !important;
+  box-shadow: 0 6px 30px 0 var(--darken25) !important;
 }
 
 .shadow-darken50-bold {
-  box-shadow: 0 0 30px 6px var(--darken50) !important;
+  box-shadow: 0 6px 30px 0 var(--darken50) !important;
 }
 
 .shadow-darken75-bold {
-  box-shadow: 0 0 30px 6px var(--darken75) !important;
+  box-shadow: 0 6px 30px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10-bold {
-  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25-bold {
-  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50-bold {
-  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75-bold {
-  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -2234,89 +2234,89 @@ input:checked + .switch--dot-transparent::after {
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
 .shadow-darken10-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken10) !important;
+  box-shadow: 0 2px 10px 0 var(--darken10) !important;
 }
 .shadow-darken10-bold-on-hover:hover,
 .shadow-darken10-bold-on-active.is-active,
 .shadow-darken10-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken10) !important;
+  box-shadow: 0 6px 30px 0 var(--darken10) !important;
 }
 
 .shadow-darken25-on-hover:hover,
 .shadow-darken25-on-active.is-active,
 .shadow-darken25-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken25) !important;
+  box-shadow: 0 2px 10px 0 var(--darken25) !important;
 }
 .shadow-darken25-bold-on-hover:hover,
 .shadow-darken25-bold-on-active.is-active,
 .shadow-darken25-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken25) !important;
+  box-shadow: 0 6px 30px 0 var(--darken25) !important;
 }
 
 .shadow-darken50-on-hover:hover,
 .shadow-darken50-on-active.is-active,
 .shadow-darken50-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken50) !important;
+  box-shadow: 0 2px 10px 0 var(--darken50) !important;
 }
 .shadow-darken50-bold-on-hover:hover,
 .shadow-darken50-bold-on-active.is-active,
 .shadow-darken50-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken50) !important;
+  box-shadow: 0 6px 30px 0 var(--darken50) !important;
 }
 
 .shadow-darken75-on-hover:hover,
 .shadow-darken75-on-active.is-active,
 .shadow-darken75-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken75) !important;
+  box-shadow: 0 2px 10px 0 var(--darken75) !important;
 }
 .shadow-darken75-bold-on-hover:hover,
 .shadow-darken75-bold-on-active.is-active,
 .shadow-darken75-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken75) !important;
+  box-shadow: 0 6px 30px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10-on-hover:hover,
 .shadow-lighten10-on-active.is-active,
 .shadow-lighten10-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten10) !important;
 }
 .shadow-lighten10-bold-on-hover:hover,
 .shadow-lighten10-bold-on-active.is-active,
 .shadow-lighten10-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25-on-hover:hover,
 .shadow-lighten25-on-active.is-active,
 .shadow-lighten25-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten25) !important;
 }
 .shadow-lighten25-bold-on-hover:hover,
 .shadow-lighten25-bold-on-active.is-active,
 .shadow-lighten25-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50-on-hover:hover,
 .shadow-lighten50-on-active.is-active,
 .shadow-lighten50-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten50) !important;
 }
 .shadow-lighten50-bold-on-hover:hover,
 .shadow-lighten50-bold-on-active.is-active,
 .shadow-lighten50-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75-on-hover:hover,
 .shadow-lighten75-on-active.is-active,
 .shadow-lighten75-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 .shadow-lighten75-bold-on-hover:hover,
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -5291,35 +5291,35 @@ input:checked + .switch--dot-transparent::after {
  * <div class='shadow-darken25'>shadow-darken25</div>
  */
 .shadow-darken10 {
-  box-shadow: 0 0 10px 2px var(--darken10) !important;
+  box-shadow: 0 2px 10px 0 var(--darken10) !important;
 }
 
 .shadow-darken25 {
-  box-shadow: 0 0 10px 2px var(--darken25) !important;
+  box-shadow: 0 2px 10px 0 var(--darken25) !important;
 }
 
 .shadow-darken50 {
-  box-shadow: 0 0 10px 2px var(--darken50) !important;
+  box-shadow: 0 2px 10px 0 var(--darken50) !important;
 }
 
 .shadow-darken75 {
-  box-shadow: 0 0 10px 2px var(--darken75) !important;
+  box-shadow: 0 2px 10px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10 {
-  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25 {
-  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50 {
-  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75 {
-  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -5330,38 +5330,38 @@ input:checked + .switch--dot-transparent::after {
  * @group
  * @memberof Shadows
  * @example
- * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ * <div class='shadow-darken25-bold'>shadow-darken25-bold</div>
  */
 .shadow-darken10-bold {
-  box-shadow: 0 0 30px 6px var(--darken10) !important;
+  box-shadow: 0 6px 30px 0 var(--darken10) !important;
 }
 
 .shadow-darken25-bold {
-  box-shadow: 0 0 30px 6px var(--darken25) !important;
+  box-shadow: 0 6px 30px 0 var(--darken25) !important;
 }
 
 .shadow-darken50-bold {
-  box-shadow: 0 0 30px 6px var(--darken50) !important;
+  box-shadow: 0 6px 30px 0 var(--darken50) !important;
 }
 
 .shadow-darken75-bold {
-  box-shadow: 0 0 30px 6px var(--darken75) !important;
+  box-shadow: 0 6px 30px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10-bold {
-  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25-bold {
-  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50-bold {
-  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75-bold {
-  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -5379,89 +5379,89 @@ input:checked + .switch--dot-transparent::after {
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
 .shadow-darken10-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken10) !important;
+  box-shadow: 0 2px 10px 0 var(--darken10) !important;
 }
 .shadow-darken10-bold-on-hover:hover,
 .shadow-darken10-bold-on-active.is-active,
 .shadow-darken10-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken10) !important;
+  box-shadow: 0 6px 30px 0 var(--darken10) !important;
 }
 
 .shadow-darken25-on-hover:hover,
 .shadow-darken25-on-active.is-active,
 .shadow-darken25-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken25) !important;
+  box-shadow: 0 2px 10px 0 var(--darken25) !important;
 }
 .shadow-darken25-bold-on-hover:hover,
 .shadow-darken25-bold-on-active.is-active,
 .shadow-darken25-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken25) !important;
+  box-shadow: 0 6px 30px 0 var(--darken25) !important;
 }
 
 .shadow-darken50-on-hover:hover,
 .shadow-darken50-on-active.is-active,
 .shadow-darken50-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken50) !important;
+  box-shadow: 0 2px 10px 0 var(--darken50) !important;
 }
 .shadow-darken50-bold-on-hover:hover,
 .shadow-darken50-bold-on-active.is-active,
 .shadow-darken50-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken50) !important;
+  box-shadow: 0 6px 30px 0 var(--darken50) !important;
 }
 
 .shadow-darken75-on-hover:hover,
 .shadow-darken75-on-active.is-active,
 .shadow-darken75-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--darken75) !important;
+  box-shadow: 0 2px 10px 0 var(--darken75) !important;
 }
 .shadow-darken75-bold-on-hover:hover,
 .shadow-darken75-bold-on-active.is-active,
 .shadow-darken75-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--darken75) !important;
+  box-shadow: 0 6px 30px 0 var(--darken75) !important;
 }
 
 .shadow-lighten10-on-hover:hover,
 .shadow-lighten10-on-active.is-active,
 .shadow-lighten10-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten10) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten10) !important;
 }
 .shadow-lighten10-bold-on-hover:hover,
 .shadow-lighten10-bold-on-active.is-active,
 .shadow-lighten10-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten10) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten10) !important;
 }
 
 .shadow-lighten25-on-hover:hover,
 .shadow-lighten25-on-active.is-active,
 .shadow-lighten25-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten25) !important;
 }
 .shadow-lighten25-bold-on-hover:hover,
 .shadow-lighten25-bold-on-active.is-active,
 .shadow-lighten25-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten25) !important;
 }
 
 .shadow-lighten50-on-hover:hover,
 .shadow-lighten50-on-active.is-active,
 .shadow-lighten50-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten50) !important;
 }
 .shadow-lighten50-bold-on-hover:hover,
 .shadow-lighten50-bold-on-active.is-active,
 .shadow-lighten50-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten75-on-hover:hover,
 .shadow-lighten75-on-active.is-active,
 .shadow-lighten75-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten75) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 .shadow-lighten75-bold-on-hover:hover,
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten75) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten75) !important;
 }
 
 /** @endgroup */
@@ -6602,7 +6602,7 @@ input:checked + .switch--dot-teal::after {
  * @group
  * @memberof Shadows
  * @example
- * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ * <div class='shadow-darken25-bold'>shadow-darken25-bold</div>
  */
 /** @endgroup */
 
@@ -7027,11 +7027,11 @@ input:checked + .toggle--active-gray {
  * <div class='shadow-darken25'>shadow-darken25</div>
  */
 .shadow-lighten50 {
-  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten25 {
-  box-shadow: 0 0 10px 2px var(--lighten25) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten25) !important;
 }
 
 /** @endgroup */
@@ -7042,14 +7042,14 @@ input:checked + .toggle--active-gray {
  * @group
  * @memberof Shadows
  * @example
- * <div class='mt6 shadow-darken25-bold'>shadow-darken25-bold</div>
+ * <div class='shadow-darken25-bold'>shadow-darken25-bold</div>
  */
 .shadow-lighten50-bold {
-  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten50) !important;
 }
 
 .shadow-lighten25-bold {
-  box-shadow: 0 0 30px 6px var(--lighten25) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten25) !important;
 }
 
 /** @endgroup */
@@ -7067,12 +7067,12 @@ input:checked + .toggle--active-gray {
 .shadow-lighten50-on-hover:hover,
 .shadow-lighten50-on-active.is-active,
 .shadow-lighten50-on-active.is-active:hover {
-  box-shadow: 0 0 10px 2px var(--lighten50) !important;
+  box-shadow: 0 2px 10px 0 var(--lighten50) !important;
 }
 .shadow-lighten50-bold-on-hover:hover,
 .shadow-lighten50-bold-on-active.is-active,
 .shadow-lighten50-bold-on-active.is-active:hover {
-  box-shadow: 0 0 30px 6px var(--lighten50) !important;
+  box-shadow: 0 6px 30px 0 var(--lighten50) !important;
 }
 
 /** @endgroup */

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -10237,153 +10237,153 @@ input:checked + .switch--dot-transparent::after{
   border-color:transparent !important;
 }
 .shadow-darken10{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.1) !important;
 }
 
 .shadow-darken25{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.25) !important;
 }
 
 .shadow-darken50{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.5) !important;
 }
 
 .shadow-darken75{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.75) !important;
 }
 
 .shadow-lighten10{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.1) !important;
 }
 
 .shadow-lighten25{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.25) !important;
 }
 
 .shadow-lighten50{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.5) !important;
 }
 
 .shadow-lighten75{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.75) !important;
 }
 .shadow-darken10-bold{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.1) !important;
 }
 
 .shadow-darken25-bold{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.25) !important;
 }
 
 .shadow-darken50-bold{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.5) !important;
 }
 
 .shadow-darken75-bold{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.75) !important;
 }
 
 .shadow-lighten10-bold{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.1) !important;
 }
 
 .shadow-lighten25-bold{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.25) !important;
 }
 
 .shadow-lighten50-bold{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.5) !important;
 }
 
 .shadow-lighten75-bold{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
 }
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
 .shadow-darken10-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.1) !important;
 }
 .shadow-darken10-bold-on-hover:hover,
 .shadow-darken10-bold-on-active.is-active,
 .shadow-darken10-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.1) !important;
 }
 
 .shadow-darken25-on-hover:hover,
 .shadow-darken25-on-active.is-active,
 .shadow-darken25-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.25) !important;
 }
 .shadow-darken25-bold-on-hover:hover,
 .shadow-darken25-bold-on-active.is-active,
 .shadow-darken25-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.25) !important;
 }
 
 .shadow-darken50-on-hover:hover,
 .shadow-darken50-on-active.is-active,
 .shadow-darken50-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.5) !important;
 }
 .shadow-darken50-bold-on-hover:hover,
 .shadow-darken50-bold-on-active.is-active,
 .shadow-darken50-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.5) !important;
 }
 
 .shadow-darken75-on-hover:hover,
 .shadow-darken75-on-active.is-active,
 .shadow-darken75-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.75) !important;
 }
 .shadow-darken75-bold-on-hover:hover,
 .shadow-darken75-bold-on-active.is-active,
 .shadow-darken75-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.75) !important;
 }
 
 .shadow-lighten10-on-hover:hover,
 .shadow-lighten10-on-active.is-active,
 .shadow-lighten10-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.1) !important;
 }
 .shadow-lighten10-bold-on-hover:hover,
 .shadow-lighten10-bold-on-active.is-active,
 .shadow-lighten10-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.1) !important;
 }
 
 .shadow-lighten25-on-hover:hover,
 .shadow-lighten25-on-active.is-active,
 .shadow-lighten25-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.25) !important;
 }
 .shadow-lighten25-bold-on-hover:hover,
 .shadow-lighten25-bold-on-active.is-active,
 .shadow-lighten25-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.25) !important;
 }
 
 .shadow-lighten50-on-hover:hover,
 .shadow-lighten50-on-active.is-active,
 .shadow-lighten50-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.5) !important;
 }
 .shadow-lighten50-bold-on-hover:hover,
 .shadow-lighten50-bold-on-active.is-active,
 .shadow-lighten50-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.5) !important;
 }
 
 .shadow-lighten75-on-hover:hover,
 .shadow-lighten75-on-active.is-active,
 .shadow-lighten75-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.75) !important;
 }
 .shadow-lighten75-bold-on-hover:hover,
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
 }
 .bg-gray-dark-on-hover:hover,
 .bg-gray-dark-on-active.is-active,
@@ -22130,153 +22130,153 @@ input:checked + .switch--dot-transparent::after{
   border-color:transparent !important;
 }
 .shadow-darken10{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.1) !important;
 }
 
 .shadow-darken25{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.25) !important;
 }
 
 .shadow-darken50{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.5) !important;
 }
 
 .shadow-darken75{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.75) !important;
 }
 
 .shadow-lighten10{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.1) !important;
 }
 
 .shadow-lighten25{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.25) !important;
 }
 
 .shadow-lighten50{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.5) !important;
 }
 
 .shadow-lighten75{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.75) !important;
 }
 .shadow-darken10-bold{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.1) !important;
 }
 
 .shadow-darken25-bold{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.25) !important;
 }
 
 .shadow-darken50-bold{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.5) !important;
 }
 
 .shadow-darken75-bold{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.75) !important;
 }
 
 .shadow-lighten10-bold{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.1) !important;
 }
 
 .shadow-lighten25-bold{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.25) !important;
 }
 
 .shadow-lighten50-bold{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.5) !important;
 }
 
 .shadow-lighten75-bold{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
 }
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
 .shadow-darken10-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.1) !important;
 }
 .shadow-darken10-bold-on-hover:hover,
 .shadow-darken10-bold-on-active.is-active,
 .shadow-darken10-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.1) !important;
 }
 
 .shadow-darken25-on-hover:hover,
 .shadow-darken25-on-active.is-active,
 .shadow-darken25-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.25) !important;
 }
 .shadow-darken25-bold-on-hover:hover,
 .shadow-darken25-bold-on-active.is-active,
 .shadow-darken25-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.25) !important;
 }
 
 .shadow-darken50-on-hover:hover,
 .shadow-darken50-on-active.is-active,
 .shadow-darken50-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.5) !important;
 }
 .shadow-darken50-bold-on-hover:hover,
 .shadow-darken50-bold-on-active.is-active,
 .shadow-darken50-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.5) !important;
 }
 
 .shadow-darken75-on-hover:hover,
 .shadow-darken75-on-active.is-active,
 .shadow-darken75-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.75) !important;
 }
 .shadow-darken75-bold-on-hover:hover,
 .shadow-darken75-bold-on-active.is-active,
 .shadow-darken75-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.75) !important;
 }
 
 .shadow-lighten10-on-hover:hover,
 .shadow-lighten10-on-active.is-active,
 .shadow-lighten10-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.1) !important;
 }
 .shadow-lighten10-bold-on-hover:hover,
 .shadow-lighten10-bold-on-active.is-active,
 .shadow-lighten10-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.1) !important;
 }
 
 .shadow-lighten25-on-hover:hover,
 .shadow-lighten25-on-active.is-active,
 .shadow-lighten25-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.25) !important;
 }
 .shadow-lighten25-bold-on-hover:hover,
 .shadow-lighten25-bold-on-active.is-active,
 .shadow-lighten25-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.25) !important;
 }
 
 .shadow-lighten50-on-hover:hover,
 .shadow-lighten50-on-active.is-active,
 .shadow-lighten50-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.5) !important;
 }
 .shadow-lighten50-bold-on-hover:hover,
 .shadow-lighten50-bold-on-active.is-active,
 .shadow-lighten50-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.5) !important;
 }
 
 .shadow-lighten75-on-hover:hover,
 .shadow-lighten75-on-active.is-active,
 .shadow-lighten75-on-active.is-active:hover{
-  box-shadow:0 0 10px 2px rgba(255, 255, 255, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.75) !important;
 }
 .shadow-lighten75-bold-on-hover:hover,
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover{
-  box-shadow:0 0 30px 6px rgba(255, 255, 255, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
 }
 .bg-gray-dark-on-hover:hover,
 .bg-gray-dark-on-active.is-active,


### PR DESCRIPTION
This is a fairly subtle tweak to shadows. Remove shadow grow, adds shadow y offset.

`shadow-darken25-bold` before:
<img width="333" alt="Screen Shot 2021-03-31 at 1 41 42 PM" src="https://user-images.githubusercontent.com/108094/113208926-42fa1e80-9227-11eb-87aa-3aa70333cecc.png">

`shadow-darken25-bold` after:

<img width="320" alt="Screen Shot 2021-03-31 at 1 41 45 PM" src="https://user-images.githubusercontent.com/108094/113208925-42618800-9227-11eb-85dc-076e59582e08.png">

---

`shadow-darken10` before:
<img width="336" alt="Screen Shot 2021-03-31 at 1 41 09 PM" src="https://user-images.githubusercontent.com/108094/113209013-5c9b6600-9227-11eb-8703-da101ba86a89.png">

`shadow-darken10` after:
<img width="334" alt="Screen Shot 2021-03-31 at 1 41 12 PM" src="https://user-images.githubusercontent.com/108094/113209009-5c02cf80-9227-11eb-9e97-6dccf082eba8.png">

---

@tristen for review
