### PR TITLE
Add select--stroke modifier and change to default borderless select

### DIFF
--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -190,6 +190,14 @@ function buildColorVariants(variables, config) {
       if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return (result += stripIndent(`
+        .select--${color} {
+          color: var(--${color});
+        }
+
+        .select--${color}:focus {
+          color: var(--${darkerShade});
+        }
+
         .select--${color} + .select-arrow {
           border-top-color: var(--${color});
         }

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -229,7 +229,7 @@ function buildColorVariants(variables, config) {
           box-shadow: inset 0 0 0 1px var(--${darkerShade});
         }
 
-        .select--stroke.select--${color}:focus {
+        [data-assembly-focus-control='visible'] .select--stroke.select--${color}:focus {
           box-shadow: inset 0 0 0 1px var(--${darkerShade}), var(--focus-shadow);
         }
       `));

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -221,9 +221,12 @@ function buildColorVariants(variables, config) {
         }
 
         .textarea--border-${color}:focus,
-        .input--border-${color}:focus,
-        .select--stroke.select--${color}:focus {
+        .input--border-${color}:focus {
           box-shadow: inset 0 0 0 1px var(--${darkerShade});
+        }
+
+        .select--stroke.select--${color}:focus {
+          box-shadow: inset 0 0 0 1px var(--${darkerShade}), var(--focus-shadow);
         }
       `));
     }, '');

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -190,11 +190,11 @@ function buildColorVariants(variables, config) {
       if (isNotAccessibleForForms(color)) return result;
       const darkerShade = getDarkerShade(color);
       return (result += stripIndent(`
-        .select--border-${color} + .select-arrow {
+        .select--${color} + .select-arrow {
           border-top-color: var(--${color});
         }
 
-        .select--border-${color}:focus + .select-arrow {
+        .select--${color}:focus + .select-arrow {
           border-top-color: var(--${darkerShade});
         }
       `));
@@ -208,13 +208,13 @@ function buildColorVariants(variables, config) {
       return (result += stripIndent(`
         .textarea--border-${color},
         .input--border-${color},
-        .select--border-${color} {
+        .select--stroke.select--${color} {
           box-shadow: inset 0 0 0 1px var(--${color});
         }
 
         .textarea--border-${color}:focus,
         .input--border-${color}:focus,
-        .select--border-${color}:focus {
+        .select--stroke.select--${color}:focus {
           box-shadow: inset 0 0 0 1px var(--${darkerShade});
         }
       `));

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -198,6 +198,10 @@ function buildColorVariants(variables, config) {
           color: var(--${darkerShade});
         }
 
+        .select--${color}:hover {
+          color: var(--${darkerShade});
+        }
+
         .select--${color} + .select-arrow {
           border-top-color: var(--${color});
         }

--- a/site/catalog/selects.js
+++ b/site/catalog/selects.js
@@ -26,9 +26,11 @@ export class Selects extends React.Component {
 
         {colors.map(color => {
           let selectClass = 'select';
+          let selectClassStroke = 'select select--stroke';
           const selectContainerClass = 'select-container';
           if (color !== null) {
-            selectClass += ` select--border-${color}`;
+            selectClass += ` select--${color}`;
+            selectClassStroke += ` select--${color}`;
           }
           return (
             <div key={color} className="mb12">
@@ -55,6 +57,36 @@ export class Selects extends React.Component {
               <div className="inline-block mr12">
                 <div className={selectContainerClass}>
                   <select className={`${selectClass} select--s`}>
+                    <option>firstoption</option>
+                    <option>two</option>
+                    <option>three</option>
+                  </select>
+                  <div className="select-arrow" />
+                </div>
+              </div>
+              <div className="inline-block mr12">
+                <div className={selectContainerClass}>
+                  <select className={selectClassStroke}>
+                    <option>firstoption</option>
+                    <option disabled={true}>two</option>
+                    <option>three</option>
+                  </select>
+                  <div className="select-arrow" />
+                </div>
+              </div>
+              <div className="inline-block mr12">
+                <div className={selectContainerClass}>
+                  <select className={selectClassStroke} disabled={true}>
+                    <option>firstoption</option>
+                    <option>two</option>
+                    <option>three</option>
+                  </select>
+                  <div className="select-arrow" />
+                </div>
+              </div>
+              <div className="inline-block mr12">
+                <div className={selectContainerClass}>
+                  <select className={`${selectClassStroke} select--s`}>
                     <option>firstoption</option>
                     <option>two</option>
                     <option>three</option>

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -395,6 +395,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--gray-dark);
 }
 
+.select--gray:hover {
+  color: var(--gray-dark);
+}
+
 .select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
@@ -408,6 +412,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus {
+  color: var(--pink-dark);
+}
+
+.select--pink:hover {
   color: var(--pink-dark);
 }
 
@@ -427,6 +435,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--red-dark);
 }
 
+.select--red:hover {
+  color: var(--red-dark);
+}
+
 .select--red + .select-arrow {
   border-top-color: var(--red);
 }
@@ -440,6 +452,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus {
+  color: var(--orange-dark);
+}
+
+.select--orange:hover {
   color: var(--orange-dark);
 }
 
@@ -459,6 +475,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--yellow-dark);
 }
 
+.select--yellow:hover {
+  color: var(--yellow-dark);
+}
+
 .select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
@@ -472,6 +492,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus {
+  color: var(--green-dark);
+}
+
+.select--green:hover {
   color: var(--green-dark);
 }
 
@@ -491,6 +515,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--blue-dark);
 }
 
+.select--blue:hover {
+  color: var(--blue-dark);
+}
+
 .select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
@@ -504,6 +532,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus {
+  color: var(--purple-dark);
+}
+
+.select--purple:hover {
   color: var(--purple-dark);
 }
 
@@ -523,6 +555,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--darken50);
 }
 
+.select--darken25:hover {
+  color: var(--darken50);
+}
+
 .select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
@@ -536,6 +572,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--darken50:focus {
+  color: var(--darken75);
+}
+
+.select--darken50:hover {
   color: var(--darken75);
 }
 
@@ -555,6 +595,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--black);
 }
 
+.select--darken75:hover {
+  color: var(--black);
+}
+
 .select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
@@ -568,6 +612,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--lighten25:focus {
+  color: var(--lighten50);
+}
+
+.select--lighten25:hover {
   color: var(--lighten50);
 }
 
@@ -587,6 +635,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--lighten75);
 }
 
+.select--lighten50:hover {
+  color: var(--lighten75);
+}
+
 .select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
@@ -600,6 +652,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--lighten75:focus {
+  color: var(--white);
+}
+
+.select--lighten75:hover {
   color: var(--white);
 }
 
@@ -619,6 +675,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--lighten75);
 }
 
+.select--white:hover {
+  color: var(--lighten75);
+}
+
 .select--white + .select-arrow {
   border-top-color: var(--white);
 }
@@ -632,6 +692,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--transparent:focus {
+  color: var(--darken10);
+}
+
+.select--transparent:hover {
   color: var(--darken10);
 }
 

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -387,323 +387,323 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--border-gray + .select-arrow {
+.select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
 
-.select--border-gray:focus + .select-arrow {
+.select--gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
 }
 
-.select--border-pink + .select-arrow {
+.select--pink + .select-arrow {
   border-top-color: var(--pink);
 }
 
-.select--border-pink:focus + .select-arrow {
+.select--pink:focus + .select-arrow {
   border-top-color: var(--pink-dark);
 }
 
-.select--border-red + .select-arrow {
+.select--red + .select-arrow {
   border-top-color: var(--red);
 }
 
-.select--border-red:focus + .select-arrow {
+.select--red:focus + .select-arrow {
   border-top-color: var(--red-dark);
 }
 
-.select--border-orange + .select-arrow {
+.select--orange + .select-arrow {
   border-top-color: var(--orange);
 }
 
-.select--border-orange:focus + .select-arrow {
+.select--orange:focus + .select-arrow {
   border-top-color: var(--orange-dark);
 }
 
-.select--border-yellow + .select-arrow {
+.select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
 
-.select--border-yellow:focus + .select-arrow {
+.select--yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
 }
 
-.select--border-green + .select-arrow {
+.select--green + .select-arrow {
   border-top-color: var(--green);
 }
 
-.select--border-green:focus + .select-arrow {
+.select--green:focus + .select-arrow {
   border-top-color: var(--green-dark);
 }
 
-.select--border-blue + .select-arrow {
+.select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
 
-.select--border-blue:focus + .select-arrow {
+.select--blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
 }
 
-.select--border-purple + .select-arrow {
+.select--purple + .select-arrow {
   border-top-color: var(--purple);
 }
 
-.select--border-purple:focus + .select-arrow {
+.select--purple:focus + .select-arrow {
   border-top-color: var(--purple-dark);
 }
 
-.select--border-darken25 + .select-arrow {
+.select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
 
-.select--border-darken25:focus + .select-arrow {
+.select--darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--border-darken50 + .select-arrow {
+.select--darken50 + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--border-darken50:focus + .select-arrow {
+.select--darken50:focus + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--border-darken75 + .select-arrow {
+.select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--border-darken75:focus + .select-arrow {
+.select--darken75:focus + .select-arrow {
   border-top-color: var(--black);
 }
 
-.select--border-lighten25 + .select-arrow {
+.select--lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
 
-.select--border-lighten25:focus + .select-arrow {
+.select--lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--border-lighten50 + .select-arrow {
+.select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--border-lighten50:focus + .select-arrow {
+.select--lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-lighten75 + .select-arrow {
+.select--lighten75 + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-lighten75:focus + .select-arrow {
+.select--lighten75:focus + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--border-white + .select-arrow {
+.select--white + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--border-white:focus + .select-arrow {
+.select--white:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-transparent + .select-arrow {
+.select--transparent + .select-arrow {
   border-top-color: var(--transparent);
 }
 
-.select--border-transparent:focus + .select-arrow {
+.select--transparent:focus + .select-arrow {
   border-top-color: var(--darken10);
 }
 
 .textarea--border-gray,
 .input--border-gray,
-.select--border-gray {
+.select--stroke.select--gray {
   box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus,
-.select--border-gray:focus {
+.select--gray:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
 .input--border-pink,
-.select--border-pink {
+.select--stroke.select--pink {
   box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus,
-.select--border-pink:focus {
+.select--pink:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
 .input--border-red,
-.select--border-red {
+.select--stroke.select--red {
   box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus,
-.select--border-red:focus {
+.select--red:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
 .input--border-orange,
-.select--border-orange {
+.select--stroke.select--orange {
   box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus,
-.select--border-orange:focus {
+.select--orange:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
 .input--border-yellow,
-.select--border-yellow {
+.select--stroke.select--yellow {
   box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus,
-.select--border-yellow:focus {
+.select--yellow:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
 .input--border-green,
-.select--border-green {
+.select--stroke.select--green {
   box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus,
-.select--border-green:focus {
+.select--green:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
 .input--border-blue,
-.select--border-blue {
+.select--stroke.select--blue {
   box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus,
-.select--border-blue:focus {
+.select--blue:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
 .input--border-purple,
-.select--border-purple {
+.select--stroke.select--purple {
   box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus,
-.select--border-purple:focus {
+.select--purple:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
 .input--border-darken25,
-.select--border-darken25 {
+.select--stroke.select--darken25 {
   box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus,
-.select--border-darken25:focus {
+.select--darken25:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
 .input--border-darken50,
-.select--border-darken50 {
+.select--stroke.select--darken50 {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus,
-.select--border-darken50:focus {
+.select--darken50:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75,
-.select--border-darken75 {
+.select--stroke.select--darken75 {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus,
-.select--border-darken75:focus {
+.select--darken75:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25,
-.select--border-lighten25 {
+.select--stroke.select--lighten25 {
   box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus,
-.select--border-lighten25:focus {
+.select--lighten25:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50,
-.select--border-lighten50 {
+.select--stroke.select--lighten50 {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus,
-.select--border-lighten50:focus {
+.select--lighten50:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75,
-.select--border-lighten75 {
+.select--stroke.select--lighten75 {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus,
-.select--border-lighten75:focus {
+.select--lighten75:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
 .input--border-white,
-.select--border-white {
+.select--stroke.select--white {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus,
-.select--border-white:focus {
+.select--white:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent,
-.select--border-transparent {
+.select--stroke.select--transparent {
   box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus,
-.select--border-transparent:focus {
+.select--transparent:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -387,12 +387,28 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
+.select--gray {
+  color: var(--gray);
+}
+
+.select--gray:focus {
+  color: var(--gray-dark);
+}
+
 .select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
 
 .select--gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
+}
+
+.select--pink {
+  color: var(--pink);
+}
+
+.select--pink:focus {
+  color: var(--pink-dark);
 }
 
 .select--pink + .select-arrow {
@@ -403,12 +419,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--pink-dark);
 }
 
+.select--red {
+  color: var(--red);
+}
+
+.select--red:focus {
+  color: var(--red-dark);
+}
+
 .select--red + .select-arrow {
   border-top-color: var(--red);
 }
 
 .select--red:focus + .select-arrow {
   border-top-color: var(--red-dark);
+}
+
+.select--orange {
+  color: var(--orange);
+}
+
+.select--orange:focus {
+  color: var(--orange-dark);
 }
 
 .select--orange + .select-arrow {
@@ -419,12 +451,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--orange-dark);
 }
 
+.select--yellow {
+  color: var(--yellow);
+}
+
+.select--yellow:focus {
+  color: var(--yellow-dark);
+}
+
 .select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
 
 .select--yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
+}
+
+.select--green {
+  color: var(--green);
+}
+
+.select--green:focus {
+  color: var(--green-dark);
 }
 
 .select--green + .select-arrow {
@@ -435,12 +483,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--green-dark);
 }
 
+.select--blue {
+  color: var(--blue);
+}
+
+.select--blue:focus {
+  color: var(--blue-dark);
+}
+
 .select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
 
 .select--blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
+}
+
+.select--purple {
+  color: var(--purple);
+}
+
+.select--purple:focus {
+  color: var(--purple-dark);
 }
 
 .select--purple + .select-arrow {
@@ -451,12 +515,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--purple-dark);
 }
 
+.select--darken25 {
+  color: var(--darken25);
+}
+
+.select--darken25:focus {
+  color: var(--darken50);
+}
+
 .select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
 
 .select--darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
+}
+
+.select--darken50 {
+  color: var(--darken50);
+}
+
+.select--darken50:focus {
+  color: var(--darken75);
 }
 
 .select--darken50 + .select-arrow {
@@ -467,12 +547,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--darken75);
 }
 
+.select--darken75 {
+  color: var(--darken75);
+}
+
+.select--darken75:focus {
+  color: var(--black);
+}
+
 .select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
 
 .select--darken75:focus + .select-arrow {
   border-top-color: var(--black);
+}
+
+.select--lighten25 {
+  color: var(--lighten25);
+}
+
+.select--lighten25:focus {
+  color: var(--lighten50);
 }
 
 .select--lighten25 + .select-arrow {
@@ -483,12 +579,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--lighten50);
 }
 
+.select--lighten50 {
+  color: var(--lighten50);
+}
+
+.select--lighten50:focus {
+  color: var(--lighten75);
+}
+
 .select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
 .select--lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
+}
+
+.select--lighten75 {
+  color: var(--lighten75);
+}
+
+.select--lighten75:focus {
+  color: var(--white);
 }
 
 .select--lighten75 + .select-arrow {
@@ -499,12 +611,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--white);
 }
 
+.select--white {
+  color: var(--white);
+}
+
+.select--white:focus {
+  color: var(--lighten75);
+}
+
 .select--white + .select-arrow {
   border-top-color: var(--white);
 }
 
 .select--white:focus + .select-arrow {
   border-top-color: var(--lighten75);
+}
+
+.select--transparent {
+  color: var(--transparent);
+}
+
+.select--transparent:focus {
+  color: var(--darken10);
 }
 
 .select--transparent + .select-arrow {
@@ -523,7 +651,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-gray:focus,
 .input--border-gray:focus,
-.select--gray:focus .select--stroke {
+.select--stroke.select--gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
@@ -535,7 +663,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-pink:focus,
 .input--border-pink:focus,
-.select--pink:focus .select--stroke {
+.select--stroke.select--pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
@@ -547,7 +675,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-red:focus,
 .input--border-red:focus,
-.select--red:focus .select--stroke {
+.select--stroke.select--red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
@@ -559,7 +687,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-orange:focus,
 .input--border-orange:focus,
-.select--orange:focus .select--stroke {
+.select--stroke.select--orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
@@ -571,7 +699,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus,
-.select--yellow:focus .select--stroke {
+.select--stroke.select--yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
@@ -583,7 +711,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-green:focus,
 .input--border-green:focus,
-.select--green:focus .select--stroke {
+.select--stroke.select--green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
@@ -595,7 +723,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-blue:focus,
 .input--border-blue:focus,
-.select--blue:focus .select--stroke {
+.select--stroke.select--blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
@@ -607,7 +735,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-purple:focus,
 .input--border-purple:focus,
-.select--purple:focus .select--stroke {
+.select--stroke.select--purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
@@ -619,7 +747,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus,
-.select--darken25:focus .select--stroke {
+.select--stroke.select--darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
@@ -631,7 +759,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus,
-.select--darken50:focus .select--stroke {
+.select--stroke.select--darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
@@ -643,7 +771,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus,
-.select--darken75:focus .select--stroke {
+.select--stroke.select--darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
@@ -655,7 +783,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus,
-.select--lighten25:focus .select--stroke {
+.select--stroke.select--lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
@@ -667,7 +795,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus,
-.select--lighten50:focus .select--stroke {
+.select--stroke.select--lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
@@ -679,7 +807,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus,
-.select--lighten75:focus .select--stroke {
+.select--stroke.select--lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
@@ -691,7 +819,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-white:focus,
 .input--border-white:focus,
-.select--white:focus .select--stroke {
+.select--stroke.select--white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
@@ -703,7 +831,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus,
-.select--transparent:focus .select--stroke {
+.select--stroke.select--transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -718,7 +718,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
-.select--stroke.select--gray:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
 }
 
@@ -733,7 +733,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
-.select--stroke.select--pink:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
 }
 
@@ -748,7 +748,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
-.select--stroke.select--red:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
 }
 
@@ -763,7 +763,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
-.select--stroke.select--orange:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
 }
 
@@ -778,7 +778,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
-.select--stroke.select--yellow:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
 }
 
@@ -793,7 +793,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
-.select--stroke.select--green:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
 }
 
@@ -808,7 +808,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
-.select--stroke.select--blue:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
 }
 
@@ -823,7 +823,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
-.select--stroke.select--purple:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
 }
 
@@ -838,7 +838,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
-.select--stroke.select--darken25:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50), var(--focus-shadow);
 }
 
@@ -853,7 +853,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
-.select--stroke.select--darken50:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75), var(--focus-shadow);
 }
 
@@ -868,7 +868,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
-.select--stroke.select--darken75:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black), var(--focus-shadow);
 }
 
@@ -883,7 +883,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
-.select--stroke.select--lighten25:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50), var(--focus-shadow);
 }
 
@@ -898,7 +898,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
-.select--stroke.select--lighten50:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
@@ -913,7 +913,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
-.select--stroke.select--lighten75:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white), var(--focus-shadow);
 }
 
@@ -928,7 +928,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
-.select--stroke.select--white:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
@@ -943,7 +943,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
-.select--stroke.select--transparent:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10), var(--focus-shadow);
 }
 

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -650,9 +650,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus,
-.select--stroke.select--gray:focus {
+.input--border-gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
+}
+
+.select--stroke.select--gray:focus {
+  box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
 }
 
 .textarea--border-pink,
@@ -662,9 +665,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus,
-.select--stroke.select--pink:focus {
+.input--border-pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
+}
+
+.select--stroke.select--pink:focus {
+  box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
 }
 
 .textarea--border-red,
@@ -674,9 +680,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus,
-.select--stroke.select--red:focus {
+.input--border-red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
+}
+
+.select--stroke.select--red:focus {
+  box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
 }
 
 .textarea--border-orange,
@@ -686,9 +695,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus,
-.select--stroke.select--orange:focus {
+.input--border-orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
+}
+
+.select--stroke.select--orange:focus {
+  box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
 }
 
 .textarea--border-yellow,
@@ -698,9 +710,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus,
-.select--stroke.select--yellow:focus {
+.input--border-yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
+}
+
+.select--stroke.select--yellow:focus {
+  box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
 }
 
 .textarea--border-green,
@@ -710,9 +725,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus,
-.select--stroke.select--green:focus {
+.input--border-green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
+}
+
+.select--stroke.select--green:focus {
+  box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
 }
 
 .textarea--border-blue,
@@ -722,9 +740,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus,
-.select--stroke.select--blue:focus {
+.input--border-blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
+}
+
+.select--stroke.select--blue:focus {
+  box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
 }
 
 .textarea--border-purple,
@@ -734,9 +755,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus,
-.select--stroke.select--purple:focus {
+.input--border-purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
+}
+
+.select--stroke.select--purple:focus {
+  box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
 }
 
 .textarea--border-darken25,
@@ -746,9 +770,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus,
-.select--stroke.select--darken25:focus {
+.input--border-darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
+}
+
+.select--stroke.select--darken25:focus {
+  box-shadow: inset 0 0 0 1px var(--darken50), var(--focus-shadow);
 }
 
 .textarea--border-darken50,
@@ -758,9 +785,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus,
-.select--stroke.select--darken50:focus {
+.input--border-darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
+}
+
+.select--stroke.select--darken50:focus {
+  box-shadow: inset 0 0 0 1px var(--darken75), var(--focus-shadow);
 }
 
 .textarea--border-darken75,
@@ -770,9 +800,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus,
-.select--stroke.select--darken75:focus {
+.input--border-darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
+}
+
+.select--stroke.select--darken75:focus {
+  box-shadow: inset 0 0 0 1px var(--black), var(--focus-shadow);
 }
 
 .textarea--border-lighten25,
@@ -782,9 +815,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus,
-.select--stroke.select--lighten25:focus {
+.input--border-lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
+}
+
+.select--stroke.select--lighten25:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten50), var(--focus-shadow);
 }
 
 .textarea--border-lighten50,
@@ -794,9 +830,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus,
-.select--stroke.select--lighten50:focus {
+.input--border-lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
+}
+
+.select--stroke.select--lighten50:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
 .textarea--border-lighten75,
@@ -806,9 +845,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus,
-.select--stroke.select--lighten75:focus {
+.input--border-lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
+}
+
+.select--stroke.select--lighten75:focus {
+  box-shadow: inset 0 0 0 1px var(--white), var(--focus-shadow);
 }
 
 .textarea--border-white,
@@ -818,9 +860,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus,
-.select--stroke.select--white:focus {
+.input--border-white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
+}
+
+.select--stroke.select--white:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
 .textarea--border-transparent,
@@ -830,9 +875,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus,
-.select--stroke.select--transparent:focus {
+.input--border-transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
+}
+
+.select--stroke.select--transparent:focus {
+  box-shadow: inset 0 0 0 1px var(--darken10), var(--focus-shadow);
 }
 
 .checkbox--gray {

--- a/src/forms.css
+++ b/src/forms.css
@@ -192,7 +192,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
   color: currentColor;
-  padding: 6px 30px 6px 12px; /* plus arrow */
+  padding: 6px 30px 6px 12px; /* plus arrow */ 
   cursor: pointer;
 }
 
@@ -267,6 +267,30 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 .select--s + .select-arrow {
   right: 8px;
+}
+
+/**
+ * Make a select component borderless.
+ *
+ * @memberof Selects
+ * @example
+ * <div class='select-container'>
+ *   <select class='select select--border-0'>
+ *     <option>one</option>
+ *     <option>two</option>
+ *   </select>
+ *   <div class='select-arrow'></div>
+ * </div>
+ * <div class='select-container'>
+ *   <select class='select select--border-0'>
+ *     <option>one</option>
+ *     <option>two</option>
+ *   </select>
+ *   <div class='select-arrow'></div>
+ * </div>
+ */
+.select--border-0 {
+  box-shadow: none !important;
 }
 
 /**

--- a/src/forms.css
+++ b/src/forms.css
@@ -320,7 +320,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  *   <div class='select-arrow'></div>
  * </div>
  */
- .select:disabled {
+.select:disabled {
   pointer-events: none;
   color: var(--inactive-text-color);
 }

--- a/src/forms.css
+++ b/src/forms.css
@@ -192,7 +192,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
   color: currentColor;
-  padding: 6px 30px 6px 12px; /* plus arrow */ 
+  padding: 6px 30px 6px 12px; /* plus arrow */
   cursor: pointer;
 }
 
@@ -281,16 +281,10 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  *   </select>
  *   <div class='select-arrow'></div>
  * </div>
- * <div class='select-container'>
- *   <select class='select select--border-0'>
- *     <option>one</option>
- *     <option>two</option>
- *   </select>
- *   <div class='select-arrow'></div>
- * </div>
  */
 .select--border-0 {
   box-shadow: none !important;
+  padding: 6px 30px 6px 0;
 }
 
 /**

--- a/src/forms.css
+++ b/src/forms.css
@@ -41,14 +41,13 @@
 }
 
 .input:focus,
-.textarea:focus,
-.select.select--stroke:focus {
+.textarea:focus {
   box-shadow: inset 0 0 0 1px var(--default-form-color);
 }
 
-.select:focus {
+/* .select:focus {
   box-shadow: none;
-}
+} */
 
 .input::placeholder,
 .textarea::placeholder {

--- a/src/forms.css
+++ b/src/forms.css
@@ -216,6 +216,10 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /** @endgroup */
 
+.select:hover {
+  color: var(--default-form-color-dark);
+}
+
 .select:focus + .select-arrow {
   border-top-color: var(--default-form-color);
 }
@@ -297,6 +301,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 .select--stroke {
   padding: 6px 30px 6px 12px; /* plus arrow */
   box-shadow: inset 0 0 0 1px var(--default-form-color-light);
+  color: var(--default-form-color) !important;
 }
 
 .select--stroke .select--s {

--- a/src/forms.css
+++ b/src/forms.css
@@ -45,7 +45,7 @@
   box-shadow: inset 0 0 0 1px var(--default-form-color);
 }
 
-.select.select--stroke:focus {
+[data-assembly-focus-control='visible'] .select.select--stroke:focus {
   box-shadow: inset 0 0 0 1px var(--default-form-color), var(--focus-shadow);
 }
 

--- a/src/forms.css
+++ b/src/forms.css
@@ -42,7 +42,7 @@
 
 .input:focus,
 .textarea:focus,
-.select:focus {
+.select:focus .select--stroke {
   box-shadow: inset 0 0 0 1px var(--default-form-color);
 }
 
@@ -126,11 +126,11 @@
  */
 .input:disabled,
 .textarea:disabled,
-.select:disabled {
+.select--stroke:disabled {
   pointer-events: none;
   color: var(--darken50);
   background-color: var(--disabled-interactive-color);
-  box-shadow: inset 0 0 0 1px var(--disabled-interactive-color-dark);
+  box-shadow: inset 0 0 0 1px var(--disabled-interactive-color-dark) !important;
 }
 
 /* Using the attribute selector instead of the pseudo-class `:read-only`
@@ -160,7 +160,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /*
  * Style a select component.
- * Set the border (and arrow) color by adding a `select--border-{color}` modifier to the `select` element (`*-dark` colors are not available).
+ * Set the arrow color by adding a `select--{color}` modifier to the `select` element (`*-dark` colors are not available).
  *
  * @memberof Selects
  * @group
@@ -172,9 +172,9 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  *   </select>
  *   <div class='select-arrow'></div>
  * </div>
- * <div class='select-container mt6'>
- *   <select class='select select--border-green'>
- *     <option>green</option>
+ * <div class='select-container'>
+ *   <select class='select select--green'>
+ *     <option>default</option>
  *     <option>two</option>
  *   </select>
  *   <div class='select-arrow'></div>
@@ -192,8 +192,9 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
   color: currentColor;
-  padding: 6px 30px 6px 12px; /* plus arrow */
+  padding: 6px 30px 6px 0; /* plus arrow */
   cursor: pointer;
+  box-shadow: none;
 }
 
 .select-arrow {
@@ -212,7 +213,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /** @endgroup */
 
-.select:focus + .select-arrow {
+.select .select--stroke:focus + .select-arrow {
   border-top-color: var(--default-form-color);
 }
 
@@ -262,7 +263,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 .select--s {
   font-size: var(--font-size-s);
   line-height: var(--line-height-s);
-  padding: 3px 24px 3px 6px; /* plus arrow */
+  padding: 3px 24px 3px 0; /* plus arrow */
 }
 
 .select--s + .select-arrow {
@@ -270,21 +271,33 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 }
 
 /**
- * Make a select component borderless.
+ * Modify a select component so that it has a border.
+ * Set the border (and arrow) color by adding a `select--{color}` modifier to the `select` element along with the `select--stroke` modifier (`*-dark` colors are not available).
  *
  * @memberof Selects
  * @example
  * <div class='select-container'>
- *   <select class='select select--border-0'>
+ *   <select class='select select--stroke'>
  *     <option>one</option>
  *     <option>two</option>
  *   </select>
  *   <div class='select-arrow'></div>
  * </div>
+ * <div class='select-container mt6'>
+ *   <select class='select select--stroke select--green'>
+ *     <option>green</option>
+ *     <option>two</option>
+ *   </select>
+ *   <div class='select-arrow'></div>
+ * </div>
  */
-.select--border-0 {
-  box-shadow: none !important;
-  padding: 6px 30px 6px 0;
+.select--stroke {
+  padding: 6px 30px 6px 12px; /* plus arrow */
+  box-shadow: inset 0 0 0 1px var(--default-form-color-light);
+}
+
+.select--stroke .select--s {
+  padding: 3px 24px 3px 6px; /* plus arrow */
 }
 
 /**
@@ -299,12 +312,17 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  *   </select>
  *   <div class='select-arrow'></div>
  * </div>
+  * <div class='select-container'>
+ *   <select disabled class='select select--stroke'>
+ *     <option>one</option>
+ *     <option>two</option>
+ *   </select>
+ *   <div class='select-arrow'></div>
+ * </div>
  */
-.select:disabled {
+ .select:disabled {
   pointer-events: none;
-  color: var(--darken25);
-  background-color: var(--disabled-interactive-color-dark);
-  border-color: var(--transparent);
+  color: var(--inactive-text-color);
 }
 
 .select:disabled + .select-arrow {

--- a/src/forms.css
+++ b/src/forms.css
@@ -45,9 +45,9 @@
   box-shadow: inset 0 0 0 1px var(--default-form-color);
 }
 
-/* .select:focus {
-  box-shadow: none;
-} */
+.select.select--stroke:focus {
+  box-shadow: inset 0 0 0 1px var(--default-form-color), var(--focus-shadow);
+}
 
 .input::placeholder,
 .textarea::placeholder {

--- a/src/forms.css
+++ b/src/forms.css
@@ -42,8 +42,12 @@
 
 .input:focus,
 .textarea:focus,
-.select:focus .select--stroke {
+.select.select--stroke:focus {
   box-shadow: inset 0 0 0 1px var(--default-form-color);
+}
+
+.select:focus {
+ box-shadow: none;
 }
 
 .input::placeholder,
@@ -204,7 +208,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   pointer-events: none;
   border-left: 4px solid var(--transparent);
   border-right: 4px solid var(--transparent);
-  border-top: 5px solid var(--default-form-color-light);
+  border-top: 5px solid var(--default-form-color);
   width: 8px;
   height: 8px;
   margin-top: -1px;
@@ -213,7 +217,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /** @endgroup */
 
-.select .select--stroke:focus + .select-arrow {
+.select:focus + .select-arrow {
   border-top-color: var(--default-form-color);
 }
 

--- a/src/forms.css
+++ b/src/forms.css
@@ -280,7 +280,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 /**
  * Modify a select component so that it has a border.
  * Set the border and arrow color by adding a `select--{color}` modifier to the `select` element along with the `select--stroke` modifier (`*-dark` colors are not available).
- * Note that the `select--stroke` modifier changes how the color modifier is interpreted. 
+ * Note that the `select--stroke` modifier changes how the color modifier is interpreted.
  *
  * @memberof Selects
  * @example

--- a/src/forms.css
+++ b/src/forms.css
@@ -163,7 +163,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /*
  * Style a select component.
- * Set the arrow color by adding a `select--{color}` modifier to the `select` element (`*-dark` colors are not available).
+ * Set the text and arrow color by adding a `select--{color}` modifier to the `select` element (`*-dark` colors are not available).
  *
  * @memberof Selects
  * @group
@@ -279,7 +279,8 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 
 /**
  * Modify a select component so that it has a border.
- * Set the border (and arrow) color by adding a `select--{color}` modifier to the `select` element along with the `select--stroke` modifier (`*-dark` colors are not available).
+ * Set the border and arrow color by adding a `select--{color}` modifier to the `select` element along with the `select--stroke` modifier (`*-dark` colors are not available).
+ * Note that the `select--stroke` modifier changes how the color modifier is interpreted. 
  *
  * @memberof Selects
  * @example

--- a/src/forms.css
+++ b/src/forms.css
@@ -47,7 +47,7 @@
 }
 
 .select:focus {
- box-shadow: none;
+  box-shadow: none;
 }
 
 .input::placeholder,

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -721,7 +721,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
-.select--stroke.select--gray:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
 }
 
@@ -736,7 +736,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
-.select--stroke.select--pink:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
 }
 
@@ -751,7 +751,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
-.select--stroke.select--red:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
 }
 
@@ -766,7 +766,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
-.select--stroke.select--orange:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
 }
 
@@ -781,7 +781,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
-.select--stroke.select--yellow:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
 }
 
@@ -796,7 +796,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
-.select--stroke.select--green:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
 }
 
@@ -811,7 +811,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
-.select--stroke.select--blue:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
 }
 
@@ -826,7 +826,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
-.select--stroke.select--purple:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
 }
 
@@ -841,7 +841,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
-.select--stroke.select--darken25:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50), var(--focus-shadow);
 }
 
@@ -856,7 +856,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
-.select--stroke.select--darken50:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75), var(--focus-shadow);
 }
 
@@ -871,7 +871,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
-.select--stroke.select--darken75:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black), var(--focus-shadow);
 }
 
@@ -886,7 +886,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
-.select--stroke.select--lighten25:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50), var(--focus-shadow);
 }
 
@@ -901,7 +901,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
-.select--stroke.select--lighten50:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
@@ -916,7 +916,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
-.select--stroke.select--lighten75:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white), var(--focus-shadow);
 }
 
@@ -931,7 +931,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
-.select--stroke.select--white:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
@@ -946,7 +946,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
-.select--stroke.select--transparent:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10), var(--focus-shadow);
 }
 
@@ -4106,7 +4106,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
-.select--stroke.select--gray:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
 }
 
@@ -4121,7 +4121,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
-.select--stroke.select--pink:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
 }
 
@@ -4136,7 +4136,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
-.select--stroke.select--red:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
 }
 
@@ -4151,7 +4151,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
-.select--stroke.select--orange:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
 }
 
@@ -4166,7 +4166,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
-.select--stroke.select--yellow:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
 }
 
@@ -4181,7 +4181,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
-.select--stroke.select--green:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
 }
 
@@ -4196,7 +4196,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
-.select--stroke.select--blue:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
 }
 
@@ -4211,7 +4211,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
-.select--stroke.select--purple:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
 }
 
@@ -4226,7 +4226,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
-.select--stroke.select--darken25:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50), var(--focus-shadow);
 }
 
@@ -4241,7 +4241,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
-.select--stroke.select--darken50:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75), var(--focus-shadow);
 }
 
@@ -4256,7 +4256,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
-.select--stroke.select--darken75:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black), var(--focus-shadow);
 }
 
@@ -4271,7 +4271,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
-.select--stroke.select--lighten25:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50), var(--focus-shadow);
 }
 
@@ -4286,7 +4286,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
-.select--stroke.select--lighten50:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
@@ -4301,7 +4301,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
-.select--stroke.select--lighten75:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white), var(--focus-shadow);
 }
 
@@ -4316,7 +4316,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
-.select--stroke.select--white:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
@@ -4331,7 +4331,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
-.select--stroke.select--transparent:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10), var(--focus-shadow);
 }
 
@@ -6878,7 +6878,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
-.select--stroke.select--red:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
 }
 
@@ -6893,7 +6893,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--teal-dark);
 }
 
-.select--stroke.select--teal:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--teal:focus {
   box-shadow: inset 0 0 0 1px var(--teal-dark), var(--focus-shadow);
 }
 
@@ -7366,7 +7366,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
-.select--stroke.select--lighten50:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
@@ -7381,7 +7381,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
-.select--stroke.select--lighten25:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50), var(--focus-shadow);
 }
 
@@ -7396,7 +7396,7 @@ scripts/build-color-variants.js to produce the output you want */
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
-.select--stroke.select--gray:focus {
+[data-assembly-focus-control='visible'] .select--stroke.select--gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
 }
 

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -390,323 +390,323 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--border-gray + .select-arrow {
+.select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
 
-.select--border-gray:focus + .select-arrow {
+.select--gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
 }
 
-.select--border-pink + .select-arrow {
+.select--pink + .select-arrow {
   border-top-color: var(--pink);
 }
 
-.select--border-pink:focus + .select-arrow {
+.select--pink:focus + .select-arrow {
   border-top-color: var(--pink-dark);
 }
 
-.select--border-red + .select-arrow {
+.select--red + .select-arrow {
   border-top-color: var(--red);
 }
 
-.select--border-red:focus + .select-arrow {
+.select--red:focus + .select-arrow {
   border-top-color: var(--red-dark);
 }
 
-.select--border-orange + .select-arrow {
+.select--orange + .select-arrow {
   border-top-color: var(--orange);
 }
 
-.select--border-orange:focus + .select-arrow {
+.select--orange:focus + .select-arrow {
   border-top-color: var(--orange-dark);
 }
 
-.select--border-yellow + .select-arrow {
+.select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
 
-.select--border-yellow:focus + .select-arrow {
+.select--yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
 }
 
-.select--border-green + .select-arrow {
+.select--green + .select-arrow {
   border-top-color: var(--green);
 }
 
-.select--border-green:focus + .select-arrow {
+.select--green:focus + .select-arrow {
   border-top-color: var(--green-dark);
 }
 
-.select--border-blue + .select-arrow {
+.select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
 
-.select--border-blue:focus + .select-arrow {
+.select--blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
 }
 
-.select--border-purple + .select-arrow {
+.select--purple + .select-arrow {
   border-top-color: var(--purple);
 }
 
-.select--border-purple:focus + .select-arrow {
+.select--purple:focus + .select-arrow {
   border-top-color: var(--purple-dark);
 }
 
-.select--border-darken25 + .select-arrow {
+.select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
 
-.select--border-darken25:focus + .select-arrow {
+.select--darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--border-darken50 + .select-arrow {
+.select--darken50 + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--border-darken50:focus + .select-arrow {
+.select--darken50:focus + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--border-darken75 + .select-arrow {
+.select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--border-darken75:focus + .select-arrow {
+.select--darken75:focus + .select-arrow {
   border-top-color: var(--black);
 }
 
-.select--border-lighten25 + .select-arrow {
+.select--lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
 
-.select--border-lighten25:focus + .select-arrow {
+.select--lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--border-lighten50 + .select-arrow {
+.select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--border-lighten50:focus + .select-arrow {
+.select--lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-lighten75 + .select-arrow {
+.select--lighten75 + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-lighten75:focus + .select-arrow {
+.select--lighten75:focus + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--border-white + .select-arrow {
+.select--white + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--border-white:focus + .select-arrow {
+.select--white:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-transparent + .select-arrow {
+.select--transparent + .select-arrow {
   border-top-color: var(--transparent);
 }
 
-.select--border-transparent:focus + .select-arrow {
+.select--transparent:focus + .select-arrow {
   border-top-color: var(--darken10);
 }
 
 .textarea--border-gray,
 .input--border-gray,
-.select--border-gray {
+.select--stroke.select--gray {
   box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus,
-.select--border-gray:focus {
+.select--stroke.select--gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
 .input--border-pink,
-.select--border-pink {
+.select--stroke.select--pink {
   box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus,
-.select--border-pink:focus {
+.select--stroke.select--pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
 .input--border-red,
-.select--border-red {
+.select--stroke.select--red {
   box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus,
-.select--border-red:focus {
+.select--stroke.select--red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
 .input--border-orange,
-.select--border-orange {
+.select--stroke.select--orange {
   box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus,
-.select--border-orange:focus {
+.select--stroke.select--orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
 .input--border-yellow,
-.select--border-yellow {
+.select--stroke.select--yellow {
   box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus,
-.select--border-yellow:focus {
+.select--stroke.select--yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
 .input--border-green,
-.select--border-green {
+.select--stroke.select--green {
   box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus,
-.select--border-green:focus {
+.select--stroke.select--green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
 .input--border-blue,
-.select--border-blue {
+.select--stroke.select--blue {
   box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus,
-.select--border-blue:focus {
+.select--stroke.select--blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
 .input--border-purple,
-.select--border-purple {
+.select--stroke.select--purple {
   box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus,
-.select--border-purple:focus {
+.select--stroke.select--purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
 .input--border-darken25,
-.select--border-darken25 {
+.select--stroke.select--darken25 {
   box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus,
-.select--border-darken25:focus {
+.select--stroke.select--darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
 .input--border-darken50,
-.select--border-darken50 {
+.select--stroke.select--darken50 {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus,
-.select--border-darken50:focus {
+.select--stroke.select--darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75,
-.select--border-darken75 {
+.select--stroke.select--darken75 {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus,
-.select--border-darken75:focus {
+.select--stroke.select--darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25,
-.select--border-lighten25 {
+.select--stroke.select--lighten25 {
   box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus,
-.select--border-lighten25:focus {
+.select--stroke.select--lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50,
-.select--border-lighten50 {
+.select--stroke.select--lighten50 {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus,
-.select--border-lighten50:focus {
+.select--stroke.select--lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75,
-.select--border-lighten75 {
+.select--stroke.select--lighten75 {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus,
-.select--border-lighten75:focus {
+.select--stroke.select--lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
 .input--border-white,
-.select--border-white {
+.select--stroke.select--white {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus,
-.select--border-white:focus {
+.select--stroke.select--white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent,
-.select--border-transparent {
+.select--stroke.select--transparent {
   box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus,
-.select--border-transparent:focus {
+.select--stroke.select--transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
@@ -3535,323 +3535,323 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--border-gray + .select-arrow {
+.select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
 
-.select--border-gray:focus + .select-arrow {
+.select--gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
 }
 
-.select--border-pink + .select-arrow {
+.select--pink + .select-arrow {
   border-top-color: var(--pink);
 }
 
-.select--border-pink:focus + .select-arrow {
+.select--pink:focus + .select-arrow {
   border-top-color: var(--pink-dark);
 }
 
-.select--border-red + .select-arrow {
+.select--red + .select-arrow {
   border-top-color: var(--red);
 }
 
-.select--border-red:focus + .select-arrow {
+.select--red:focus + .select-arrow {
   border-top-color: var(--red-dark);
 }
 
-.select--border-orange + .select-arrow {
+.select--orange + .select-arrow {
   border-top-color: var(--orange);
 }
 
-.select--border-orange:focus + .select-arrow {
+.select--orange:focus + .select-arrow {
   border-top-color: var(--orange-dark);
 }
 
-.select--border-yellow + .select-arrow {
+.select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
 
-.select--border-yellow:focus + .select-arrow {
+.select--yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
 }
 
-.select--border-green + .select-arrow {
+.select--green + .select-arrow {
   border-top-color: var(--green);
 }
 
-.select--border-green:focus + .select-arrow {
+.select--green:focus + .select-arrow {
   border-top-color: var(--green-dark);
 }
 
-.select--border-blue + .select-arrow {
+.select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
 
-.select--border-blue:focus + .select-arrow {
+.select--blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
 }
 
-.select--border-purple + .select-arrow {
+.select--purple + .select-arrow {
   border-top-color: var(--purple);
 }
 
-.select--border-purple:focus + .select-arrow {
+.select--purple:focus + .select-arrow {
   border-top-color: var(--purple-dark);
 }
 
-.select--border-darken25 + .select-arrow {
+.select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
 
-.select--border-darken25:focus + .select-arrow {
+.select--darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--border-darken50 + .select-arrow {
+.select--darken50 + .select-arrow {
   border-top-color: var(--darken50);
 }
 
-.select--border-darken50:focus + .select-arrow {
+.select--darken50:focus + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--border-darken75 + .select-arrow {
+.select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
 
-.select--border-darken75:focus + .select-arrow {
+.select--darken75:focus + .select-arrow {
   border-top-color: var(--black);
 }
 
-.select--border-lighten25 + .select-arrow {
+.select--lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
 
-.select--border-lighten25:focus + .select-arrow {
+.select--lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--border-lighten50 + .select-arrow {
+.select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--border-lighten50:focus + .select-arrow {
+.select--lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-lighten75 + .select-arrow {
+.select--lighten75 + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-lighten75:focus + .select-arrow {
+.select--lighten75:focus + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--border-white + .select-arrow {
+.select--white + .select-arrow {
   border-top-color: var(--white);
 }
 
-.select--border-white:focus + .select-arrow {
+.select--white:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-transparent + .select-arrow {
+.select--transparent + .select-arrow {
   border-top-color: var(--transparent);
 }
 
-.select--border-transparent:focus + .select-arrow {
+.select--transparent:focus + .select-arrow {
   border-top-color: var(--darken10);
 }
 
 .textarea--border-gray,
 .input--border-gray,
-.select--border-gray {
+.select--stroke.select--gray {
   box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus,
-.select--border-gray:focus {
+.select--stroke.select--gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 
 .textarea--border-pink,
 .input--border-pink,
-.select--border-pink {
+.select--stroke.select--pink {
   box-shadow: inset 0 0 0 1px var(--pink);
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus,
-.select--border-pink:focus {
+.select--stroke.select--pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
 }
 
 .textarea--border-red,
 .input--border-red,
-.select--border-red {
+.select--stroke.select--red {
   box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus,
-.select--border-red:focus {
+.select--stroke.select--red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-orange,
 .input--border-orange,
-.select--border-orange {
+.select--stroke.select--orange {
   box-shadow: inset 0 0 0 1px var(--orange);
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus,
-.select--border-orange:focus {
+.select--stroke.select--orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
 }
 
 .textarea--border-yellow,
 .input--border-yellow,
-.select--border-yellow {
+.select--stroke.select--yellow {
   box-shadow: inset 0 0 0 1px var(--yellow);
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus,
-.select--border-yellow:focus {
+.select--stroke.select--yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
 }
 
 .textarea--border-green,
 .input--border-green,
-.select--border-green {
+.select--stroke.select--green {
   box-shadow: inset 0 0 0 1px var(--green);
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus,
-.select--border-green:focus {
+.select--stroke.select--green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
 }
 
 .textarea--border-blue,
 .input--border-blue,
-.select--border-blue {
+.select--stroke.select--blue {
   box-shadow: inset 0 0 0 1px var(--blue);
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus,
-.select--border-blue:focus {
+.select--stroke.select--blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
 }
 
 .textarea--border-purple,
 .input--border-purple,
-.select--border-purple {
+.select--stroke.select--purple {
   box-shadow: inset 0 0 0 1px var(--purple);
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus,
-.select--border-purple:focus {
+.select--stroke.select--purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
 }
 
 .textarea--border-darken25,
 .input--border-darken25,
-.select--border-darken25 {
+.select--stroke.select--darken25 {
   box-shadow: inset 0 0 0 1px var(--darken25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus,
-.select--border-darken25:focus {
+.select--stroke.select--darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50,
 .input--border-darken50,
-.select--border-darken50 {
+.select--stroke.select--darken50 {
   box-shadow: inset 0 0 0 1px var(--darken50);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus,
-.select--border-darken50:focus {
+.select--stroke.select--darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75,
-.select--border-darken75 {
+.select--stroke.select--darken75 {
   box-shadow: inset 0 0 0 1px var(--darken75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus,
-.select--border-darken75:focus {
+.select--stroke.select--darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25,
-.select--border-lighten25 {
+.select--stroke.select--lighten25 {
   box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus,
-.select--border-lighten25:focus {
+.select--stroke.select--lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50,
-.select--border-lighten50 {
+.select--stroke.select--lighten50 {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus,
-.select--border-lighten50:focus {
+.select--stroke.select--lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75,
-.select--border-lighten75 {
+.select--stroke.select--lighten75 {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus,
-.select--border-lighten75:focus {
+.select--stroke.select--lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white,
 .input--border-white,
-.select--border-white {
+.select--stroke.select--white {
   box-shadow: inset 0 0 0 1px var(--white);
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus,
-.select--border-white:focus {
+.select--stroke.select--white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent,
-.select--border-transparent {
+.select--stroke.select--transparent {
   box-shadow: inset 0 0 0 1px var(--transparent);
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus,
-.select--border-transparent:focus {
+.select--stroke.select--transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
 }
 
@@ -6347,43 +6347,43 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--border-red + .select-arrow {
+.select--red + .select-arrow {
   border-top-color: var(--red);
 }
 
-.select--border-red:focus + .select-arrow {
+.select--red:focus + .select-arrow {
   border-top-color: var(--red-dark);
 }
 
-.select--border-teal + .select-arrow {
+.select--teal + .select-arrow {
   border-top-color: var(--teal);
 }
 
-.select--border-teal:focus + .select-arrow {
+.select--teal:focus + .select-arrow {
   border-top-color: var(--teal-dark);
 }
 
 .textarea--border-red,
 .input--border-red,
-.select--border-red {
+.select--stroke.select--red {
   box-shadow: inset 0 0 0 1px var(--red);
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus,
-.select--border-red:focus {
+.select--stroke.select--red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
 }
 
 .textarea--border-teal,
 .input--border-teal,
-.select--border-teal {
+.select--stroke.select--teal {
   box-shadow: inset 0 0 0 1px var(--teal);
 }
 
 .textarea--border-teal:focus,
 .input--border-teal:focus,
-.select--border-teal:focus {
+.select--stroke.select--teal:focus {
   box-shadow: inset 0 0 0 1px var(--teal-dark);
 }
 
@@ -6785,63 +6785,63 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
-.select--border-lighten50 + .select-arrow {
+.select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--border-lighten50:focus + .select-arrow {
+.select--lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
 }
 
-.select--border-lighten25 + .select-arrow {
+.select--lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
 
-.select--border-lighten25:focus + .select-arrow {
+.select--lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
-.select--border-gray + .select-arrow {
+.select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
 
-.select--border-gray:focus + .select-arrow {
+.select--gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50,
-.select--border-lighten50 {
+.select--stroke.select--lighten50 {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus,
-.select--border-lighten50:focus {
+.select--stroke.select--lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25,
-.select--border-lighten25 {
+.select--stroke.select--lighten25 {
   box-shadow: inset 0 0 0 1px var(--lighten25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus,
-.select--border-lighten25:focus {
+.select--stroke.select--lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
 }
 
 .textarea--border-gray,
 .input--border-gray,
-.select--border-gray {
+.select--stroke.select--gray {
   box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus,
-.select--border-gray:focus {
+.select--stroke.select--gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
 }
 

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -398,6 +398,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--gray-dark);
 }
 
+.select--gray:hover {
+  color: var(--gray-dark);
+}
+
 .select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
@@ -411,6 +415,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus {
+  color: var(--pink-dark);
+}
+
+.select--pink:hover {
   color: var(--pink-dark);
 }
 
@@ -430,6 +438,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--red-dark);
 }
 
+.select--red:hover {
+  color: var(--red-dark);
+}
+
 .select--red + .select-arrow {
   border-top-color: var(--red);
 }
@@ -443,6 +455,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus {
+  color: var(--orange-dark);
+}
+
+.select--orange:hover {
   color: var(--orange-dark);
 }
 
@@ -462,6 +478,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--yellow-dark);
 }
 
+.select--yellow:hover {
+  color: var(--yellow-dark);
+}
+
 .select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
@@ -475,6 +495,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus {
+  color: var(--green-dark);
+}
+
+.select--green:hover {
   color: var(--green-dark);
 }
 
@@ -494,6 +518,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--blue-dark);
 }
 
+.select--blue:hover {
+  color: var(--blue-dark);
+}
+
 .select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
@@ -507,6 +535,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus {
+  color: var(--purple-dark);
+}
+
+.select--purple:hover {
   color: var(--purple-dark);
 }
 
@@ -526,6 +558,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--darken50);
 }
 
+.select--darken25:hover {
+  color: var(--darken50);
+}
+
 .select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
@@ -539,6 +575,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--darken50:focus {
+  color: var(--darken75);
+}
+
+.select--darken50:hover {
   color: var(--darken75);
 }
 
@@ -558,6 +598,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--black);
 }
 
+.select--darken75:hover {
+  color: var(--black);
+}
+
 .select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
@@ -571,6 +615,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--lighten25:focus {
+  color: var(--lighten50);
+}
+
+.select--lighten25:hover {
   color: var(--lighten50);
 }
 
@@ -590,6 +638,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--lighten75);
 }
 
+.select--lighten50:hover {
+  color: var(--lighten75);
+}
+
 .select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
@@ -603,6 +655,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--lighten75:focus {
+  color: var(--white);
+}
+
+.select--lighten75:hover {
   color: var(--white);
 }
 
@@ -622,6 +678,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--lighten75);
 }
 
+.select--white:hover {
+  color: var(--lighten75);
+}
+
 .select--white + .select-arrow {
   border-top-color: var(--white);
 }
@@ -635,6 +695,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--transparent:focus {
+  color: var(--darken10);
+}
+
+.select--transparent:hover {
   color: var(--darken10);
 }
 
@@ -3719,6 +3783,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--gray-dark);
 }
 
+.select--gray:hover {
+  color: var(--gray-dark);
+}
+
 .select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
@@ -3732,6 +3800,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus {
+  color: var(--pink-dark);
+}
+
+.select--pink:hover {
   color: var(--pink-dark);
 }
 
@@ -3751,6 +3823,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--red-dark);
 }
 
+.select--red:hover {
+  color: var(--red-dark);
+}
+
 .select--red + .select-arrow {
   border-top-color: var(--red);
 }
@@ -3764,6 +3840,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus {
+  color: var(--orange-dark);
+}
+
+.select--orange:hover {
   color: var(--orange-dark);
 }
 
@@ -3783,6 +3863,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--yellow-dark);
 }
 
+.select--yellow:hover {
+  color: var(--yellow-dark);
+}
+
 .select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
@@ -3796,6 +3880,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus {
+  color: var(--green-dark);
+}
+
+.select--green:hover {
   color: var(--green-dark);
 }
 
@@ -3815,6 +3903,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--blue-dark);
 }
 
+.select--blue:hover {
+  color: var(--blue-dark);
+}
+
 .select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
@@ -3828,6 +3920,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus {
+  color: var(--purple-dark);
+}
+
+.select--purple:hover {
   color: var(--purple-dark);
 }
 
@@ -3847,6 +3943,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--darken50);
 }
 
+.select--darken25:hover {
+  color: var(--darken50);
+}
+
 .select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
@@ -3860,6 +3960,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--darken50:focus {
+  color: var(--darken75);
+}
+
+.select--darken50:hover {
   color: var(--darken75);
 }
 
@@ -3879,6 +3983,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--black);
 }
 
+.select--darken75:hover {
+  color: var(--black);
+}
+
 .select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
@@ -3892,6 +4000,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--lighten25:focus {
+  color: var(--lighten50);
+}
+
+.select--lighten25:hover {
   color: var(--lighten50);
 }
 
@@ -3911,6 +4023,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--lighten75);
 }
 
+.select--lighten50:hover {
+  color: var(--lighten75);
+}
+
 .select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
@@ -3924,6 +4040,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--lighten75:focus {
+  color: var(--white);
+}
+
+.select--lighten75:hover {
   color: var(--white);
 }
 
@@ -3943,6 +4063,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--lighten75);
 }
 
+.select--white:hover {
+  color: var(--lighten75);
+}
+
 .select--white + .select-arrow {
   border-top-color: var(--white);
 }
@@ -3956,6 +4080,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--transparent:focus {
+  color: var(--darken10);
+}
+
+.select--transparent:hover {
   color: var(--darken10);
 }
 
@@ -6707,6 +6835,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--red-dark);
 }
 
+.select--red:hover {
+  color: var(--red-dark);
+}
+
 .select--red + .select-arrow {
   border-top-color: var(--red);
 }
@@ -6720,6 +6852,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--teal:focus {
+  color: var(--teal-dark);
+}
+
+.select--teal:hover {
   color: var(--teal-dark);
 }
 
@@ -7167,6 +7303,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--lighten75);
 }
 
+.select--lighten50:hover {
+  color: var(--lighten75);
+}
+
 .select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
@@ -7183,6 +7323,10 @@ scripts/build-color-variants.js to produce the output you want */
   color: var(--lighten50);
 }
 
+.select--lighten25:hover {
+  color: var(--lighten50);
+}
+
 .select--lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
@@ -7196,6 +7340,10 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus {
+  color: var(--gray-dark);
+}
+
+.select--gray:hover {
   color: var(--gray-dark);
 }
 

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -390,12 +390,28 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
+.select--gray {
+  color: var(--gray);
+}
+
+.select--gray:focus {
+  color: var(--gray-dark);
+}
+
 .select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
 
 .select--gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
+}
+
+.select--pink {
+  color: var(--pink);
+}
+
+.select--pink:focus {
+  color: var(--pink-dark);
 }
 
 .select--pink + .select-arrow {
@@ -406,12 +422,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--pink-dark);
 }
 
+.select--red {
+  color: var(--red);
+}
+
+.select--red:focus {
+  color: var(--red-dark);
+}
+
 .select--red + .select-arrow {
   border-top-color: var(--red);
 }
 
 .select--red:focus + .select-arrow {
   border-top-color: var(--red-dark);
+}
+
+.select--orange {
+  color: var(--orange);
+}
+
+.select--orange:focus {
+  color: var(--orange-dark);
 }
 
 .select--orange + .select-arrow {
@@ -422,12 +454,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--orange-dark);
 }
 
+.select--yellow {
+  color: var(--yellow);
+}
+
+.select--yellow:focus {
+  color: var(--yellow-dark);
+}
+
 .select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
 
 .select--yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
+}
+
+.select--green {
+  color: var(--green);
+}
+
+.select--green:focus {
+  color: var(--green-dark);
 }
 
 .select--green + .select-arrow {
@@ -438,12 +486,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--green-dark);
 }
 
+.select--blue {
+  color: var(--blue);
+}
+
+.select--blue:focus {
+  color: var(--blue-dark);
+}
+
 .select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
 
 .select--blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
+}
+
+.select--purple {
+  color: var(--purple);
+}
+
+.select--purple:focus {
+  color: var(--purple-dark);
 }
 
 .select--purple + .select-arrow {
@@ -454,12 +518,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--purple-dark);
 }
 
+.select--darken25 {
+  color: var(--darken25);
+}
+
+.select--darken25:focus {
+  color: var(--darken50);
+}
+
 .select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
 
 .select--darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
+}
+
+.select--darken50 {
+  color: var(--darken50);
+}
+
+.select--darken50:focus {
+  color: var(--darken75);
 }
 
 .select--darken50 + .select-arrow {
@@ -470,12 +550,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--darken75);
 }
 
+.select--darken75 {
+  color: var(--darken75);
+}
+
+.select--darken75:focus {
+  color: var(--black);
+}
+
 .select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
 
 .select--darken75:focus + .select-arrow {
   border-top-color: var(--black);
+}
+
+.select--lighten25 {
+  color: var(--lighten25);
+}
+
+.select--lighten25:focus {
+  color: var(--lighten50);
 }
 
 .select--lighten25 + .select-arrow {
@@ -486,12 +582,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--lighten50);
 }
 
+.select--lighten50 {
+  color: var(--lighten50);
+}
+
+.select--lighten50:focus {
+  color: var(--lighten75);
+}
+
 .select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
 .select--lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
+}
+
+.select--lighten75 {
+  color: var(--lighten75);
+}
+
+.select--lighten75:focus {
+  color: var(--white);
 }
 
 .select--lighten75 + .select-arrow {
@@ -502,12 +614,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--white);
 }
 
+.select--white {
+  color: var(--white);
+}
+
+.select--white:focus {
+  color: var(--lighten75);
+}
+
 .select--white + .select-arrow {
   border-top-color: var(--white);
 }
 
 .select--white:focus + .select-arrow {
   border-top-color: var(--lighten75);
+}
+
+.select--transparent {
+  color: var(--transparent);
+}
+
+.select--transparent:focus {
+  color: var(--darken10);
 }
 
 .select--transparent + .select-arrow {
@@ -3535,12 +3663,28 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
+.select--gray {
+  color: var(--gray);
+}
+
+.select--gray:focus {
+  color: var(--gray-dark);
+}
+
 .select--gray + .select-arrow {
   border-top-color: var(--gray);
 }
 
 .select--gray:focus + .select-arrow {
   border-top-color: var(--gray-dark);
+}
+
+.select--pink {
+  color: var(--pink);
+}
+
+.select--pink:focus {
+  color: var(--pink-dark);
 }
 
 .select--pink + .select-arrow {
@@ -3551,12 +3695,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--pink-dark);
 }
 
+.select--red {
+  color: var(--red);
+}
+
+.select--red:focus {
+  color: var(--red-dark);
+}
+
 .select--red + .select-arrow {
   border-top-color: var(--red);
 }
 
 .select--red:focus + .select-arrow {
   border-top-color: var(--red-dark);
+}
+
+.select--orange {
+  color: var(--orange);
+}
+
+.select--orange:focus {
+  color: var(--orange-dark);
 }
 
 .select--orange + .select-arrow {
@@ -3567,12 +3727,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--orange-dark);
 }
 
+.select--yellow {
+  color: var(--yellow);
+}
+
+.select--yellow:focus {
+  color: var(--yellow-dark);
+}
+
 .select--yellow + .select-arrow {
   border-top-color: var(--yellow);
 }
 
 .select--yellow:focus + .select-arrow {
   border-top-color: var(--yellow-dark);
+}
+
+.select--green {
+  color: var(--green);
+}
+
+.select--green:focus {
+  color: var(--green-dark);
 }
 
 .select--green + .select-arrow {
@@ -3583,12 +3759,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--green-dark);
 }
 
+.select--blue {
+  color: var(--blue);
+}
+
+.select--blue:focus {
+  color: var(--blue-dark);
+}
+
 .select--blue + .select-arrow {
   border-top-color: var(--blue);
 }
 
 .select--blue:focus + .select-arrow {
   border-top-color: var(--blue-dark);
+}
+
+.select--purple {
+  color: var(--purple);
+}
+
+.select--purple:focus {
+  color: var(--purple-dark);
 }
 
 .select--purple + .select-arrow {
@@ -3599,12 +3791,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--purple-dark);
 }
 
+.select--darken25 {
+  color: var(--darken25);
+}
+
+.select--darken25:focus {
+  color: var(--darken50);
+}
+
 .select--darken25 + .select-arrow {
   border-top-color: var(--darken25);
 }
 
 .select--darken25:focus + .select-arrow {
   border-top-color: var(--darken50);
+}
+
+.select--darken50 {
+  color: var(--darken50);
+}
+
+.select--darken50:focus {
+  color: var(--darken75);
 }
 
 .select--darken50 + .select-arrow {
@@ -3615,12 +3823,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--darken75);
 }
 
+.select--darken75 {
+  color: var(--darken75);
+}
+
+.select--darken75:focus {
+  color: var(--black);
+}
+
 .select--darken75 + .select-arrow {
   border-top-color: var(--darken75);
 }
 
 .select--darken75:focus + .select-arrow {
   border-top-color: var(--black);
+}
+
+.select--lighten25 {
+  color: var(--lighten25);
+}
+
+.select--lighten25:focus {
+  color: var(--lighten50);
 }
 
 .select--lighten25 + .select-arrow {
@@ -3631,12 +3855,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--lighten50);
 }
 
+.select--lighten50 {
+  color: var(--lighten50);
+}
+
+.select--lighten50:focus {
+  color: var(--lighten75);
+}
+
 .select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
 
 .select--lighten50:focus + .select-arrow {
   border-top-color: var(--lighten75);
+}
+
+.select--lighten75 {
+  color: var(--lighten75);
+}
+
+.select--lighten75:focus {
+  color: var(--white);
 }
 
 .select--lighten75 + .select-arrow {
@@ -3647,12 +3887,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--white);
 }
 
+.select--white {
+  color: var(--white);
+}
+
+.select--white:focus {
+  color: var(--lighten75);
+}
+
 .select--white + .select-arrow {
   border-top-color: var(--white);
 }
 
 .select--white:focus + .select-arrow {
   border-top-color: var(--lighten75);
+}
+
+.select--transparent {
+  color: var(--transparent);
+}
+
+.select--transparent:focus {
+  color: var(--darken10);
 }
 
 .select--transparent + .select-arrow {
@@ -6347,12 +6603,28 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
+.select--red {
+  color: var(--red);
+}
+
+.select--red:focus {
+  color: var(--red-dark);
+}
+
 .select--red + .select-arrow {
   border-top-color: var(--red);
 }
 
 .select--red:focus + .select-arrow {
   border-top-color: var(--red-dark);
+}
+
+.select--teal {
+  color: var(--teal);
+}
+
+.select--teal:focus {
+  color: var(--teal-dark);
 }
 
 .select--teal + .select-arrow {
@@ -6785,6 +7057,14 @@ scripts/build-color-variants.js to produce the output you want */
   background-color: transparent;
 }
 
+.select--lighten50 {
+  color: var(--lighten50);
+}
+
+.select--lighten50:focus {
+  color: var(--lighten75);
+}
+
 .select--lighten50 + .select-arrow {
   border-top-color: var(--lighten50);
 }
@@ -6793,12 +7073,28 @@ scripts/build-color-variants.js to produce the output you want */
   border-top-color: var(--lighten75);
 }
 
+.select--lighten25 {
+  color: var(--lighten25);
+}
+
+.select--lighten25:focus {
+  color: var(--lighten50);
+}
+
 .select--lighten25 + .select-arrow {
   border-top-color: var(--lighten25);
 }
 
 .select--lighten25:focus + .select-arrow {
   border-top-color: var(--lighten50);
+}
+
+.select--gray {
+  color: var(--gray);
+}
+
+.select--gray:focus {
+  color: var(--gray-dark);
 }
 
 .select--gray + .select-arrow {

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -653,9 +653,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus,
-.select--stroke.select--gray:focus {
+.input--border-gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
+}
+
+.select--stroke.select--gray:focus {
+  box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
 }
 
 .textarea--border-pink,
@@ -665,9 +668,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus,
-.select--stroke.select--pink:focus {
+.input--border-pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
+}
+
+.select--stroke.select--pink:focus {
+  box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
 }
 
 .textarea--border-red,
@@ -677,9 +683,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus,
-.select--stroke.select--red:focus {
+.input--border-red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
+}
+
+.select--stroke.select--red:focus {
+  box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
 }
 
 .textarea--border-orange,
@@ -689,9 +698,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus,
-.select--stroke.select--orange:focus {
+.input--border-orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
+}
+
+.select--stroke.select--orange:focus {
+  box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
 }
 
 .textarea--border-yellow,
@@ -701,9 +713,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus,
-.select--stroke.select--yellow:focus {
+.input--border-yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
+}
+
+.select--stroke.select--yellow:focus {
+  box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
 }
 
 .textarea--border-green,
@@ -713,9 +728,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus,
-.select--stroke.select--green:focus {
+.input--border-green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
+}
+
+.select--stroke.select--green:focus {
+  box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
 }
 
 .textarea--border-blue,
@@ -725,9 +743,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus,
-.select--stroke.select--blue:focus {
+.input--border-blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
+}
+
+.select--stroke.select--blue:focus {
+  box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
 }
 
 .textarea--border-purple,
@@ -737,9 +758,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus,
-.select--stroke.select--purple:focus {
+.input--border-purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
+}
+
+.select--stroke.select--purple:focus {
+  box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
 }
 
 .textarea--border-darken25,
@@ -749,9 +773,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus,
-.select--stroke.select--darken25:focus {
+.input--border-darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
+}
+
+.select--stroke.select--darken25:focus {
+  box-shadow: inset 0 0 0 1px var(--darken50), var(--focus-shadow);
 }
 
 .textarea--border-darken50,
@@ -761,9 +788,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus,
-.select--stroke.select--darken50:focus {
+.input--border-darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
+}
+
+.select--stroke.select--darken50:focus {
+  box-shadow: inset 0 0 0 1px var(--darken75), var(--focus-shadow);
 }
 
 .textarea--border-darken75,
@@ -773,9 +803,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus,
-.select--stroke.select--darken75:focus {
+.input--border-darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
+}
+
+.select--stroke.select--darken75:focus {
+  box-shadow: inset 0 0 0 1px var(--black), var(--focus-shadow);
 }
 
 .textarea--border-lighten25,
@@ -785,9 +818,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus,
-.select--stroke.select--lighten25:focus {
+.input--border-lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
+}
+
+.select--stroke.select--lighten25:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten50), var(--focus-shadow);
 }
 
 .textarea--border-lighten50,
@@ -797,9 +833,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus,
-.select--stroke.select--lighten50:focus {
+.input--border-lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
+}
+
+.select--stroke.select--lighten50:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
 .textarea--border-lighten75,
@@ -809,9 +848,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus,
-.select--stroke.select--lighten75:focus {
+.input--border-lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
+}
+
+.select--stroke.select--lighten75:focus {
+  box-shadow: inset 0 0 0 1px var(--white), var(--focus-shadow);
 }
 
 .textarea--border-white,
@@ -821,9 +863,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus,
-.select--stroke.select--white:focus {
+.input--border-white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
+}
+
+.select--stroke.select--white:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
 .textarea--border-transparent,
@@ -833,9 +878,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus,
-.select--stroke.select--transparent:focus {
+.input--border-transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
+}
+
+.select--stroke.select--transparent:focus {
+  box-shadow: inset 0 0 0 1px var(--darken10), var(--focus-shadow);
 }
 
 .checkbox--gray {
@@ -3926,9 +3974,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus,
-.select--stroke.select--gray:focus {
+.input--border-gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
+}
+
+.select--stroke.select--gray:focus {
+  box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
 }
 
 .textarea--border-pink,
@@ -3938,9 +3989,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus,
-.select--stroke.select--pink:focus {
+.input--border-pink:focus {
   box-shadow: inset 0 0 0 1px var(--pink-dark);
+}
+
+.select--stroke.select--pink:focus {
+  box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
 }
 
 .textarea--border-red,
@@ -3950,9 +4004,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus,
-.select--stroke.select--red:focus {
+.input--border-red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
+}
+
+.select--stroke.select--red:focus {
+  box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
 }
 
 .textarea--border-orange,
@@ -3962,9 +4019,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus,
-.select--stroke.select--orange:focus {
+.input--border-orange:focus {
   box-shadow: inset 0 0 0 1px var(--orange-dark);
+}
+
+.select--stroke.select--orange:focus {
+  box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
 }
 
 .textarea--border-yellow,
@@ -3974,9 +4034,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus,
-.select--stroke.select--yellow:focus {
+.input--border-yellow:focus {
   box-shadow: inset 0 0 0 1px var(--yellow-dark);
+}
+
+.select--stroke.select--yellow:focus {
+  box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
 }
 
 .textarea--border-green,
@@ -3986,9 +4049,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus,
-.select--stroke.select--green:focus {
+.input--border-green:focus {
   box-shadow: inset 0 0 0 1px var(--green-dark);
+}
+
+.select--stroke.select--green:focus {
+  box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
 }
 
 .textarea--border-blue,
@@ -3998,9 +4064,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus,
-.select--stroke.select--blue:focus {
+.input--border-blue:focus {
   box-shadow: inset 0 0 0 1px var(--blue-dark);
+}
+
+.select--stroke.select--blue:focus {
+  box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
 }
 
 .textarea--border-purple,
@@ -4010,9 +4079,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus,
-.select--stroke.select--purple:focus {
+.input--border-purple:focus {
   box-shadow: inset 0 0 0 1px var(--purple-dark);
+}
+
+.select--stroke.select--purple:focus {
+  box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
 }
 
 .textarea--border-darken25,
@@ -4022,9 +4094,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus,
-.select--stroke.select--darken25:focus {
+.input--border-darken25:focus {
   box-shadow: inset 0 0 0 1px var(--darken50);
+}
+
+.select--stroke.select--darken25:focus {
+  box-shadow: inset 0 0 0 1px var(--darken50), var(--focus-shadow);
 }
 
 .textarea--border-darken50,
@@ -4034,9 +4109,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus,
-.select--stroke.select--darken50:focus {
+.input--border-darken50:focus {
   box-shadow: inset 0 0 0 1px var(--darken75);
+}
+
+.select--stroke.select--darken50:focus {
+  box-shadow: inset 0 0 0 1px var(--darken75), var(--focus-shadow);
 }
 
 .textarea--border-darken75,
@@ -4046,9 +4124,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus,
-.select--stroke.select--darken75:focus {
+.input--border-darken75:focus {
   box-shadow: inset 0 0 0 1px var(--black);
+}
+
+.select--stroke.select--darken75:focus {
+  box-shadow: inset 0 0 0 1px var(--black), var(--focus-shadow);
 }
 
 .textarea--border-lighten25,
@@ -4058,9 +4139,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus,
-.select--stroke.select--lighten25:focus {
+.input--border-lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
+}
+
+.select--stroke.select--lighten25:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten50), var(--focus-shadow);
 }
 
 .textarea--border-lighten50,
@@ -4070,9 +4154,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus,
-.select--stroke.select--lighten50:focus {
+.input--border-lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
+}
+
+.select--stroke.select--lighten50:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
 .textarea--border-lighten75,
@@ -4082,9 +4169,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus,
-.select--stroke.select--lighten75:focus {
+.input--border-lighten75:focus {
   box-shadow: inset 0 0 0 1px var(--white);
+}
+
+.select--stroke.select--lighten75:focus {
+  box-shadow: inset 0 0 0 1px var(--white), var(--focus-shadow);
 }
 
 .textarea--border-white,
@@ -4094,9 +4184,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus,
-.select--stroke.select--white:focus {
+.input--border-white:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
+}
+
+.select--stroke.select--white:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
 .textarea--border-transparent,
@@ -4106,9 +4199,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus,
-.select--stroke.select--transparent:focus {
+.input--border-transparent:focus {
   box-shadow: inset 0 0 0 1px var(--darken10);
+}
+
+.select--stroke.select--transparent:focus {
+  box-shadow: inset 0 0 0 1px var(--darken10), var(--focus-shadow);
 }
 
 .checkbox--gray {
@@ -6642,9 +6738,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus,
-.select--stroke.select--red:focus {
+.input--border-red:focus {
   box-shadow: inset 0 0 0 1px var(--red-dark);
+}
+
+.select--stroke.select--red:focus {
+  box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
 }
 
 .textarea--border-teal,
@@ -6654,9 +6753,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-teal:focus,
-.input--border-teal:focus,
-.select--stroke.select--teal:focus {
+.input--border-teal:focus {
   box-shadow: inset 0 0 0 1px var(--teal-dark);
+}
+
+.select--stroke.select--teal:focus {
+  box-shadow: inset 0 0 0 1px var(--teal-dark), var(--focus-shadow);
 }
 
 .checkbox--red {
@@ -7112,9 +7214,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus,
-.select--stroke.select--lighten50:focus {
+.input--border-lighten50:focus {
   box-shadow: inset 0 0 0 1px var(--lighten75);
+}
+
+.select--stroke.select--lighten50:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten75), var(--focus-shadow);
 }
 
 .textarea--border-lighten25,
@@ -7124,9 +7229,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus,
-.select--stroke.select--lighten25:focus {
+.input--border-lighten25:focus {
   box-shadow: inset 0 0 0 1px var(--lighten50);
+}
+
+.select--stroke.select--lighten25:focus {
+  box-shadow: inset 0 0 0 1px var(--lighten50), var(--focus-shadow);
 }
 
 .textarea--border-gray,
@@ -7136,9 +7244,12 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus,
-.select--stroke.select--gray:focus {
+.input--border-gray:focus {
   box-shadow: inset 0 0 0 1px var(--gray-dark);
+}
+
+.select--stroke.select--gray:focus {
+  box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
 }
 
 .checkbox--lighten50 {

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -9000,7 +9000,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #2d2d2d;
 }
 
-.select--stroke.select--gray:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--gray:focus{
   box-shadow:inset 0 0 0 1px #2d2d2d, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9015,7 +9015,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #ab084b;
 }
 
-.select--stroke.select--pink:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--pink:focus{
   box-shadow:inset 0 0 0 1px #ab084b, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9030,7 +9030,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #a30003;
 }
 
-.select--stroke.select--red:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--red:focus{
   box-shadow:inset 0 0 0 1px #a30003, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9045,7 +9045,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #bc3a00;
 }
 
-.select--stroke.select--orange:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--orange:focus{
   box-shadow:inset 0 0 0 1px #bc3a00, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9060,7 +9060,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #d9a100;
 }
 
-.select--stroke.select--yellow:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus{
   box-shadow:inset 0 0 0 1px #d9a100, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9075,7 +9075,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #006427;
 }
 
-.select--stroke.select--green:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--green:focus{
   box-shadow:inset 0 0 0 1px #006427, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9090,7 +9090,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #223B53;
 }
 
-.select--stroke.select--blue:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--blue:focus{
   box-shadow:inset 0 0 0 1px #223B53, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9105,7 +9105,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #440067;
 }
 
-.select--stroke.select--purple:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--purple:focus{
   box-shadow:inset 0 0 0 1px #440067, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9120,7 +9120,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
-.select--stroke.select--darken25:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--darken25:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9135,7 +9135,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
-.select--stroke.select--darken50:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--darken50:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9150,7 +9150,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #000;
 }
 
-.select--stroke.select--darken75:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--darken75:focus{
   box-shadow:inset 0 0 0 1px #000, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9165,7 +9165,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
-.select--stroke.select--lighten25:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten25:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9180,7 +9180,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
-.select--stroke.select--lighten50:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten50:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9195,7 +9195,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
-.select--stroke.select--lighten75:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten75:focus{
   box-shadow:inset 0 0 0 1px #fff, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9210,7 +9210,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
-.select--stroke.select--white:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--white:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -9225,7 +9225,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 
-.select--stroke.select--transparent:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--transparent:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21129,7 +21129,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #2d2d2d;
 }
 
-.select--stroke.select--gray:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--gray:focus{
   box-shadow:inset 0 0 0 1px #2d2d2d, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21144,7 +21144,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #ab084b;
 }
 
-.select--stroke.select--pink:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--pink:focus{
   box-shadow:inset 0 0 0 1px #ab084b, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21159,7 +21159,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #a30003;
 }
 
-.select--stroke.select--red:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--red:focus{
   box-shadow:inset 0 0 0 1px #a30003, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21174,7 +21174,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #bc3a00;
 }
 
-.select--stroke.select--orange:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--orange:focus{
   box-shadow:inset 0 0 0 1px #bc3a00, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21189,7 +21189,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #d9a100;
 }
 
-.select--stroke.select--yellow:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus{
   box-shadow:inset 0 0 0 1px #d9a100, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21204,7 +21204,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #006427;
 }
 
-.select--stroke.select--green:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--green:focus{
   box-shadow:inset 0 0 0 1px #006427, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21219,7 +21219,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #295b97;
 }
 
-.select--stroke.select--blue:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--blue:focus{
   box-shadow:inset 0 0 0 1px #295b97, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21234,7 +21234,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #440067;
 }
 
-.select--stroke.select--purple:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--purple:focus{
   box-shadow:inset 0 0 0 1px #440067, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21249,7 +21249,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
-.select--stroke.select--darken25:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--darken25:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21264,7 +21264,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
-.select--stroke.select--darken50:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--darken50:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21279,7 +21279,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #000;
 }
 
-.select--stroke.select--darken75:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--darken75:focus{
   box-shadow:inset 0 0 0 1px #000, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21294,7 +21294,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
-.select--stroke.select--lighten25:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten25:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21309,7 +21309,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
-.select--stroke.select--lighten50:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten50:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21324,7 +21324,7 @@ textarea{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
-.select--stroke.select--lighten75:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--lighten75:focus{
   box-shadow:inset 0 0 0 1px #fff, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21339,7 +21339,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
-.select--stroke.select--white:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--white:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -21354,7 +21354,7 @@ textarea{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 
-.select--stroke.select--transparent:focus{
+[data-assembly-focus-control='visible'] .select--stroke.select--transparent:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -532,6 +532,10 @@ legend{
 .select--s + .select-arrow{
   right:8px;
 }
+.select--border-0{
+  box-shadow:none !important;
+  padding:6px 30px 6px 0;
+}
 .select:disabled{
   pointer-events:none;
   color:rgba(0, 0, 0, 0.25);
@@ -12419,6 +12423,10 @@ legend{
 
 .select--s + .select-arrow{
   right:8px;
+}
+.select--border-0{
+  box-shadow:none !important;
+  padding:6px 30px 6px 0;
 }
 .select:disabled{
   pointer-events:none;

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -418,7 +418,7 @@ legend{
 
 .input:focus,
 .textarea:focus,
-.select:focus{
+.select:focus .select--stroke{
   box-shadow:inset 0 0 0 1px #666;
 }
 
@@ -457,11 +457,11 @@ legend{
 }
 .input:disabled,
 .textarea:disabled,
-.select:disabled{
+.select--stroke:disabled{
   pointer-events:none;
   color:rgba(0, 0, 0, 0.5);
   background-color:rgba(127, 127, 127, 0.1);
-  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25);
+  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25) !important;
 }
 .input[readonly],
 .textarea[readonly]{
@@ -480,8 +480,9 @@ legend{
   font-size:16px;
   line-height:24px;
   color:currentColor;
-  padding:6px 30px 6px 12px;
+  padding:6px 30px 6px 0;
   cursor:pointer;
+  box-shadow:none;
 }
 
 .select-arrow{
@@ -498,7 +499,7 @@ legend{
   transition:border-top-color 0.125s;
 }
 
-.select:focus + .select-arrow{
+.select .select--stroke:focus + .select-arrow{
   border-top-color:#666;
 }
 .select option{
@@ -526,21 +527,23 @@ legend{
 .select--s{
   font-size:12px;
   line-height:18px;
-  padding:3px 24px 3px 6px;
+  padding:3px 24px 3px 0;
 }
 
 .select--s + .select-arrow{
   right:8px;
 }
-.select--border-0{
-  box-shadow:none !important;
-  padding:6px 30px 6px 0;
+.select--stroke{
+  padding:6px 30px 6px 12px;
+  box-shadow:inset 0 0 0 1px #ccc;
+}
+
+.select--stroke .select--s{
+  padding:3px 24px 3px 6px;
 }
 .select:disabled{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25);
-  background-color:rgba(127, 127, 127, 0.25);
-  border-color:transparent;
+  color:rgba(64, 64, 64, 0.45);
 }
 
 .select:disabled + .select-arrow{
@@ -8658,323 +8661,323 @@ textarea{
   background-color:transparent;
 }
 
-.select--border-gray + .select-arrow{
+.select--gray + .select-arrow{
   border-top-color:#666;
 }
 
-.select--border-gray:focus + .select-arrow{
+.select--gray:focus + .select-arrow{
   border-top-color:#2d2d2d;
 }
 
-.select--border-pink + .select-arrow{
+.select--pink + .select-arrow{
   border-top-color:#ff3c96;
 }
 
-.select--border-pink:focus + .select-arrow{
+.select--pink:focus + .select-arrow{
   border-top-color:#ab084b;
 }
 
-.select--border-red + .select-arrow{
+.select--red + .select-arrow{
   border-top-color:#dc2b28;
 }
 
-.select--border-red:focus + .select-arrow{
+.select--red:focus + .select-arrow{
   border-top-color:#a30003;
 }
 
-.select--border-orange + .select-arrow{
+.select--orange + .select-arrow{
   border-top-color:#ff6e00;
 }
 
-.select--border-orange:focus + .select-arrow{
+.select--orange:focus + .select-arrow{
   border-top-color:#bc3a00;
 }
 
-.select--border-yellow + .select-arrow{
+.select--yellow + .select-arrow{
   border-top-color:#f0dc00;
 }
 
-.select--border-yellow:focus + .select-arrow{
+.select--yellow:focus + .select-arrow{
   border-top-color:#d9a100;
 }
 
-.select--border-green + .select-arrow{
+.select--green + .select-arrow{
   border-top-color:#01aa46;
 }
 
-.select--border-green:focus + .select-arrow{
+.select--green:focus + .select-arrow{
   border-top-color:#006427;
 }
 
-.select--border-blue + .select-arrow{
+.select--blue + .select-arrow{
   border-top-color:#3887BE;
 }
 
-.select--border-blue:focus + .select-arrow{
+.select--blue:focus + .select-arrow{
   border-top-color:#223B53;
 }
 
-.select--border-purple + .select-arrow{
+.select--purple + .select-arrow{
   border-top-color:#8c50c7;
 }
 
-.select--border-purple:focus + .select-arrow{
+.select--purple:focus + .select-arrow{
   border-top-color:#440067;
 }
 
-.select--border-darken25 + .select-arrow{
+.select--darken25 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.25);
 }
 
-.select--border-darken25:focus + .select-arrow{
+.select--darken25:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
 }
 
-.select--border-darken50 + .select-arrow{
+.select--darken50 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
 }
 
-.select--border-darken50:focus + .select-arrow{
+.select--darken50:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
-.select--border-darken75 + .select-arrow{
+.select--darken75 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
-.select--border-darken75:focus + .select-arrow{
+.select--darken75:focus + .select-arrow{
   border-top-color:#000;
 }
 
-.select--border-lighten25 + .select-arrow{
+.select--lighten25 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.25);
 }
 
-.select--border-lighten25:focus + .select-arrow{
+.select--lighten25:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
-.select--border-lighten50 + .select-arrow{
+.select--lighten50 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
-.select--border-lighten50:focus + .select-arrow{
+.select--lighten50:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--border-lighten75 + .select-arrow{
+.select--lighten75 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--border-lighten75:focus + .select-arrow{
+.select--lighten75:focus + .select-arrow{
   border-top-color:#fff;
 }
 
-.select--border-white + .select-arrow{
+.select--white + .select-arrow{
   border-top-color:#fff;
 }
 
-.select--border-white:focus + .select-arrow{
+.select--white:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--border-transparent + .select-arrow{
+.select--transparent + .select-arrow{
   border-top-color:transparent;
 }
 
-.select--border-transparent:focus + .select-arrow{
+.select--transparent:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.1);
 }
 
 .textarea--border-gray,
 .input--border-gray,
-.select--border-gray{
+.select--stroke.select--gray{
   box-shadow:inset 0 0 0 1px #666;
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus,
-.select--border-gray:focus{
+.select--stroke.select--gray:focus{
   box-shadow:inset 0 0 0 1px #2d2d2d;
 }
 
 .textarea--border-pink,
 .input--border-pink,
-.select--border-pink{
+.select--stroke.select--pink{
   box-shadow:inset 0 0 0 1px #ff3c96;
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus,
-.select--border-pink:focus{
+.select--stroke.select--pink:focus{
   box-shadow:inset 0 0 0 1px #ab084b;
 }
 
 .textarea--border-red,
 .input--border-red,
-.select--border-red{
+.select--stroke.select--red{
   box-shadow:inset 0 0 0 1px #dc2b28;
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus,
-.select--border-red:focus{
+.select--stroke.select--red:focus{
   box-shadow:inset 0 0 0 1px #a30003;
 }
 
 .textarea--border-orange,
 .input--border-orange,
-.select--border-orange{
+.select--stroke.select--orange{
   box-shadow:inset 0 0 0 1px #ff6e00;
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus,
-.select--border-orange:focus{
+.select--stroke.select--orange:focus{
   box-shadow:inset 0 0 0 1px #bc3a00;
 }
 
 .textarea--border-yellow,
 .input--border-yellow,
-.select--border-yellow{
+.select--stroke.select--yellow{
   box-shadow:inset 0 0 0 1px #f0dc00;
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus,
-.select--border-yellow:focus{
+.select--stroke.select--yellow:focus{
   box-shadow:inset 0 0 0 1px #d9a100;
 }
 
 .textarea--border-green,
 .input--border-green,
-.select--border-green{
+.select--stroke.select--green{
   box-shadow:inset 0 0 0 1px #01aa46;
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus,
-.select--border-green:focus{
+.select--stroke.select--green:focus{
   box-shadow:inset 0 0 0 1px #006427;
 }
 
 .textarea--border-blue,
 .input--border-blue,
-.select--border-blue{
+.select--stroke.select--blue{
   box-shadow:inset 0 0 0 1px #3887BE;
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus,
-.select--border-blue:focus{
+.select--stroke.select--blue:focus{
   box-shadow:inset 0 0 0 1px #223B53;
 }
 
 .textarea--border-purple,
 .input--border-purple,
-.select--border-purple{
+.select--stroke.select--purple{
   box-shadow:inset 0 0 0 1px #8c50c7;
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus,
-.select--border-purple:focus{
+.select--stroke.select--purple:focus{
   box-shadow:inset 0 0 0 1px #440067;
 }
 
 .textarea--border-darken25,
 .input--border-darken25,
-.select--border-darken25{
+.select--stroke.select--darken25{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus,
-.select--border-darken25:focus{
+.select--stroke.select--darken25:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50,
 .input--border-darken50,
-.select--border-darken50{
+.select--stroke.select--darken50{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus,
-.select--border-darken50:focus{
+.select--stroke.select--darken50:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75,
-.select--border-darken75{
+.select--stroke.select--darken75{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus,
-.select--border-darken75:focus{
+.select--stroke.select--darken75:focus{
   box-shadow:inset 0 0 0 1px #000;
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25,
-.select--border-lighten25{
+.select--stroke.select--lighten25{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus,
-.select--border-lighten25:focus{
+.select--stroke.select--lighten25:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50,
-.select--border-lighten50{
+.select--stroke.select--lighten50{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus,
-.select--border-lighten50:focus{
+.select--stroke.select--lighten50:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75,
-.select--border-lighten75{
+.select--stroke.select--lighten75{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus,
-.select--border-lighten75:focus{
+.select--stroke.select--lighten75:focus{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white,
 .input--border-white,
-.select--border-white{
+.select--stroke.select--white{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus,
-.select--border-white:focus{
+.select--stroke.select--white:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent,
-.select--border-transparent{
+.select--stroke.select--transparent{
   box-shadow:inset 0 0 0 1px transparent;
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus,
-.select--border-transparent:focus{
+.select--stroke.select--transparent:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 
@@ -12310,7 +12313,7 @@ legend{
 
 .input:focus,
 .textarea:focus,
-.select:focus{
+.select:focus .select--stroke{
   box-shadow:inset 0 0 0 1px #666;
 }
 
@@ -12349,11 +12352,11 @@ legend{
 }
 .input:disabled,
 .textarea:disabled,
-.select:disabled{
+.select--stroke:disabled{
   pointer-events:none;
   color:rgba(0, 0, 0, 0.5);
   background-color:rgba(127, 127, 127, 0.1);
-  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25);
+  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25) !important;
 }
 .input[readonly],
 .textarea[readonly]{
@@ -12372,8 +12375,9 @@ legend{
   font-size:16px;
   line-height:24px;
   color:currentColor;
-  padding:6px 30px 6px 12px;
+  padding:6px 30px 6px 0;
   cursor:pointer;
+  box-shadow:none;
 }
 
 .select-arrow{
@@ -12390,7 +12394,7 @@ legend{
   transition:border-top-color 0.125s;
 }
 
-.select:focus + .select-arrow{
+.select .select--stroke:focus + .select-arrow{
   border-top-color:#666;
 }
 .select option{
@@ -12418,21 +12422,23 @@ legend{
 .select--s{
   font-size:12px;
   line-height:18px;
-  padding:3px 24px 3px 6px;
+  padding:3px 24px 3px 0;
 }
 
 .select--s + .select-arrow{
   right:8px;
 }
-.select--border-0{
-  box-shadow:none !important;
-  padding:6px 30px 6px 0;
+.select--stroke{
+  padding:6px 30px 6px 12px;
+  box-shadow:inset 0 0 0 1px #ccc;
+}
+
+.select--stroke .select--s{
+  padding:3px 24px 3px 6px;
 }
 .select:disabled{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25);
-  background-color:rgba(127, 127, 127, 0.25);
-  border-color:transparent;
+  color:rgba(64, 64, 64, 0.45);
 }
 
 .select:disabled + .select-arrow{
@@ -20536,323 +20542,323 @@ textarea{
   background-color:transparent;
 }
 
-.select--border-gray + .select-arrow{
+.select--gray + .select-arrow{
   border-top-color:#666;
 }
 
-.select--border-gray:focus + .select-arrow{
+.select--gray:focus + .select-arrow{
   border-top-color:#2d2d2d;
 }
 
-.select--border-pink + .select-arrow{
+.select--pink + .select-arrow{
   border-top-color:#ff3c96;
 }
 
-.select--border-pink:focus + .select-arrow{
+.select--pink:focus + .select-arrow{
   border-top-color:#ab084b;
 }
 
-.select--border-red + .select-arrow{
+.select--red + .select-arrow{
   border-top-color:#dc2b28;
 }
 
-.select--border-red:focus + .select-arrow{
+.select--red:focus + .select-arrow{
   border-top-color:#a30003;
 }
 
-.select--border-orange + .select-arrow{
+.select--orange + .select-arrow{
   border-top-color:#ff6e00;
 }
 
-.select--border-orange:focus + .select-arrow{
+.select--orange:focus + .select-arrow{
   border-top-color:#bc3a00;
 }
 
-.select--border-yellow + .select-arrow{
+.select--yellow + .select-arrow{
   border-top-color:#f0dc00;
 }
 
-.select--border-yellow:focus + .select-arrow{
+.select--yellow:focus + .select-arrow{
   border-top-color:#d9a100;
 }
 
-.select--border-green + .select-arrow{
+.select--green + .select-arrow{
   border-top-color:#01aa46;
 }
 
-.select--border-green:focus + .select-arrow{
+.select--green:focus + .select-arrow{
   border-top-color:#006427;
 }
 
-.select--border-blue + .select-arrow{
+.select--blue + .select-arrow{
   border-top-color:#448ee4;
 }
 
-.select--border-blue:focus + .select-arrow{
+.select--blue:focus + .select-arrow{
   border-top-color:#295b97;
 }
 
-.select--border-purple + .select-arrow{
+.select--purple + .select-arrow{
   border-top-color:#8c50c7;
 }
 
-.select--border-purple:focus + .select-arrow{
+.select--purple:focus + .select-arrow{
   border-top-color:#440067;
 }
 
-.select--border-darken25 + .select-arrow{
+.select--darken25 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.25);
 }
 
-.select--border-darken25:focus + .select-arrow{
+.select--darken25:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
 }
 
-.select--border-darken50 + .select-arrow{
+.select--darken50 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
 }
 
-.select--border-darken50:focus + .select-arrow{
+.select--darken50:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
-.select--border-darken75 + .select-arrow{
+.select--darken75 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
-.select--border-darken75:focus + .select-arrow{
+.select--darken75:focus + .select-arrow{
   border-top-color:#000;
 }
 
-.select--border-lighten25 + .select-arrow{
+.select--lighten25 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.25);
 }
 
-.select--border-lighten25:focus + .select-arrow{
+.select--lighten25:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
-.select--border-lighten50 + .select-arrow{
+.select--lighten50 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
-.select--border-lighten50:focus + .select-arrow{
+.select--lighten50:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--border-lighten75 + .select-arrow{
+.select--lighten75 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--border-lighten75:focus + .select-arrow{
+.select--lighten75:focus + .select-arrow{
   border-top-color:#fff;
 }
 
-.select--border-white + .select-arrow{
+.select--white + .select-arrow{
   border-top-color:#fff;
 }
 
-.select--border-white:focus + .select-arrow{
+.select--white:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
 }
 
-.select--border-transparent + .select-arrow{
+.select--transparent + .select-arrow{
   border-top-color:transparent;
 }
 
-.select--border-transparent:focus + .select-arrow{
+.select--transparent:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.1);
 }
 
 .textarea--border-gray,
 .input--border-gray,
-.select--border-gray{
+.select--stroke.select--gray{
   box-shadow:inset 0 0 0 1px #666;
 }
 
 .textarea--border-gray:focus,
 .input--border-gray:focus,
-.select--border-gray:focus{
+.select--stroke.select--gray:focus{
   box-shadow:inset 0 0 0 1px #2d2d2d;
 }
 
 .textarea--border-pink,
 .input--border-pink,
-.select--border-pink{
+.select--stroke.select--pink{
   box-shadow:inset 0 0 0 1px #ff3c96;
 }
 
 .textarea--border-pink:focus,
 .input--border-pink:focus,
-.select--border-pink:focus{
+.select--stroke.select--pink:focus{
   box-shadow:inset 0 0 0 1px #ab084b;
 }
 
 .textarea--border-red,
 .input--border-red,
-.select--border-red{
+.select--stroke.select--red{
   box-shadow:inset 0 0 0 1px #dc2b28;
 }
 
 .textarea--border-red:focus,
 .input--border-red:focus,
-.select--border-red:focus{
+.select--stroke.select--red:focus{
   box-shadow:inset 0 0 0 1px #a30003;
 }
 
 .textarea--border-orange,
 .input--border-orange,
-.select--border-orange{
+.select--stroke.select--orange{
   box-shadow:inset 0 0 0 1px #ff6e00;
 }
 
 .textarea--border-orange:focus,
 .input--border-orange:focus,
-.select--border-orange:focus{
+.select--stroke.select--orange:focus{
   box-shadow:inset 0 0 0 1px #bc3a00;
 }
 
 .textarea--border-yellow,
 .input--border-yellow,
-.select--border-yellow{
+.select--stroke.select--yellow{
   box-shadow:inset 0 0 0 1px #f0dc00;
 }
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus,
-.select--border-yellow:focus{
+.select--stroke.select--yellow:focus{
   box-shadow:inset 0 0 0 1px #d9a100;
 }
 
 .textarea--border-green,
 .input--border-green,
-.select--border-green{
+.select--stroke.select--green{
   box-shadow:inset 0 0 0 1px #01aa46;
 }
 
 .textarea--border-green:focus,
 .input--border-green:focus,
-.select--border-green:focus{
+.select--stroke.select--green:focus{
   box-shadow:inset 0 0 0 1px #006427;
 }
 
 .textarea--border-blue,
 .input--border-blue,
-.select--border-blue{
+.select--stroke.select--blue{
   box-shadow:inset 0 0 0 1px #448ee4;
 }
 
 .textarea--border-blue:focus,
 .input--border-blue:focus,
-.select--border-blue:focus{
+.select--stroke.select--blue:focus{
   box-shadow:inset 0 0 0 1px #295b97;
 }
 
 .textarea--border-purple,
 .input--border-purple,
-.select--border-purple{
+.select--stroke.select--purple{
   box-shadow:inset 0 0 0 1px #8c50c7;
 }
 
 .textarea--border-purple:focus,
 .input--border-purple:focus,
-.select--border-purple:focus{
+.select--stroke.select--purple:focus{
   box-shadow:inset 0 0 0 1px #440067;
 }
 
 .textarea--border-darken25,
 .input--border-darken25,
-.select--border-darken25{
+.select--stroke.select--darken25{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus,
-.select--border-darken25:focus{
+.select--stroke.select--darken25:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50,
 .input--border-darken50,
-.select--border-darken50{
+.select--stroke.select--darken50{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus,
-.select--border-darken50:focus{
+.select--stroke.select--darken50:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75,
 .input--border-darken75,
-.select--border-darken75{
+.select--stroke.select--darken75{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
 }
 
 .textarea--border-darken75:focus,
 .input--border-darken75:focus,
-.select--border-darken75:focus{
+.select--stroke.select--darken75:focus{
   box-shadow:inset 0 0 0 1px #000;
 }
 
 .textarea--border-lighten25,
 .input--border-lighten25,
-.select--border-lighten25{
+.select--stroke.select--lighten25{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.25);
 }
 
 .textarea--border-lighten25:focus,
 .input--border-lighten25:focus,
-.select--border-lighten25:focus{
+.select--stroke.select--lighten25:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50,
 .input--border-lighten50,
-.select--border-lighten50{
+.select--stroke.select--lighten50{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .textarea--border-lighten50:focus,
 .input--border-lighten50:focus,
-.select--border-lighten50:focus{
+.select--stroke.select--lighten50:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75,
 .input--border-lighten75,
-.select--border-lighten75{
+.select--stroke.select--lighten75{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-lighten75:focus,
 .input--border-lighten75:focus,
-.select--border-lighten75:focus{
+.select--stroke.select--lighten75:focus{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white,
 .input--border-white,
-.select--border-white{
+.select--stroke.select--white{
   box-shadow:inset 0 0 0 1px #fff;
 }
 
 .textarea--border-white:focus,
 .input--border-white:focus,
-.select--border-white:focus{
+.select--stroke.select--white:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
 }
 
 .textarea--border-transparent,
 .input--border-transparent,
-.select--border-transparent{
+.select--stroke.select--transparent{
   box-shadow:inset 0 0 0 1px transparent;
 }
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus,
-.select--border-transparent:focus{
+.select--stroke.select--transparent:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }
 

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -421,6 +421,10 @@ legend{
   box-shadow:inset 0 0 0 1px #666;
 }
 
+.select.select--stroke:focus{
+  box-shadow:inset 0 0 0 1px #666, 0 0 0 3px rgba(137, 199, 216, 0.65);
+}
+
 .input::placeholder,
 .textarea::placeholder{
   color:rgba(64, 64, 64, 0.45);
@@ -12489,6 +12493,10 @@ legend{
 .input:focus,
 .textarea:focus{
   box-shadow:inset 0 0 0 1px #666;
+}
+
+.select.select--stroke:focus{
+  box-shadow:inset 0 0 0 1px #666, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .input::placeholder,

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -418,8 +418,12 @@ legend{
 
 .input:focus,
 .textarea:focus,
-.select:focus .select--stroke{
+.select.select--stroke:focus{
   box-shadow:inset 0 0 0 1px #666;
+}
+
+.select:focus{
+  box-shadow:none;
 }
 
 .input::placeholder,
@@ -492,14 +496,14 @@ legend{
   pointer-events:none;
   border-left:4px solid transparent;
   border-right:4px solid transparent;
-  border-top:5px solid #ccc;
+  border-top:5px solid #666;
   width:8px;
   height:8px;
   margin-top:-1px;
   transition:border-top-color 0.125s;
 }
 
-.select .select--stroke:focus + .select-arrow{
+.select:focus + .select-arrow{
   border-top-color:#666;
 }
 .select option{
@@ -8661,12 +8665,28 @@ textarea{
   background-color:transparent;
 }
 
+.select--gray{
+  color:#666;
+}
+
+.select--gray:focus{
+  color:#2d2d2d;
+}
+
 .select--gray + .select-arrow{
   border-top-color:#666;
 }
 
 .select--gray:focus + .select-arrow{
   border-top-color:#2d2d2d;
+}
+
+.select--pink{
+  color:#ff3c96;
+}
+
+.select--pink:focus{
+  color:#ab084b;
 }
 
 .select--pink + .select-arrow{
@@ -8677,12 +8697,28 @@ textarea{
   border-top-color:#ab084b;
 }
 
+.select--red{
+  color:#dc2b28;
+}
+
+.select--red:focus{
+  color:#a30003;
+}
+
 .select--red + .select-arrow{
   border-top-color:#dc2b28;
 }
 
 .select--red:focus + .select-arrow{
   border-top-color:#a30003;
+}
+
+.select--orange{
+  color:#ff6e00;
+}
+
+.select--orange:focus{
+  color:#bc3a00;
 }
 
 .select--orange + .select-arrow{
@@ -8693,12 +8729,28 @@ textarea{
   border-top-color:#bc3a00;
 }
 
+.select--yellow{
+  color:#f0dc00;
+}
+
+.select--yellow:focus{
+  color:#d9a100;
+}
+
 .select--yellow + .select-arrow{
   border-top-color:#f0dc00;
 }
 
 .select--yellow:focus + .select-arrow{
   border-top-color:#d9a100;
+}
+
+.select--green{
+  color:#01aa46;
+}
+
+.select--green:focus{
+  color:#006427;
 }
 
 .select--green + .select-arrow{
@@ -8709,12 +8761,28 @@ textarea{
   border-top-color:#006427;
 }
 
+.select--blue{
+  color:#3887BE;
+}
+
+.select--blue:focus{
+  color:#223B53;
+}
+
 .select--blue + .select-arrow{
   border-top-color:#3887BE;
 }
 
 .select--blue:focus + .select-arrow{
   border-top-color:#223B53;
+}
+
+.select--purple{
+  color:#8c50c7;
+}
+
+.select--purple:focus{
+  color:#440067;
 }
 
 .select--purple + .select-arrow{
@@ -8725,12 +8793,28 @@ textarea{
   border-top-color:#440067;
 }
 
+.select--darken25{
+  color:rgba(0, 0, 0, 0.25);
+}
+
+.select--darken25:focus{
+  color:rgba(0, 0, 0, 0.5);
+}
+
 .select--darken25 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.25);
 }
 
 .select--darken25:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
+}
+
+.select--darken50{
+  color:rgba(0, 0, 0, 0.5);
+}
+
+.select--darken50:focus{
+  color:rgba(0, 0, 0, 0.75);
 }
 
 .select--darken50 + .select-arrow{
@@ -8741,12 +8825,28 @@ textarea{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
+.select--darken75{
+  color:rgba(0, 0, 0, 0.75);
+}
+
+.select--darken75:focus{
+  color:#000;
+}
+
 .select--darken75 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
 .select--darken75:focus + .select-arrow{
   border-top-color:#000;
+}
+
+.select--lighten25{
+  color:rgba(255, 255, 255, 0.25);
+}
+
+.select--lighten25:focus{
+  color:rgba(255, 255, 255, 0.5);
 }
 
 .select--lighten25 + .select-arrow{
@@ -8757,12 +8857,28 @@ textarea{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
+.select--lighten50{
+  color:rgba(255, 255, 255, 0.5);
+}
+
+.select--lighten50:focus{
+  color:rgba(255, 255, 255, 0.75);
+}
+
 .select--lighten50 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
 .select--lighten50:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
+}
+
+.select--lighten75{
+  color:rgba(255, 255, 255, 0.75);
+}
+
+.select--lighten75:focus{
+  color:#fff;
 }
 
 .select--lighten75 + .select-arrow{
@@ -8773,12 +8889,28 @@ textarea{
   border-top-color:#fff;
 }
 
+.select--white{
+  color:#fff;
+}
+
+.select--white:focus{
+  color:rgba(255, 255, 255, 0.75);
+}
+
 .select--white + .select-arrow{
   border-top-color:#fff;
 }
 
 .select--white:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
+}
+
+.select--transparent{
+  color:transparent;
+}
+
+.select--transparent:focus{
+  color:rgba(0, 0, 0, 0.1);
 }
 
 .select--transparent + .select-arrow{
@@ -12313,8 +12445,12 @@ legend{
 
 .input:focus,
 .textarea:focus,
-.select:focus .select--stroke{
+.select.select--stroke:focus{
   box-shadow:inset 0 0 0 1px #666;
+}
+
+.select:focus{
+  box-shadow:none;
 }
 
 .input::placeholder,
@@ -12387,14 +12523,14 @@ legend{
   pointer-events:none;
   border-left:4px solid transparent;
   border-right:4px solid transparent;
-  border-top:5px solid #ccc;
+  border-top:5px solid #666;
   width:8px;
   height:8px;
   margin-top:-1px;
   transition:border-top-color 0.125s;
 }
 
-.select .select--stroke:focus + .select-arrow{
+.select:focus + .select-arrow{
   border-top-color:#666;
 }
 .select option{
@@ -20542,12 +20678,28 @@ textarea{
   background-color:transparent;
 }
 
+.select--gray{
+  color:#666;
+}
+
+.select--gray:focus{
+  color:#2d2d2d;
+}
+
 .select--gray + .select-arrow{
   border-top-color:#666;
 }
 
 .select--gray:focus + .select-arrow{
   border-top-color:#2d2d2d;
+}
+
+.select--pink{
+  color:#ff3c96;
+}
+
+.select--pink:focus{
+  color:#ab084b;
 }
 
 .select--pink + .select-arrow{
@@ -20558,12 +20710,28 @@ textarea{
   border-top-color:#ab084b;
 }
 
+.select--red{
+  color:#dc2b28;
+}
+
+.select--red:focus{
+  color:#a30003;
+}
+
 .select--red + .select-arrow{
   border-top-color:#dc2b28;
 }
 
 .select--red:focus + .select-arrow{
   border-top-color:#a30003;
+}
+
+.select--orange{
+  color:#ff6e00;
+}
+
+.select--orange:focus{
+  color:#bc3a00;
 }
 
 .select--orange + .select-arrow{
@@ -20574,12 +20742,28 @@ textarea{
   border-top-color:#bc3a00;
 }
 
+.select--yellow{
+  color:#f0dc00;
+}
+
+.select--yellow:focus{
+  color:#d9a100;
+}
+
 .select--yellow + .select-arrow{
   border-top-color:#f0dc00;
 }
 
 .select--yellow:focus + .select-arrow{
   border-top-color:#d9a100;
+}
+
+.select--green{
+  color:#01aa46;
+}
+
+.select--green:focus{
+  color:#006427;
 }
 
 .select--green + .select-arrow{
@@ -20590,12 +20774,28 @@ textarea{
   border-top-color:#006427;
 }
 
+.select--blue{
+  color:#448ee4;
+}
+
+.select--blue:focus{
+  color:#295b97;
+}
+
 .select--blue + .select-arrow{
   border-top-color:#448ee4;
 }
 
 .select--blue:focus + .select-arrow{
   border-top-color:#295b97;
+}
+
+.select--purple{
+  color:#8c50c7;
+}
+
+.select--purple:focus{
+  color:#440067;
 }
 
 .select--purple + .select-arrow{
@@ -20606,12 +20806,28 @@ textarea{
   border-top-color:#440067;
 }
 
+.select--darken25{
+  color:rgba(0, 0, 0, 0.25);
+}
+
+.select--darken25:focus{
+  color:rgba(0, 0, 0, 0.5);
+}
+
 .select--darken25 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.25);
 }
 
 .select--darken25:focus + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.5);
+}
+
+.select--darken50{
+  color:rgba(0, 0, 0, 0.5);
+}
+
+.select--darken50:focus{
+  color:rgba(0, 0, 0, 0.75);
 }
 
 .select--darken50 + .select-arrow{
@@ -20622,12 +20838,28 @@ textarea{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
+.select--darken75{
+  color:rgba(0, 0, 0, 0.75);
+}
+
+.select--darken75:focus{
+  color:#000;
+}
+
 .select--darken75 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
 
 .select--darken75:focus + .select-arrow{
   border-top-color:#000;
+}
+
+.select--lighten25{
+  color:rgba(255, 255, 255, 0.25);
+}
+
+.select--lighten25:focus{
+  color:rgba(255, 255, 255, 0.5);
 }
 
 .select--lighten25 + .select-arrow{
@@ -20638,12 +20870,28 @@ textarea{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
+.select--lighten50{
+  color:rgba(255, 255, 255, 0.5);
+}
+
+.select--lighten50:focus{
+  color:rgba(255, 255, 255, 0.75);
+}
+
 .select--lighten50 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
 
 .select--lighten50:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
+}
+
+.select--lighten75{
+  color:rgba(255, 255, 255, 0.75);
+}
+
+.select--lighten75:focus{
+  color:#fff;
 }
 
 .select--lighten75 + .select-arrow{
@@ -20654,12 +20902,28 @@ textarea{
   border-top-color:#fff;
 }
 
+.select--white{
+  color:#fff;
+}
+
+.select--white:focus{
+  color:rgba(255, 255, 255, 0.75);
+}
+
 .select--white + .select-arrow{
   border-top-color:#fff;
 }
 
 .select--white:focus + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.75);
+}
+
+.select--transparent{
+  color:transparent;
+}
+
+.select--transparent:focus{
+  color:rgba(0, 0, 0, 0.1);
 }
 
 .select--transparent + .select-arrow{

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -417,13 +417,8 @@ legend{
 }
 
 .input:focus,
-.textarea:focus,
-.select.select--stroke:focus{
+.textarea:focus{
   box-shadow:inset 0 0 0 1px #666;
-}
-
-.select:focus{
-  box-shadow:none;
 }
 
 .input::placeholder,
@@ -8928,9 +8923,12 @@ textarea{
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus,
-.select--stroke.select--gray:focus{
+.input--border-gray:focus{
   box-shadow:inset 0 0 0 1px #2d2d2d;
+}
+
+.select--stroke.select--gray:focus{
+  box-shadow:inset 0 0 0 1px #2d2d2d, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-pink,
@@ -8940,9 +8938,12 @@ textarea{
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus,
-.select--stroke.select--pink:focus{
+.input--border-pink:focus{
   box-shadow:inset 0 0 0 1px #ab084b;
+}
+
+.select--stroke.select--pink:focus{
+  box-shadow:inset 0 0 0 1px #ab084b, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-red,
@@ -8952,9 +8953,12 @@ textarea{
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus,
-.select--stroke.select--red:focus{
+.input--border-red:focus{
   box-shadow:inset 0 0 0 1px #a30003;
+}
+
+.select--stroke.select--red:focus{
+  box-shadow:inset 0 0 0 1px #a30003, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-orange,
@@ -8964,9 +8968,12 @@ textarea{
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus,
-.select--stroke.select--orange:focus{
+.input--border-orange:focus{
   box-shadow:inset 0 0 0 1px #bc3a00;
+}
+
+.select--stroke.select--orange:focus{
+  box-shadow:inset 0 0 0 1px #bc3a00, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-yellow,
@@ -8976,9 +8983,12 @@ textarea{
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus,
-.select--stroke.select--yellow:focus{
+.input--border-yellow:focus{
   box-shadow:inset 0 0 0 1px #d9a100;
+}
+
+.select--stroke.select--yellow:focus{
+  box-shadow:inset 0 0 0 1px #d9a100, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-green,
@@ -8988,9 +8998,12 @@ textarea{
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus,
-.select--stroke.select--green:focus{
+.input--border-green:focus{
   box-shadow:inset 0 0 0 1px #006427;
+}
+
+.select--stroke.select--green:focus{
+  box-shadow:inset 0 0 0 1px #006427, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-blue,
@@ -9000,9 +9013,12 @@ textarea{
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus,
-.select--stroke.select--blue:focus{
+.input--border-blue:focus{
   box-shadow:inset 0 0 0 1px #223B53;
+}
+
+.select--stroke.select--blue:focus{
+  box-shadow:inset 0 0 0 1px #223B53, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-purple,
@@ -9012,9 +9028,12 @@ textarea{
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus,
-.select--stroke.select--purple:focus{
+.input--border-purple:focus{
   box-shadow:inset 0 0 0 1px #440067;
+}
+
+.select--stroke.select--purple:focus{
+  box-shadow:inset 0 0 0 1px #440067, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken25,
@@ -9024,9 +9043,12 @@ textarea{
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus,
-.select--stroke.select--darken25:focus{
+.input--border-darken25:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+}
+
+.select--stroke.select--darken25:focus{
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken50,
@@ -9036,9 +9058,12 @@ textarea{
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus,
-.select--stroke.select--darken50:focus{
+.input--border-darken50:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
+}
+
+.select--stroke.select--darken50:focus{
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken75,
@@ -9048,9 +9073,12 @@ textarea{
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus,
-.select--stroke.select--darken75:focus{
+.input--border-darken75:focus{
   box-shadow:inset 0 0 0 1px #000;
+}
+
+.select--stroke.select--darken75:focus{
+  box-shadow:inset 0 0 0 1px #000, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-lighten25,
@@ -9060,9 +9088,12 @@ textarea{
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus,
-.select--stroke.select--lighten25:focus{
+.input--border-lighten25:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+}
+
+.select--stroke.select--lighten25:focus{
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-lighten50,
@@ -9072,9 +9103,12 @@ textarea{
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus,
-.select--stroke.select--lighten50:focus{
+.input--border-lighten50:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
+}
+
+.select--stroke.select--lighten50:focus{
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-lighten75,
@@ -9084,9 +9118,12 @@ textarea{
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus,
-.select--stroke.select--lighten75:focus{
+.input--border-lighten75:focus{
   box-shadow:inset 0 0 0 1px #fff;
+}
+
+.select--stroke.select--lighten75:focus{
+  box-shadow:inset 0 0 0 1px #fff, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-white,
@@ -9096,9 +9133,12 @@ textarea{
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus,
-.select--stroke.select--white:focus{
+.input--border-white:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
+}
+
+.select--stroke.select--white:focus{
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-transparent,
@@ -9108,9 +9148,12 @@ textarea{
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus,
-.select--stroke.select--transparent:focus{
+.input--border-transparent:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.select--stroke.select--transparent:focus{
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .checkbox--gray{
@@ -12444,13 +12487,8 @@ legend{
 }
 
 .input:focus,
-.textarea:focus,
-.select.select--stroke:focus{
+.textarea:focus{
   box-shadow:inset 0 0 0 1px #666;
-}
-
-.select:focus{
-  box-shadow:none;
 }
 
 .input::placeholder,
@@ -20941,9 +20979,12 @@ textarea{
 }
 
 .textarea--border-gray:focus,
-.input--border-gray:focus,
-.select--stroke.select--gray:focus{
+.input--border-gray:focus{
   box-shadow:inset 0 0 0 1px #2d2d2d;
+}
+
+.select--stroke.select--gray:focus{
+  box-shadow:inset 0 0 0 1px #2d2d2d, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-pink,
@@ -20953,9 +20994,12 @@ textarea{
 }
 
 .textarea--border-pink:focus,
-.input--border-pink:focus,
-.select--stroke.select--pink:focus{
+.input--border-pink:focus{
   box-shadow:inset 0 0 0 1px #ab084b;
+}
+
+.select--stroke.select--pink:focus{
+  box-shadow:inset 0 0 0 1px #ab084b, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-red,
@@ -20965,9 +21009,12 @@ textarea{
 }
 
 .textarea--border-red:focus,
-.input--border-red:focus,
-.select--stroke.select--red:focus{
+.input--border-red:focus{
   box-shadow:inset 0 0 0 1px #a30003;
+}
+
+.select--stroke.select--red:focus{
+  box-shadow:inset 0 0 0 1px #a30003, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-orange,
@@ -20977,9 +21024,12 @@ textarea{
 }
 
 .textarea--border-orange:focus,
-.input--border-orange:focus,
-.select--stroke.select--orange:focus{
+.input--border-orange:focus{
   box-shadow:inset 0 0 0 1px #bc3a00;
+}
+
+.select--stroke.select--orange:focus{
+  box-shadow:inset 0 0 0 1px #bc3a00, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-yellow,
@@ -20989,9 +21039,12 @@ textarea{
 }
 
 .textarea--border-yellow:focus,
-.input--border-yellow:focus,
-.select--stroke.select--yellow:focus{
+.input--border-yellow:focus{
   box-shadow:inset 0 0 0 1px #d9a100;
+}
+
+.select--stroke.select--yellow:focus{
+  box-shadow:inset 0 0 0 1px #d9a100, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-green,
@@ -21001,9 +21054,12 @@ textarea{
 }
 
 .textarea--border-green:focus,
-.input--border-green:focus,
-.select--stroke.select--green:focus{
+.input--border-green:focus{
   box-shadow:inset 0 0 0 1px #006427;
+}
+
+.select--stroke.select--green:focus{
+  box-shadow:inset 0 0 0 1px #006427, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-blue,
@@ -21013,9 +21069,12 @@ textarea{
 }
 
 .textarea--border-blue:focus,
-.input--border-blue:focus,
-.select--stroke.select--blue:focus{
+.input--border-blue:focus{
   box-shadow:inset 0 0 0 1px #295b97;
+}
+
+.select--stroke.select--blue:focus{
+  box-shadow:inset 0 0 0 1px #295b97, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-purple,
@@ -21025,9 +21084,12 @@ textarea{
 }
 
 .textarea--border-purple:focus,
-.input--border-purple:focus,
-.select--stroke.select--purple:focus{
+.input--border-purple:focus{
   box-shadow:inset 0 0 0 1px #440067;
+}
+
+.select--stroke.select--purple:focus{
+  box-shadow:inset 0 0 0 1px #440067, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken25,
@@ -21037,9 +21099,12 @@ textarea{
 }
 
 .textarea--border-darken25:focus,
-.input--border-darken25:focus,
-.select--stroke.select--darken25:focus{
+.input--border-darken25:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+}
+
+.select--stroke.select--darken25:focus{
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken50,
@@ -21049,9 +21114,12 @@ textarea{
 }
 
 .textarea--border-darken50:focus,
-.input--border-darken50:focus,
-.select--stroke.select--darken50:focus{
+.input--border-darken50:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
+}
+
+.select--stroke.select--darken50:focus{
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken75,
@@ -21061,9 +21129,12 @@ textarea{
 }
 
 .textarea--border-darken75:focus,
-.input--border-darken75:focus,
-.select--stroke.select--darken75:focus{
+.input--border-darken75:focus{
   box-shadow:inset 0 0 0 1px #000;
+}
+
+.select--stroke.select--darken75:focus{
+  box-shadow:inset 0 0 0 1px #000, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-lighten25,
@@ -21073,9 +21144,12 @@ textarea{
 }
 
 .textarea--border-lighten25:focus,
-.input--border-lighten25:focus,
-.select--stroke.select--lighten25:focus{
+.input--border-lighten25:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+}
+
+.select--stroke.select--lighten25:focus{
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-lighten50,
@@ -21085,9 +21159,12 @@ textarea{
 }
 
 .textarea--border-lighten50:focus,
-.input--border-lighten50:focus,
-.select--stroke.select--lighten50:focus{
+.input--border-lighten50:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
+}
+
+.select--stroke.select--lighten50:focus{
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-lighten75,
@@ -21097,9 +21174,12 @@ textarea{
 }
 
 .textarea--border-lighten75:focus,
-.input--border-lighten75:focus,
-.select--stroke.select--lighten75:focus{
+.input--border-lighten75:focus{
   box-shadow:inset 0 0 0 1px #fff;
+}
+
+.select--stroke.select--lighten75:focus{
+  box-shadow:inset 0 0 0 1px #fff, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-white,
@@ -21109,9 +21189,12 @@ textarea{
 }
 
 .textarea--border-white:focus,
-.input--border-white:focus,
-.select--stroke.select--white:focus{
+.input--border-white:focus{
   box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75);
+}
+
+.select--stroke.select--white:focus{
+  box-shadow:inset 0 0 0 1px rgba(255, 255, 255, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-transparent,
@@ -21121,9 +21204,12 @@ textarea{
 }
 
 .textarea--border-transparent:focus,
-.input--border-transparent:focus,
-.select--stroke.select--transparent:focus{
+.input--border-transparent:focus{
   box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.select--stroke.select--transparent:focus{
+  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .checkbox--gray{

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -502,6 +502,10 @@ legend{
   transition:border-top-color 0.125s;
 }
 
+.select:hover{
+  color:#2d2d2d;
+}
+
 .select:focus + .select-arrow{
   border-top-color:#666;
 }
@@ -539,6 +543,7 @@ legend{
 .select--stroke{
   padding:6px 30px 6px 12px;
   box-shadow:inset 0 0 0 1px #ccc;
+  color:#666 !important;
 }
 
 .select--stroke .select--s{
@@ -8672,6 +8677,10 @@ textarea{
   color:#2d2d2d;
 }
 
+.select--gray:hover{
+  color:#2d2d2d;
+}
+
 .select--gray + .select-arrow{
   border-top-color:#666;
 }
@@ -8685,6 +8694,10 @@ textarea{
 }
 
 .select--pink:focus{
+  color:#ab084b;
+}
+
+.select--pink:hover{
   color:#ab084b;
 }
 
@@ -8704,6 +8717,10 @@ textarea{
   color:#a30003;
 }
 
+.select--red:hover{
+  color:#a30003;
+}
+
 .select--red + .select-arrow{
   border-top-color:#dc2b28;
 }
@@ -8717,6 +8734,10 @@ textarea{
 }
 
 .select--orange:focus{
+  color:#bc3a00;
+}
+
+.select--orange:hover{
   color:#bc3a00;
 }
 
@@ -8736,6 +8757,10 @@ textarea{
   color:#d9a100;
 }
 
+.select--yellow:hover{
+  color:#d9a100;
+}
+
 .select--yellow + .select-arrow{
   border-top-color:#f0dc00;
 }
@@ -8749,6 +8774,10 @@ textarea{
 }
 
 .select--green:focus{
+  color:#006427;
+}
+
+.select--green:hover{
   color:#006427;
 }
 
@@ -8768,6 +8797,10 @@ textarea{
   color:#223B53;
 }
 
+.select--blue:hover{
+  color:#223B53;
+}
+
 .select--blue + .select-arrow{
   border-top-color:#3887BE;
 }
@@ -8781,6 +8814,10 @@ textarea{
 }
 
 .select--purple:focus{
+  color:#440067;
+}
+
+.select--purple:hover{
   color:#440067;
 }
 
@@ -8800,6 +8837,10 @@ textarea{
   color:rgba(0, 0, 0, 0.5);
 }
 
+.select--darken25:hover{
+  color:rgba(0, 0, 0, 0.5);
+}
+
 .select--darken25 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.25);
 }
@@ -8813,6 +8854,10 @@ textarea{
 }
 
 .select--darken50:focus{
+  color:rgba(0, 0, 0, 0.75);
+}
+
+.select--darken50:hover{
   color:rgba(0, 0, 0, 0.75);
 }
 
@@ -8832,6 +8877,10 @@ textarea{
   color:#000;
 }
 
+.select--darken75:hover{
+  color:#000;
+}
+
 .select--darken75 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
@@ -8845,6 +8894,10 @@ textarea{
 }
 
 .select--lighten25:focus{
+  color:rgba(255, 255, 255, 0.5);
+}
+
+.select--lighten25:hover{
   color:rgba(255, 255, 255, 0.5);
 }
 
@@ -8864,6 +8917,10 @@ textarea{
   color:rgba(255, 255, 255, 0.75);
 }
 
+.select--lighten50:hover{
+  color:rgba(255, 255, 255, 0.75);
+}
+
 .select--lighten50 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
@@ -8877,6 +8934,10 @@ textarea{
 }
 
 .select--lighten75:focus{
+  color:#fff;
+}
+
+.select--lighten75:hover{
   color:#fff;
 }
 
@@ -8896,6 +8957,10 @@ textarea{
   color:rgba(255, 255, 255, 0.75);
 }
 
+.select--white:hover{
+  color:rgba(255, 255, 255, 0.75);
+}
+
 .select--white + .select-arrow{
   border-top-color:#fff;
 }
@@ -8909,6 +8974,10 @@ textarea{
 }
 
 .select--transparent:focus{
+  color:rgba(0, 0, 0, 0.1);
+}
+
+.select--transparent:hover{
   color:rgba(0, 0, 0, 0.1);
 }
 
@@ -12576,6 +12645,10 @@ legend{
   transition:border-top-color 0.125s;
 }
 
+.select:hover{
+  color:#2d2d2d;
+}
+
 .select:focus + .select-arrow{
   border-top-color:#666;
 }
@@ -12613,6 +12686,7 @@ legend{
 .select--stroke{
   padding:6px 30px 6px 12px;
   box-shadow:inset 0 0 0 1px #ccc;
+  color:#666 !important;
 }
 
 .select--stroke .select--s{
@@ -20732,6 +20806,10 @@ textarea{
   color:#2d2d2d;
 }
 
+.select--gray:hover{
+  color:#2d2d2d;
+}
+
 .select--gray + .select-arrow{
   border-top-color:#666;
 }
@@ -20745,6 +20823,10 @@ textarea{
 }
 
 .select--pink:focus{
+  color:#ab084b;
+}
+
+.select--pink:hover{
   color:#ab084b;
 }
 
@@ -20764,6 +20846,10 @@ textarea{
   color:#a30003;
 }
 
+.select--red:hover{
+  color:#a30003;
+}
+
 .select--red + .select-arrow{
   border-top-color:#dc2b28;
 }
@@ -20777,6 +20863,10 @@ textarea{
 }
 
 .select--orange:focus{
+  color:#bc3a00;
+}
+
+.select--orange:hover{
   color:#bc3a00;
 }
 
@@ -20796,6 +20886,10 @@ textarea{
   color:#d9a100;
 }
 
+.select--yellow:hover{
+  color:#d9a100;
+}
+
 .select--yellow + .select-arrow{
   border-top-color:#f0dc00;
 }
@@ -20809,6 +20903,10 @@ textarea{
 }
 
 .select--green:focus{
+  color:#006427;
+}
+
+.select--green:hover{
   color:#006427;
 }
 
@@ -20828,6 +20926,10 @@ textarea{
   color:#295b97;
 }
 
+.select--blue:hover{
+  color:#295b97;
+}
+
 .select--blue + .select-arrow{
   border-top-color:#448ee4;
 }
@@ -20841,6 +20943,10 @@ textarea{
 }
 
 .select--purple:focus{
+  color:#440067;
+}
+
+.select--purple:hover{
   color:#440067;
 }
 
@@ -20860,6 +20966,10 @@ textarea{
   color:rgba(0, 0, 0, 0.5);
 }
 
+.select--darken25:hover{
+  color:rgba(0, 0, 0, 0.5);
+}
+
 .select--darken25 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.25);
 }
@@ -20873,6 +20983,10 @@ textarea{
 }
 
 .select--darken50:focus{
+  color:rgba(0, 0, 0, 0.75);
+}
+
+.select--darken50:hover{
   color:rgba(0, 0, 0, 0.75);
 }
 
@@ -20892,6 +21006,10 @@ textarea{
   color:#000;
 }
 
+.select--darken75:hover{
+  color:#000;
+}
+
 .select--darken75 + .select-arrow{
   border-top-color:rgba(0, 0, 0, 0.75);
 }
@@ -20905,6 +21023,10 @@ textarea{
 }
 
 .select--lighten25:focus{
+  color:rgba(255, 255, 255, 0.5);
+}
+
+.select--lighten25:hover{
   color:rgba(255, 255, 255, 0.5);
 }
 
@@ -20924,6 +21046,10 @@ textarea{
   color:rgba(255, 255, 255, 0.75);
 }
 
+.select--lighten50:hover{
+  color:rgba(255, 255, 255, 0.75);
+}
+
 .select--lighten50 + .select-arrow{
   border-top-color:rgba(255, 255, 255, 0.5);
 }
@@ -20937,6 +21063,10 @@ textarea{
 }
 
 .select--lighten75:focus{
+  color:#fff;
+}
+
+.select--lighten75:hover{
   color:#fff;
 }
 
@@ -20956,6 +21086,10 @@ textarea{
   color:rgba(255, 255, 255, 0.75);
 }
 
+.select--white:hover{
+  color:rgba(255, 255, 255, 0.75);
+}
+
 .select--white + .select-arrow{
   border-top-color:#fff;
 }
@@ -20969,6 +21103,10 @@ textarea{
 }
 
 .select--transparent:focus{
+  color:rgba(0, 0, 0, 0.1);
+}
+
+.select--transparent:hover{
   color:rgba(0, 0, 0, 0.1);
 }
 

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -421,7 +421,7 @@ legend{
   box-shadow:inset 0 0 0 1px #666;
 }
 
-.select.select--stroke:focus{
+[data-assembly-focus-control='visible'] .select.select--stroke:focus{
   box-shadow:inset 0 0 0 1px #666, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -12564,7 +12564,7 @@ legend{
   box-shadow:inset 0 0 0 1px #666;
 }
 
-.select.select--stroke:focus{
+[data-assembly-focus-control='visible'] .select.select--stroke:focus{
   box-shadow:inset 0 0 0 1px #666, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 


### PR DESCRIPTION
Closes https://github.com/mapbox/assembly/issues/982

This PR adds the ~`select--border-0` modifier class to support borderless select elements out-of-the-box. It removes the `select`'s default box-shadow and left padding.~ `select--stroke` modifier and updates select elements to be unstroked by default.

@samanpwbb for review -- I'm curious if you think the padding right of the `select-arrow` should also be reduced or removed, in which case there would be some additional work to be done here.