### PR TITLE
Rework typographic scale, closes #962

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- Rework typographic scale. Numbers are in the format _(font-size/line-height)_:
+
+  | Selector | Old value | New value |
+  | -------- | :-------: | --------: |
+  | .txt-h1  | 45px/54px | 36px/45px |
+  | .txt-h2  | 35px/42px | 30px/36px |
+  | .txt-h3  | 30px/36px | 24px/30px |
+  | .txt-h4  | 18px/24px | 20px/25px |
+  | .txt-h5  | 15px/18px | 16px/20px |
+  | .txt-xl  | 30px/45px | 30px/45px |
+  | .txt-l   | 18px/30px | 20px/30px |
+  | .txt-m   | 15px/24px | 16px/24px |
+  | .txt-ms  |    N/A    | 14px/21px |
+  | .txt-s   | 12px/18px | 12px/18px |
+  | .txt-xs  | 10px/15px | 10px/15px |
+
 - Add `font-display:swap` to all @font-face declarations.
 - Remove grow, and add y offset to `shadow` classes.
 - [breaking] Update browser compatibility targets, drop IE11 support.

--- a/scripts/build-media-variants.js
+++ b/scripts/build-media-variants.js
@@ -162,6 +162,7 @@ const targetClassArray = [
   'txt-xl',
   'txt-l',
   'txt-m',
+  'txt-ms',
   'txt-s',
   'txt-xs'
 ];

--- a/src/typography.css
+++ b/src/typography.css
@@ -157,28 +157,28 @@ textarea {
  * <div class='txt-h5'>Malesuada Pharetra Ridiculus</div>
  */
 .txt-h1 {
-  font-size: 45px;
-  line-height: 54px;
+  font-size: var(--font-size-h1);
+  line-height: var(--line-height-h1);
 }
 
 .txt-h2 {
-  font-size: 35px;
-  line-height: 42px;
+  font-size: var(--font-size-h2);
+  line-height: var(--line-height-h2);
 }
 
 .txt-h3 {
-  font-size: 30px;
-  line-height: 36px;
+  font-size: var(--font-size-h3);
+  line-height: var(--line-height-h3);
 }
 
 .txt-h4 {
-  font-size: 18px;
-  line-height: 24px;
+  font-size: var(--font-size-h4);
+  line-height: var(--line-height-h4);
 }
 
 .txt-h5 {
-  font-size: 15px;
-  line-height: 18px;
+  font-size: var(--font-size-h5);
+  line-height: var(--line-height-h5);
 }
 /** @endgroup */
 
@@ -192,6 +192,7 @@ textarea {
  * <div class='txt-xl'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</div>
  * <div class='txt-l'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</div>
  * <div class='txt-m'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</div>
+ * <div class='txt-ms'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</div>
  * <div class='txt-s'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</div>
  * <div class='txt-xs'>Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.</div>
  */
@@ -208,6 +209,11 @@ textarea {
 .txt-m {
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
+}
+
+.txt-ms {
+  font-size: var(--font-size-ms);
+  line-height: var(--line-height-ms);
 }
 
 .txt-s {
@@ -598,32 +604,32 @@ textarea {
 /* start prose-specific rules (no similar txt-) */
 .prose h1:not(.unprose) {
   font-weight: bold;
-  font-size: 45px;
-  line-height: 54px;
+  font-size: var(--font-size-h1);
+  line-height: var(--line-height-h1);
   margin-bottom: 12px;
   padding-top: 36px;
 }
 
 .prose h2:not(.unprose) {
   font-weight: bold;
-  font-size: 35px;
-  line-height: 42px;
+  font-size: var(--font-size-h2);
+  line-height: var(--line-height-h2);
   margin-bottom: 12px;
   padding-top: 24px;
 }
 
 .prose h3:not(.unprose) {
   font-weight: bold;
-  font-size: 30px;
-  line-height: 36px;
+  font-size: var(--font-size-h3);
+  line-height: var(--line-height-h3);
   margin-bottom: 12px;
   padding-top: 24px;
 }
 
 .prose h4:not(.unprose) {
   font-weight: bold;
-  font-size: 18px;
-  line-height: 24px;
+  font-size: var(--font-size-h4);
+  line-height: var(--line-height-h4);
   margin-bottom: 12px;
   padding-top: 18px;
 }
@@ -631,8 +637,8 @@ textarea {
 .prose h5:not(.unprose),
 .prose h6:not(.unprose) {
   font-weight: bold;
-  font-size: 15px;
-  line-height: 18px;
+  font-size: var(--font-size-h5);
+  line-height: var(--line-height-h5);
   margin-bottom: 12px;
   padding-top: 12px;
 }

--- a/src/variables.json
+++ b/src/variables.json
@@ -75,18 +75,33 @@
 
   "focus-shadow": "0 0 0 3px rgba(137, 199, 216, 0.65)",
 
+  "font-size-h1": "36px",
+  "font-size-h2": "30px",
+  "font-size-h3": "24px",
+  "font-size-h4": "20px",
+  "font-size-h5": "16px",
+
+  "line-height-h1": "45px",
+  "line-height-h2": "36px",
+  "line-height-h3": "30px",
+  "line-height-h4": "25px",
+  "line-height-h5": "20px",
+
   "font-size-xl": "30px",
-  "font-size-l": "18px",
-  "font-size-m": "15px",
+  "font-size-l": "20px",
+  "font-size-m": "16px",
+  "font-size-ms": "14px",
   "font-size-s": "12px",
   "font-size-xs": "10px",
 
   "line-height-xl": "45px",
   "line-height-l": "30px",
   "line-height-m": "24px",
+  "line-height-ms": "21px",
   "line-height-s": "18px",
   "line-height-xs": "15px",
 
   "font-stack-base": "'Open Sans', sans-serif",
-  "font-stack-mono": "'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace"
+  "font-stack-mono":
+    "'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace"
 }

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -502,7 +502,7 @@ legend{
   -webkit-appearance:none;
           appearance:none;
   background-color:transparent;
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
   color:currentColor;
   padding:6px 30px 6px 12px;
@@ -915,7 +915,7 @@ body,
 input,
 textarea{
   color:rgba(0, 0, 0, 0.75);
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
   font-family:'Open Sans', sans-serif;
   font-weight:normal;
@@ -987,28 +987,28 @@ textarea{
   font-weight:bold !important;
 }
 .txt-h1{
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
 }
 
 .txt-h2{
-  font-size:35px;
-  line-height:42px;
-}
-
-.txt-h3{
   font-size:30px;
   line-height:36px;
 }
 
+.txt-h3{
+  font-size:24px;
+  line-height:30px;
+}
+
 .txt-h4{
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
 }
 
 .txt-h5{
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
 }
 .txt-xl{
   font-size:30px;
@@ -1016,13 +1016,18 @@ textarea{
 }
 
 .txt-l{
-  font-size:18px;
+  font-size:20px;
   line-height:30px;
 }
 
 .txt-m{
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
+}
+
+.txt-ms{
+  font-size:14px;
+  line-height:21px;
 }
 
 .txt-s{
@@ -1154,21 +1159,13 @@ textarea{
 }
 .prose h1:not(.unprose){
   font-weight:bold;
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
   margin-bottom:12px;
   padding-top:36px;
 }
 
 .prose h2:not(.unprose){
-  font-weight:bold;
-  font-size:35px;
-  line-height:42px;
-  margin-bottom:12px;
-  padding-top:24px;
-}
-
-.prose h3:not(.unprose){
   font-weight:bold;
   font-size:30px;
   line-height:36px;
@@ -1176,10 +1173,18 @@ textarea{
   padding-top:24px;
 }
 
+.prose h3:not(.unprose){
+  font-weight:bold;
+  font-size:24px;
+  line-height:30px;
+  margin-bottom:12px;
+  padding-top:24px;
+}
+
 .prose h4:not(.unprose){
   font-weight:bold;
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
   margin-bottom:12px;
   padding-top:18px;
 }
@@ -1187,8 +1192,8 @@ textarea{
 .prose h5:not(.unprose),
 .prose h6:not(.unprose){
   font-weight:bold;
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
   margin-bottom:12px;
   padding-top:12px;
 }
@@ -11360,28 +11365,28 @@ input:checked + .switch--dot-transparent::after{
 .unround-br-mm{ border-bottom-right-radius:0 !important; }
 .unround-bl-mm{ border-bottom-left-radius:0 !important; }
 .txt-h1-mm{
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
 }
 
 .txt-h2-mm{
-  font-size:35px;
-  line-height:42px;
-}
-
-.txt-h3-mm{
   font-size:30px;
   line-height:36px;
 }
 
+.txt-h3-mm{
+  font-size:24px;
+  line-height:30px;
+}
+
 .txt-h4-mm{
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
 }
 
 .txt-h5-mm{
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
 }
 .txt-xl-mm{
   font-size:30px;
@@ -11389,13 +11394,18 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .txt-l-mm{
-  font-size:18px;
+  font-size:20px;
   line-height:30px;
 }
 
 .txt-m-mm{
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
+}
+
+.txt-ms-mm{
+  font-size:14px;
+  line-height:21px;
 }
 
 .txt-s-mm{
@@ -11595,28 +11605,28 @@ input:checked + .switch--dot-transparent::after{
 .unround-br-ml{ border-bottom-right-radius:0 !important; }
 .unround-bl-ml{ border-bottom-left-radius:0 !important; }
 .txt-h1-ml{
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
 }
 
 .txt-h2-ml{
-  font-size:35px;
-  line-height:42px;
-}
-
-.txt-h3-ml{
   font-size:30px;
   line-height:36px;
 }
 
+.txt-h3-ml{
+  font-size:24px;
+  line-height:30px;
+}
+
 .txt-h4-ml{
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
 }
 
 .txt-h5-ml{
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
 }
 .txt-xl-ml{
   font-size:30px;
@@ -11624,13 +11634,18 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .txt-l-ml{
-  font-size:18px;
+  font-size:20px;
   line-height:30px;
 }
 
 .txt-m-ml{
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
+}
+
+.txt-ms-ml{
+  font-size:14px;
+  line-height:21px;
 }
 
 .txt-s-ml{
@@ -11830,28 +11845,28 @@ input:checked + .switch--dot-transparent::after{
 .unround-br-mxl{ border-bottom-right-radius:0 !important; }
 .unround-bl-mxl{ border-bottom-left-radius:0 !important; }
 .txt-h1-mxl{
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
 }
 
 .txt-h2-mxl{
-  font-size:35px;
-  line-height:42px;
-}
-
-.txt-h3-mxl{
   font-size:30px;
   line-height:36px;
 }
 
+.txt-h3-mxl{
+  font-size:24px;
+  line-height:30px;
+}
+
 .txt-h4-mxl{
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
 }
 
 .txt-h5-mxl{
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
 }
 .txt-xl-mxl{
   font-size:30px;
@@ -11859,13 +11874,18 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .txt-l-mxl{
-  font-size:18px;
+  font-size:20px;
   line-height:30px;
 }
 
 .txt-m-mxl{
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
+}
+
+.txt-ms-mxl{
+  font-size:14px;
+  line-height:21px;
 }
 
 .txt-s-mxl{
@@ -12382,7 +12402,7 @@ legend{
   -webkit-appearance:none;
           appearance:none;
   background-color:transparent;
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
   color:currentColor;
   padding:6px 30px 6px 12px;
@@ -12795,7 +12815,7 @@ body,
 input,
 textarea{
   color:rgba(0, 0, 0, 0.75);
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
   font-family:'Open Sans', sans-serif;
   font-weight:normal;
@@ -12867,28 +12887,28 @@ textarea{
   font-weight:bold !important;
 }
 .txt-h1{
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
 }
 
 .txt-h2{
-  font-size:35px;
-  line-height:42px;
-}
-
-.txt-h3{
   font-size:30px;
   line-height:36px;
 }
 
+.txt-h3{
+  font-size:24px;
+  line-height:30px;
+}
+
 .txt-h4{
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
 }
 
 .txt-h5{
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
 }
 .txt-xl{
   font-size:30px;
@@ -12896,13 +12916,18 @@ textarea{
 }
 
 .txt-l{
-  font-size:18px;
+  font-size:20px;
   line-height:30px;
 }
 
 .txt-m{
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
+}
+
+.txt-ms{
+  font-size:14px;
+  line-height:21px;
 }
 
 .txt-s{
@@ -13034,21 +13059,13 @@ textarea{
 }
 .prose h1:not(.unprose){
   font-weight:bold;
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
   margin-bottom:12px;
   padding-top:36px;
 }
 
 .prose h2:not(.unprose){
-  font-weight:bold;
-  font-size:35px;
-  line-height:42px;
-  margin-bottom:12px;
-  padding-top:24px;
-}
-
-.prose h3:not(.unprose){
   font-weight:bold;
   font-size:30px;
   line-height:36px;
@@ -13056,10 +13073,18 @@ textarea{
   padding-top:24px;
 }
 
+.prose h3:not(.unprose){
+  font-weight:bold;
+  font-size:24px;
+  line-height:30px;
+  margin-bottom:12px;
+  padding-top:24px;
+}
+
 .prose h4:not(.unprose){
   font-weight:bold;
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
   margin-bottom:12px;
   padding-top:18px;
 }
@@ -13067,8 +13092,8 @@ textarea{
 .prose h5:not(.unprose),
 .prose h6:not(.unprose){
   font-weight:bold;
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
   margin-bottom:12px;
   padding-top:12px;
 }
@@ -23258,28 +23283,28 @@ input:checked + .switch--dot-transparent::after{
 .unround-br-mm{ border-bottom-right-radius:0 !important; }
 .unround-bl-mm{ border-bottom-left-radius:0 !important; }
 .txt-h1-mm{
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
 }
 
 .txt-h2-mm{
-  font-size:35px;
-  line-height:42px;
-}
-
-.txt-h3-mm{
   font-size:30px;
   line-height:36px;
 }
 
+.txt-h3-mm{
+  font-size:24px;
+  line-height:30px;
+}
+
 .txt-h4-mm{
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
 }
 
 .txt-h5-mm{
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
 }
 .txt-xl-mm{
   font-size:30px;
@@ -23287,13 +23312,18 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .txt-l-mm{
-  font-size:18px;
+  font-size:20px;
   line-height:30px;
 }
 
 .txt-m-mm{
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
+}
+
+.txt-ms-mm{
+  font-size:14px;
+  line-height:21px;
 }
 
 .txt-s-mm{
@@ -23493,28 +23523,28 @@ input:checked + .switch--dot-transparent::after{
 .unround-br-ml{ border-bottom-right-radius:0 !important; }
 .unround-bl-ml{ border-bottom-left-radius:0 !important; }
 .txt-h1-ml{
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
 }
 
 .txt-h2-ml{
-  font-size:35px;
-  line-height:42px;
-}
-
-.txt-h3-ml{
   font-size:30px;
   line-height:36px;
 }
 
+.txt-h3-ml{
+  font-size:24px;
+  line-height:30px;
+}
+
 .txt-h4-ml{
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
 }
 
 .txt-h5-ml{
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
 }
 .txt-xl-ml{
   font-size:30px;
@@ -23522,13 +23552,18 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .txt-l-ml{
-  font-size:18px;
+  font-size:20px;
   line-height:30px;
 }
 
 .txt-m-ml{
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
+}
+
+.txt-ms-ml{
+  font-size:14px;
+  line-height:21px;
 }
 
 .txt-s-ml{
@@ -23728,28 +23763,28 @@ input:checked + .switch--dot-transparent::after{
 .unround-br-mxl{ border-bottom-right-radius:0 !important; }
 .unround-bl-mxl{ border-bottom-left-radius:0 !important; }
 .txt-h1-mxl{
-  font-size:45px;
-  line-height:54px;
+  font-size:36px;
+  line-height:45px;
 }
 
 .txt-h2-mxl{
-  font-size:35px;
-  line-height:42px;
-}
-
-.txt-h3-mxl{
   font-size:30px;
   line-height:36px;
 }
 
+.txt-h3-mxl{
+  font-size:24px;
+  line-height:30px;
+}
+
 .txt-h4-mxl{
-  font-size:18px;
-  line-height:24px;
+  font-size:20px;
+  line-height:25px;
 }
 
 .txt-h5-mxl{
-  font-size:15px;
-  line-height:18px;
+  font-size:16px;
+  line-height:20px;
 }
 .txt-xl-mxl{
   font-size:30px;
@@ -23757,13 +23792,18 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .txt-l-mxl{
-  font-size:18px;
+  font-size:20px;
   line-height:30px;
 }
 
 .txt-m-mxl{
-  font-size:15px;
+  font-size:16px;
   line-height:24px;
+}
+
+.txt-ms-mxl{
+  font-size:14px;
+  line-height:21px;
 }
 
 .txt-s-mxl{

--- a/test/__snapshots__/build-media-variants.jest.js.snap
+++ b/test/__snapshots__/build-media-variants.jest.js.snap
@@ -187,28 +187,28 @@ exports[`buildMediaVariants defaults 1`] = `
 .unround-br-mm { border-bottom-right-radius: 0 !important; }
 .unround-bl-mm { border-bottom-left-radius: 0 !important; }
 .txt-h1-mm {
-  font-size: 45px;
-  line-height: 54px;
+  font-size: var(--font-size-h1);
+  line-height: var(--line-height-h1);
 }
 
 .txt-h2-mm {
-  font-size: 35px;
-  line-height: 42px;
+  font-size: var(--font-size-h2);
+  line-height: var(--line-height-h2);
 }
 
 .txt-h3-mm {
-  font-size: 30px;
-  line-height: 36px;
+  font-size: var(--font-size-h3);
+  line-height: var(--line-height-h3);
 }
 
 .txt-h4-mm {
-  font-size: 18px;
-  line-height: 24px;
+  font-size: var(--font-size-h4);
+  line-height: var(--line-height-h4);
 }
 
 .txt-h5-mm {
-  font-size: 15px;
-  line-height: 18px;
+  font-size: var(--font-size-h5);
+  line-height: var(--line-height-h5);
 }
 .txt-xl-mm {
   font-size: var(--font-size-xl);
@@ -223,6 +223,11 @@ exports[`buildMediaVariants defaults 1`] = `
 .txt-m-mm {
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
+}
+
+.txt-ms-mm {
+  font-size: var(--font-size-ms);
+  line-height: var(--line-height-ms);
 }
 
 .txt-s-mm {
@@ -422,28 +427,28 @@ exports[`buildMediaVariants defaults 1`] = `
 .unround-br-ml { border-bottom-right-radius: 0 !important; }
 .unround-bl-ml { border-bottom-left-radius: 0 !important; }
 .txt-h1-ml {
-  font-size: 45px;
-  line-height: 54px;
+  font-size: var(--font-size-h1);
+  line-height: var(--line-height-h1);
 }
 
 .txt-h2-ml {
-  font-size: 35px;
-  line-height: 42px;
+  font-size: var(--font-size-h2);
+  line-height: var(--line-height-h2);
 }
 
 .txt-h3-ml {
-  font-size: 30px;
-  line-height: 36px;
+  font-size: var(--font-size-h3);
+  line-height: var(--line-height-h3);
 }
 
 .txt-h4-ml {
-  font-size: 18px;
-  line-height: 24px;
+  font-size: var(--font-size-h4);
+  line-height: var(--line-height-h4);
 }
 
 .txt-h5-ml {
-  font-size: 15px;
-  line-height: 18px;
+  font-size: var(--font-size-h5);
+  line-height: var(--line-height-h5);
 }
 .txt-xl-ml {
   font-size: var(--font-size-xl);
@@ -458,6 +463,11 @@ exports[`buildMediaVariants defaults 1`] = `
 .txt-m-ml {
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
+}
+
+.txt-ms-ml {
+  font-size: var(--font-size-ms);
+  line-height: var(--line-height-ms);
 }
 
 .txt-s-ml {
@@ -657,28 +667,28 @@ exports[`buildMediaVariants defaults 1`] = `
 .unround-br-mxl { border-bottom-right-radius: 0 !important; }
 .unround-bl-mxl { border-bottom-left-radius: 0 !important; }
 .txt-h1-mxl {
-  font-size: 45px;
-  line-height: 54px;
+  font-size: var(--font-size-h1);
+  line-height: var(--line-height-h1);
 }
 
 .txt-h2-mxl {
-  font-size: 35px;
-  line-height: 42px;
+  font-size: var(--font-size-h2);
+  line-height: var(--line-height-h2);
 }
 
 .txt-h3-mxl {
-  font-size: 30px;
-  line-height: 36px;
+  font-size: var(--font-size-h3);
+  line-height: var(--line-height-h3);
 }
 
 .txt-h4-mxl {
-  font-size: 18px;
-  line-height: 24px;
+  font-size: var(--font-size-h4);
+  line-height: var(--line-height-h4);
 }
 
 .txt-h5-mxl {
-  font-size: 15px;
-  line-height: 18px;
+  font-size: var(--font-size-h5);
+  line-height: var(--line-height-h5);
 }
 .txt-xl-mxl {
   font-size: var(--font-size-xl);
@@ -693,6 +703,11 @@ exports[`buildMediaVariants defaults 1`] = `
 .txt-m-mxl {
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
+}
+
+.txt-ms-mxl {
+  font-size: var(--font-size-ms);
+  line-height: var(--line-height-ms);
 }
 
 .txt-s-mxl {


### PR DESCRIPTION
Rework of our typographic system based on feedback from Documentation and Studio teams.

  | Selector | Old value | New value |
  | -------- | :-------: | --------: |
  | .txt-h1  | 45px/54px | 36px/45px |
  | .txt-h2  | 35px/42px | 30px/36px |
  | .txt-h3  | 30px/36px | 24px/30px |
  | .txt-h4  | 18px/24px | 20px/25px |
  | .txt-h5  | 15px/18px | 16px/20px |
  | .txt-xl  | 30px/45px | 30px/45px |
  | .txt-l   | 18px/30px | 20px/30px |
  | .txt-m   | 15px/24px | 16px/24px |
  | .txt-ms  |    N/A    | 14px/21px |
  | .txt-s   | 12px/18px | 12px/18px |
  | .txt-xs  | 10px/15px | 10px/15px |

Before:
<img width="853" alt="Screen Shot 2021-04-01 at 10 44 31 AM" src="https://user-images.githubusercontent.com/108094/113336705-a5145b80-92db-11eb-8694-b91dfdaecf9f.png">
<img width="818" alt="Screen Shot 2021-04-01 at 10 44 08 AM" src="https://user-images.githubusercontent.com/108094/113336721-a9d90f80-92db-11eb-979e-d489de71da1e.png">

After:
<img width="856" alt="Screen Shot 2021-04-01 at 10 44 23 AM" src="https://user-images.githubusercontent.com/108094/113336710-a6de1f00-92db-11eb-95e0-a0ba396f9a82.png">

<img width="822" alt="Screen Shot 2021-04-01 at 10 43 56 AM" src="https://user-images.githubusercontent.com/108094/113336722-aa71a600-92db-11eb-8482-1133da3b8a57.png">
