### PR TITLE
Rework range input

### DIFF
--- a/src/focus.css
+++ b/src/focus.css
@@ -16,22 +16,22 @@
 }
 
 /* Range focus */
-[data-assembly-focus-control='visible'] input[type=range] {
+[data-assembly-focus-control='visible'] .range input[type=range] {
   box-shadow: none;
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-webkit-slider-thumb {
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-webkit-slider-thumb {
   box-shadow: var(--focus-shadow);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-upper {
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-fill-upper {
   box-shadow: var(--focus-shadow);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-lower {
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-fill-lower {
   box-shadow: var(--focus-shadow);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-thumb {
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-thumb {
   box-shadow: var(--focus-shadow);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-moz-range-thumb {
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-moz-range-thumb {
   box-shadow: var(--focus-shadow);
 }
 

--- a/src/focus.css
+++ b/src/focus.css
@@ -16,22 +16,22 @@
 }
 
 /* Range focus */
-[data-assembly-focus-control='visible'] .range {
+[data-assembly-focus-control='visible'] input[type=range] {
   box-shadow: none;
 }
-[data-assembly-focus-control='visible'] .range:focus::-webkit-slider-thumb {
+[data-assembly-focus-control='visible'] input[type=range]:focus::-webkit-slider-thumb {
   box-shadow: var(--focus-shadow);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-fill-upper {
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-upper {
   box-shadow: var(--focus-shadow);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-fill-lower {
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-lower {
   box-shadow: var(--focus-shadow);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-thumb {
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-thumb {
   box-shadow: var(--focus-shadow);
 }
-[data-assembly-focus-control='visible'] .range:focus::-moz-range-thumb {
+[data-assembly-focus-control='visible'] input[type=range]:focus::-moz-range-thumb {
   box-shadow: var(--focus-shadow);
 }
 

--- a/src/forms.css
+++ b/src/forms.css
@@ -328,6 +328,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   margin: 0;
   border: 0;
   background: var(--transparent);
+  cursor: pointer;
 }
 
 /* range track */
@@ -390,7 +391,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   height: 20px;
   margin-top: -8px;
   border-radius: 50%;
-  border: 2px solid currentColor;
+  border: 1px solid currentColor;
   background: var(--white);
   cursor: pointer;
 }
@@ -401,7 +402,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  border: 2px solid currentColor;
+  border: 1px solid currentColor;
   background: var(--white);
   cursor: pointer;
 }
@@ -413,7 +414,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   height: 20px;
   margin-top: 0; /* Fixes Edge's vertical alignment */
   border-radius: 50%;
-  border: 2px solid currentColor;
+  border: 1px solid currentColor;
   background: var(--white);
   cursor: pointer;
 }

--- a/src/forms.css
+++ b/src/forms.css
@@ -400,7 +400,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-radius: 50%;
   border: 1px solid currentColor;
   background: var(--white);
-  cursor: pointer;
+  cursor: grab;
 }
 
 .range > input::-moz-range-thumb {
@@ -411,7 +411,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-radius: 50%;
   border: 1px solid currentColor;
   background: var(--white);
-  cursor: pointer;
+  cursor: grab;
 }
 
 .range > input::-ms-thumb {
@@ -423,7 +423,19 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-radius: 50%;
   border: 1px solid currentColor;
   background: var(--white);
-  cursor: pointer;
+  cursor: grab;
+}
+
+.range > input::-webkit-slider-thumb:active {
+  cursor: grabbing;
+}
+
+.range > input::-moz-range-thumb:active {
+  cursor: grabbing;
+}
+
+.range > input::-ms-thumb:active {
+  cursor: grabbing;
 }
 
 /*

--- a/src/forms.css
+++ b/src/forms.css
@@ -324,11 +324,18 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 .range > input {
   appearance: none;
   width: 100%;
-  padding: 0;
   margin: 0;
   border: 0;
   background: var(--transparent);
   cursor: pointer;
+  padding: 8px 0; /* widen clickable track area */
+}
+
+/* remove additional padding for firefox */
+@-moz-document url-prefix('') {
+  .range > input {
+    padding: 0;
+  }
 }
 
 /* range track */
@@ -431,6 +438,17 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .range--s {
   height: 24px;
+}
+
+.range--s > input {
+  padding: 4px 0; /* widen clickable track area */
+}
+
+/* remove additional padding for firefox */
+@-moz-document url-prefix('') {
+  .range--s > input {
+    padding: 0;
+  }
 }
 
 /* range small track */

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -139,22 +139,22 @@ legend{
 [data-assembly-focus-control='visible'] input:focus + .toggle{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]{
+[data-assembly-focus-control='visible'] .range input[type=range]{
   box-shadow:none;
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-webkit-slider-thumb{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-webkit-slider-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-upper{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-fill-upper{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-lower{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-fill-lower{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-thumb{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-moz-range-thumb{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-moz-range-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -552,11 +552,16 @@ legend{
   -webkit-appearance:none;
           appearance:none;
   width:100%;
-  padding:0;
   margin:0;
   border:0;
   background:transparent;
   cursor:pointer;
+  padding:8px 0;
+}
+@-moz-document url-prefix(''){
+  .range > input{
+    padding:0;
+  }
 }
 .range > input::-webkit-slider-runnable-track{
   width:100%;
@@ -646,6 +651,15 @@ legend{
 }
 .range--s{
   height:24px;
+}
+
+.range--s > input{
+  padding:4px 0;
+}
+@-moz-document url-prefix(''){
+  .range--s > input{
+    padding:0;
+  }
 }
 .range--s > input::-webkit-slider-runnable-track{
   height:2px;
@@ -12028,22 +12042,22 @@ legend{
 [data-assembly-focus-control='visible'] input:focus + .toggle{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]{
+[data-assembly-focus-control='visible'] .range input[type=range]{
   box-shadow:none;
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-webkit-slider-thumb{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-webkit-slider-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-upper{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-fill-upper{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-lower{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-fill-lower{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-thumb{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-ms-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] input[type=range]:focus::-moz-range-thumb{
+[data-assembly-focus-control='visible'] .range input[type=range]:focus::-moz-range-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -12441,11 +12455,16 @@ legend{
   -webkit-appearance:none;
           appearance:none;
   width:100%;
-  padding:0;
   margin:0;
   border:0;
   background:transparent;
   cursor:pointer;
+  padding:8px 0;
+}
+@-moz-document url-prefix(''){
+  .range > input{
+    padding:0;
+  }
 }
 .range > input::-webkit-slider-runnable-track{
   width:100%;
@@ -12535,6 +12554,15 @@ legend{
 }
 .range--s{
   height:24px;
+}
+
+.range--s > input{
+  padding:4px 0;
+}
+@-moz-document url-prefix(''){
+  .range--s > input{
+    padding:0;
+  }
 }
 .range--s > input::-webkit-slider-runnable-track{
   height:2px;

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -139,22 +139,22 @@ legend{
 [data-assembly-focus-control='visible'] input:focus + .toggle{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range{
+[data-assembly-focus-control='visible'] input[type=range]{
   box-shadow:none;
 }
-[data-assembly-focus-control='visible'] .range:focus::-webkit-slider-thumb{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-webkit-slider-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-fill-upper{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-upper{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-fill-lower{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-lower{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-thumb{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range:focus::-moz-range-thumb{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-moz-range-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
@@ -12028,22 +12028,22 @@ legend{
 [data-assembly-focus-control='visible'] input:focus + .toggle{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range{
+[data-assembly-focus-control='visible'] input[type=range]{
   box-shadow:none;
 }
-[data-assembly-focus-control='visible'] .range:focus::-webkit-slider-thumb{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-webkit-slider-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-fill-upper{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-upper{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-fill-lower{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-fill-lower{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range:focus::-ms-thumb{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-ms-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
-[data-assembly-focus-control='visible'] .range:focus::-moz-range-thumb{
+[data-assembly-focus-control='visible'] input[type=range]:focus::-moz-range-thumb{
   box-shadow:0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -556,6 +556,7 @@ legend{
   margin:0;
   border:0;
   background:transparent;
+  cursor:pointer;
 }
 .range > input::-webkit-slider-runnable-track{
   width:100%;
@@ -614,7 +615,7 @@ legend{
   height:20px;
   margin-top:-8px;
   border-radius:50%;
-  border:2px solid currentColor;
+  border:1px solid currentColor;
   background:#fff;
   cursor:pointer;
 }
@@ -626,7 +627,7 @@ legend{
   width:20px;
   height:20px;
   border-radius:50%;
-  border:2px solid currentColor;
+  border:1px solid currentColor;
   background:#fff;
   cursor:pointer;
 }
@@ -639,7 +640,7 @@ legend{
   height:20px;
   margin-top:0;
   border-radius:50%;
-  border:2px solid currentColor;
+  border:1px solid currentColor;
   background:#fff;
   cursor:pointer;
 }
@@ -12444,6 +12445,7 @@ legend{
   margin:0;
   border:0;
   background:transparent;
+  cursor:pointer;
 }
 .range > input::-webkit-slider-runnable-track{
   width:100%;
@@ -12502,7 +12504,7 @@ legend{
   height:20px;
   margin-top:-8px;
   border-radius:50%;
-  border:2px solid currentColor;
+  border:1px solid currentColor;
   background:#fff;
   cursor:pointer;
 }
@@ -12514,7 +12516,7 @@ legend{
   width:20px;
   height:20px;
   border-radius:50%;
-  border:2px solid currentColor;
+  border:1px solid currentColor;
   background:#fff;
   cursor:pointer;
 }
@@ -12527,7 +12529,7 @@ legend{
   height:20px;
   margin-top:0;
   border-radius:50%;
-  border:2px solid currentColor;
+  border:1px solid currentColor;
   background:#fff;
   cursor:pointer;
 }

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -622,7 +622,7 @@ legend{
   border-radius:50%;
   border:1px solid currentColor;
   background:#fff;
-  cursor:pointer;
+  cursor:grab;
 }
 
 .range > input::-moz-range-thumb{
@@ -634,7 +634,7 @@ legend{
   border-radius:50%;
   border:1px solid currentColor;
   background:#fff;
-  cursor:pointer;
+  cursor:grab;
 }
 
 .range > input::-ms-thumb{
@@ -647,7 +647,19 @@ legend{
   border-radius:50%;
   border:1px solid currentColor;
   background:#fff;
-  cursor:pointer;
+  cursor:grab;
+}
+
+.range > input::-webkit-slider-thumb:active{
+  cursor:grabbing;
+}
+
+.range > input::-moz-range-thumb:active{
+  cursor:grabbing;
+}
+
+.range > input::-ms-thumb:active{
+  cursor:grabbing;
 }
 .range--s{
   height:24px;
@@ -12525,7 +12537,7 @@ legend{
   border-radius:50%;
   border:1px solid currentColor;
   background:#fff;
-  cursor:pointer;
+  cursor:grab;
 }
 
 .range > input::-moz-range-thumb{
@@ -12537,7 +12549,7 @@ legend{
   border-radius:50%;
   border:1px solid currentColor;
   background:#fff;
-  cursor:pointer;
+  cursor:grab;
 }
 
 .range > input::-ms-thumb{
@@ -12550,7 +12562,19 @@ legend{
   border-radius:50%;
   border:1px solid currentColor;
   background:#fff;
-  cursor:pointer;
+  cursor:grab;
+}
+
+.range > input::-webkit-slider-thumb:active{
+  cursor:grabbing;
+}
+
+.range > input::-moz-range-thumb:active{
+  cursor:grabbing;
+}
+
+.range > input::-ms-thumb:active{
+  cursor:grabbing;
 }
 .range--s{
   height:24px;


### PR DESCRIPTION
This PR closes https://github.com/mapbox/assembly/issues/980 and https://github.com/mapbox/assembly/issues/889

- Updates cursor to a pointer when inside the range input's clickable area. This makes it clearer that the user does not need to click _exactly_ on the pixels of the range track to update the position of the range thumb.
- Update range thumb's border-radius from 2px to 1px for consistency with style guide.
- Apply focus state to range thumb instead of track ~(_note: this point is still in progress_)~