### PR TITLE
Simplify color system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0
+
+- [style change] Slightly saturate `darken` colors, and make disabled state colors legible against both light and dark backgrounds.
+- [style change] Use `-deep` modifiers for active/hover states instead of `-dark`.
+- [internal] Simplify internal color variables.
+
 ## 1.0.1
 
 - [fix] Fix bug where handle on `loading--dark` was not visible.

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -155,7 +155,7 @@ function buildColorVariants(variables, config) {
       case 'light':
         return colorBase;
       case undefined:
-        return `${colorBase}-dark`;
+        return `${colorBase}-deep`;
       case 'dark':
         throw new Error(
           `Dark variants not allowed as base colors: use "${colorBase}" instead of "${color}"`
@@ -377,7 +377,7 @@ function buildColorVariants(variables, config) {
     }, '');
     css += stripIndent(`
       .color-text {
-        color: var(--gray-dark) !important;
+        color: var(--gray-deep) !important;
       }
     `);
     return (css += '\n/** @endgroup */\n');

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -77,15 +77,11 @@ const allColors = [
 
   'white',
   'black',
-  'transparent',
-
-  'disabled10',
-  'disabled25',
-  'disabled75'
+  'transparent'
 ];
 
 function isSemitransparent(color) {
-  return /^(disabled|lighten|darken)/.test(color);
+  return /^(lighten|darken)/.test(color);
 }
 
 function isNotAccessibleForForms(color) {
@@ -93,9 +89,7 @@ function isNotAccessibleForForms(color) {
   // for accessibility and to save space.
   return (
     color === 'black' ||
-    /^(disabled10|disabled25|disabled75|darken5|darken10|lighten5|lighten10)$/.test(
-      color
-    ) ||
+    /^(darken5|darken10|lighten5|lighten10)$/.test(color) ||
     /(-dark|-deep|-light|-lighter|-faint)$/.test(color)
   );
 }
@@ -104,7 +98,7 @@ function isNotAccessibleForButtons(color) {
   // Elements that are primarily defined by their background can have looser requirements.
   return (
     color === 'black' ||
-    /^(disabled10|disabled25|disabled75|darken5|lighten5)$/.test(color) ||
+    /^(darken5|lighten5)$/.test(color) ||
     /(-faint|-lighter|-deep|-dark)$/.test(color)
   );
 }

--- a/scripts/build-color-variants.js
+++ b/scripts/build-color-variants.js
@@ -77,11 +77,15 @@ const allColors = [
 
   'white',
   'black',
-  'transparent'
+  'transparent',
+
+  'disabled10',
+  'disabled25',
+  'disabled75'
 ];
 
 function isSemitransparent(color) {
-  return /^(lighten|darken)/.test(color);
+  return /^(disabled|lighten|darken)/.test(color);
 }
 
 function isNotAccessibleForForms(color) {
@@ -89,7 +93,9 @@ function isNotAccessibleForForms(color) {
   // for accessibility and to save space.
   return (
     color === 'black' ||
-    /^(darken5|darken10|lighten5|lighten10)$/.test(color) ||
+    /^(disabled10|disabled25|disabled75|darken5|darken10|lighten5|lighten10)$/.test(
+      color
+    ) ||
     /(-dark|-deep|-light|-lighter|-faint)$/.test(color)
   );
 }
@@ -98,7 +104,7 @@ function isNotAccessibleForButtons(color) {
   // Elements that are primarily defined by their background can have looser requirements.
   return (
     color === 'black' ||
-    /^(darken5|lighten5)$/.test(color) ||
+    /^(disabled10|disabled25|disabled75|darken5|lighten5)$/.test(color) ||
     /(-faint|-lighter|-deep|-dark)$/.test(color)
   );
 }
@@ -371,7 +377,7 @@ function buildColorVariants(variables, config) {
     }, '');
     css += stripIndent(`
       .color-text {
-        color: var(--text-color) !important;
+        color: var(--gray-dark) !important;
       }
     `);
     return (css += '\n/** @endgroup */\n');

--- a/src/buttons.css
+++ b/src/buttons.css
@@ -11,7 +11,7 @@
 
 /**
  * Apply a button style.
- * To change the background color of a button, use a `btn--{color}` modifier  (`*-dark` colors are not available).
+ * To change the background color of a button, use a `btn--{color}` modifier  (`*-deep` and `*-dark` colors are not available).
  * Buttons have white text unless combined with a [`color-*`](#Text-colors) class.
  * Buttons have fully rounded corners unless combined with a [`round-*`](#Border-radius) class.
  *
@@ -42,7 +42,7 @@
 /**
  * Modify a button so its text and borders are colored and its background transparent.
  * The border color and text color will always match.
- * To change the text and border color, use a `btn--{color}` modifier (`*-dark` colors are not available).
+ * To change the text and border color, use a `btn--{color}` modifier (`*-deep` colors are not available).
  *
  * @memberof Buttons
  * @example
@@ -86,13 +86,13 @@
  */
 .btn:hover,
 .btn.is-active {
-  background-color: var(--blue-dark);
+  background-color: var(--blue-deep);
 }
 
 .btn--stroke:hover,
 .btn--stroke.is-active {
   background-color: transparent;
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 /**

--- a/src/buttons.css
+++ b/src/buttons.css
@@ -28,7 +28,7 @@
 .btn {
   display: inline-block;
   font-weight: bold;
-  background-color: var(--default-button-color);
+  background-color: var(--blue);
   font-size: var(--font-size-s);
   color: var(--white);
   border-radius: 18px; /* fully round by default */
@@ -56,7 +56,7 @@
 .btn--stroke {
   background-color: transparent;
   box-shadow: inset 0 0 0 1px currentColor;
-  color: var(--default-button-color);
+  color: var(--blue);
 }
 
 /**
@@ -86,13 +86,13 @@
  */
 .btn:hover,
 .btn.is-active {
-  background-color: var(--default-button-color-dark);
+  background-color: var(--blue-dark);
 }
 
 .btn--stroke:hover,
 .btn--stroke.is-active {
   background-color: transparent;
-  color: var(--default-button-color-dark);
+  color: var(--blue-dark);
 }
 
 /**
@@ -104,16 +104,16 @@
  */
 .btn:disabled {
   pointer-events: none;
-  color: var(--inactive-text-color);
-  background-color: var(--disabled-interactive-color-dark);
+  color: var(--disabled75);
+  background-color: var(--disabled25);
   box-shadow: none;
 }
 
 .btn.btn--stroke:disabled {
   pointer-events: none;
   background-color: transparent;
-  box-shadow: inset 0 0 0 1px var(--inactive-text-color);
-  color: var(--inactive-text-color);
+  box-shadow: inset 0 0 0 1px var(--disabled75);
+  color: var(--disabled75);
 }
 
 /**

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -11,7 +11,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--gray:hover,
 .btn--gray.is-active {
-  background-color: var(--gray-dark);
+  background-color: var(--gray-deep);
 }
 
 .btn--gray-light {
@@ -29,7 +29,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--pink:hover,
 .btn--pink.is-active {
-  background-color: var(--pink-dark);
+  background-color: var(--pink-deep);
 }
 
 .btn--pink-light {
@@ -47,7 +47,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--red:hover,
 .btn--red.is-active {
-  background-color: var(--red-dark);
+  background-color: var(--red-deep);
 }
 
 .btn--red-light {
@@ -65,7 +65,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--orange:hover,
 .btn--orange.is-active {
-  background-color: var(--orange-dark);
+  background-color: var(--orange-deep);
 }
 
 .btn--orange-light {
@@ -83,7 +83,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--yellow:hover,
 .btn--yellow.is-active {
-  background-color: var(--yellow-dark);
+  background-color: var(--yellow-deep);
 }
 
 .btn--yellow-light {
@@ -101,7 +101,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--green:hover,
 .btn--green.is-active {
-  background-color: var(--green-dark);
+  background-color: var(--green-deep);
 }
 
 .btn--green-light {
@@ -119,7 +119,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--blue:hover,
 .btn--blue.is-active {
-  background-color: var(--blue-dark);
+  background-color: var(--blue-deep);
 }
 
 .btn--blue-light {
@@ -137,7 +137,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--purple:hover,
 .btn--purple.is-active {
-  background-color: var(--purple-dark);
+  background-color: var(--purple-deep);
 }
 
 .btn--purple-light {
@@ -245,7 +245,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--gray:hover,
 .btn--stroke.btn--gray.is-active {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .btn--stroke.btn--pink {
@@ -254,7 +254,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--pink:hover,
 .btn--stroke.btn--pink.is-active {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .btn--stroke.btn--red {
@@ -263,7 +263,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--red:hover,
 .btn--stroke.btn--red.is-active {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .btn--stroke.btn--orange {
@@ -272,7 +272,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--orange:hover,
 .btn--stroke.btn--orange.is-active {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .btn--stroke.btn--yellow {
@@ -281,7 +281,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--yellow:hover,
 .btn--stroke.btn--yellow.is-active {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .btn--stroke.btn--green {
@@ -290,7 +290,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--green:hover,
 .btn--stroke.btn--green.is-active {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .btn--stroke.btn--blue {
@@ -299,7 +299,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--blue:hover,
 .btn--stroke.btn--blue.is-active {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .btn--stroke.btn--purple {
@@ -308,7 +308,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--purple:hover,
 .btn--stroke.btn--purple.is-active {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .btn--stroke.btn--darken25 {
@@ -392,11 +392,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select--gray:hover {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select--gray + .select-arrow {
@@ -404,7 +404,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus + .select-arrow {
-  border-top-color: var(--gray-dark);
+  border-top-color: var(--gray-deep);
 }
 
 .select--pink {
@@ -412,11 +412,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .select--pink:hover {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .select--pink + .select-arrow {
@@ -424,7 +424,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus + .select-arrow {
-  border-top-color: var(--pink-dark);
+  border-top-color: var(--pink-deep);
 }
 
 .select--red {
@@ -432,11 +432,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--red:focus {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .select--red:hover {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .select--red + .select-arrow {
@@ -444,7 +444,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--red:focus + .select-arrow {
-  border-top-color: var(--red-dark);
+  border-top-color: var(--red-deep);
 }
 
 .select--orange {
@@ -452,11 +452,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .select--orange:hover {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .select--orange + .select-arrow {
@@ -464,7 +464,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus + .select-arrow {
-  border-top-color: var(--orange-dark);
+  border-top-color: var(--orange-deep);
 }
 
 .select--yellow {
@@ -472,11 +472,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--yellow:focus {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .select--yellow:hover {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .select--yellow + .select-arrow {
@@ -484,7 +484,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--yellow:focus + .select-arrow {
-  border-top-color: var(--yellow-dark);
+  border-top-color: var(--yellow-deep);
 }
 
 .select--green {
@@ -492,11 +492,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .select--green:hover {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .select--green + .select-arrow {
@@ -504,7 +504,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus + .select-arrow {
-  border-top-color: var(--green-dark);
+  border-top-color: var(--green-deep);
 }
 
 .select--blue {
@@ -512,11 +512,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--blue:focus {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .select--blue:hover {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .select--blue + .select-arrow {
@@ -524,7 +524,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--blue:focus + .select-arrow {
-  border-top-color: var(--blue-dark);
+  border-top-color: var(--blue-deep);
 }
 
 .select--purple {
@@ -532,11 +532,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .select--purple:hover {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .select--purple + .select-arrow {
@@ -544,7 +544,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus + .select-arrow {
-  border-top-color: var(--purple-dark);
+  border-top-color: var(--purple-deep);
 }
 
 .select--darken25 {
@@ -715,11 +715,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-gray:focus,
 .input--border-gray:focus {
-  box-shadow: inset 0 0 0 1px var(--gray-dark);
+  box-shadow: inset 0 0 0 1px var(--gray-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--gray:focus {
-  box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--gray-deep), var(--focus-shadow);
 }
 
 .textarea--border-pink,
@@ -730,11 +730,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-pink:focus,
 .input--border-pink:focus {
-  box-shadow: inset 0 0 0 1px var(--pink-dark);
+  box-shadow: inset 0 0 0 1px var(--pink-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--pink:focus {
-  box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--pink-deep), var(--focus-shadow);
 }
 
 .textarea--border-red,
@@ -745,11 +745,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-red:focus,
 .input--border-red:focus {
-  box-shadow: inset 0 0 0 1px var(--red-dark);
+  box-shadow: inset 0 0 0 1px var(--red-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--red:focus {
-  box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--red-deep), var(--focus-shadow);
 }
 
 .textarea--border-orange,
@@ -760,11 +760,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-orange:focus,
 .input--border-orange:focus {
-  box-shadow: inset 0 0 0 1px var(--orange-dark);
+  box-shadow: inset 0 0 0 1px var(--orange-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--orange:focus {
-  box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--orange-deep), var(--focus-shadow);
 }
 
 .textarea--border-yellow,
@@ -775,11 +775,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus {
-  box-shadow: inset 0 0 0 1px var(--yellow-dark);
+  box-shadow: inset 0 0 0 1px var(--yellow-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus {
-  box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--yellow-deep), var(--focus-shadow);
 }
 
 .textarea--border-green,
@@ -790,11 +790,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-green:focus,
 .input--border-green:focus {
-  box-shadow: inset 0 0 0 1px var(--green-dark);
+  box-shadow: inset 0 0 0 1px var(--green-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--green:focus {
-  box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--green-deep), var(--focus-shadow);
 }
 
 .textarea--border-blue,
@@ -805,11 +805,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-blue:focus,
 .input--border-blue:focus {
-  box-shadow: inset 0 0 0 1px var(--blue-dark);
+  box-shadow: inset 0 0 0 1px var(--blue-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--blue:focus {
-  box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--blue-deep), var(--focus-shadow);
 }
 
 .textarea--border-purple,
@@ -820,11 +820,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-purple:focus,
 .input--border-purple:focus {
-  box-shadow: inset 0 0 0 1px var(--purple-dark);
+  box-shadow: inset 0 0 0 1px var(--purple-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--purple:focus {
-  box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--purple-deep), var(--focus-shadow);
 }
 
 .textarea--border-darken25,
@@ -1897,7 +1897,7 @@ input:checked + .switch--dot-transparent::after {
 }
 
 .color-text {
-  color: var(--gray-dark) !important;
+  color: var(--gray-deep) !important;
 }
 
 /** @endgroup */
@@ -2244,7 +2244,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--gray:hover,
 .link--gray.is-active {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .link--pink {
@@ -2253,7 +2253,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--pink:hover,
 .link--pink.is-active {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .link--red {
@@ -2262,7 +2262,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--red:hover,
 .link--red.is-active {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .link--orange {
@@ -2271,7 +2271,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--orange:hover,
 .link--orange.is-active {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .link--yellow {
@@ -2280,7 +2280,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--yellow:hover,
 .link--yellow.is-active {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .link--green {
@@ -2289,7 +2289,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--green:hover,
 .link--green.is-active {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .link--blue {
@@ -2298,7 +2298,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--blue:hover,
 .link--blue.is-active {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .link--purple {
@@ -2307,7 +2307,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--purple:hover,
 .link--purple.is-active {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .link--darken25 {

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -1642,6 +1642,9 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 color-white'>color-white</div>
  *   <div class='col w-1/4 color-black'>color-black</div>
  *   <div class='col w-1/4 color-transparent'>color-transparent</div>
+ *   <div class='col w-1/4 color-disabled10'>color-disabled10</div>
+ *   <div class='col w-1/4 color-disabled25'>color-disabled25</div>
+ *   <div class='col w-1/4 color-disabled75'>color-disabled75</div>
  *   <div class='col w-1/4 color-text'>color-text</div>
  * </div>
  */
@@ -1881,8 +1884,20 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
+.color-disabled10 {
+  color: var(--disabled10) !important;
+}
+
+.color-disabled25 {
+  color: var(--disabled25) !important;
+}
+
+.color-disabled75 {
+  color: var(--disabled75) !important;
+}
+
 .color-text {
-  color: var(--text-color) !important;
+  color: var(--gray-dark) !important;
 }
 
 /** @endgroup */
@@ -1960,6 +1975,9 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 bg-white py6 px6'>bg-white</div>
  *   <div class='col w-1/4 bg-black py6 px6'>bg-black</div>
  *   <div class='col w-1/4 bg-transparent py6 px6'>bg-transparent</div>
+ *   <div class='col w-1/4 bg-disabled10 py6 px6'>bg-disabled10</div>
+ *   <div class='col w-1/4 bg-disabled25 py6 px6'>bg-disabled25</div>
+ *   <div class='col w-1/4 bg-disabled75 py6 px6'>bg-disabled75</div>
  * </div>
  */
 .bg-gray-dark {
@@ -2204,6 +2222,18 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-transparent {
   background-color: var(--transparent) !important;
+}
+
+.bg-disabled10 {
+  background-color: var(--disabled10) !important;
+}
+
+.bg-disabled25 {
+  background-color: var(--disabled25) !important;
+}
+
+.bg-disabled75 {
+  background-color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -2596,6 +2626,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--transparent) !important;
 }
 
+.border--disabled10 {
+  border-color: var(--disabled10) !important;
+}
+
+.border--disabled25 {
+  border-color: var(--disabled25) !important;
+}
+
+.border--disabled75 {
+  border-color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -2638,6 +2680,18 @@ input:checked + .switch--dot-transparent::after {
   box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
+.shadow-disabled10 {
+  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25 {
+  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75 {
+  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -2678,6 +2732,18 @@ input:checked + .switch--dot-transparent::after {
 
 .shadow-lighten75-bold {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
+}
+
+.shadow-disabled10-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -2778,6 +2844,39 @@ input:checked + .switch--dot-transparent::after {
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
+}
+
+.shadow-disabled10-on-hover:hover,
+.shadow-disabled10-on-active.is-active,
+.shadow-disabled10-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
+}
+.shadow-disabled10-bold-on-hover:hover,
+.shadow-disabled10-bold-on-active.is-active,
+.shadow-disabled10-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25-on-hover:hover,
+.shadow-disabled25-on-active.is-active,
+.shadow-disabled25-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
+}
+.shadow-disabled25-bold-on-hover:hover,
+.shadow-disabled25-bold-on-active.is-active,
+.shadow-disabled25-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75-on-hover:hover,
+.shadow-disabled75-on-active.is-active,
+.shadow-disabled75-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
+}
+.shadow-disabled75-bold-on-hover:hover,
+.shadow-disabled75-bold-on-active.is-active,
+.shadow-disabled75-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -3158,6 +3257,24 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--transparent) !important;
 }
 
+.bg-disabled10-on-hover:hover,
+.bg-disabled10-on-active.is-active,
+.bg-disabled10-on-active.is-active:hover {
+  background-color: var(--disabled10) !important;
+}
+
+.bg-disabled25-on-hover:hover,
+.bg-disabled25-on-active.is-active,
+.bg-disabled25-on-active.is-active:hover {
+  background-color: var(--disabled25) !important;
+}
+
+.bg-disabled75-on-hover:hover,
+.bg-disabled75-on-active.is-active,
+.bg-disabled75-on-active.is-active:hover {
+  background-color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -3524,6 +3641,24 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
+.color-disabled10-on-hover:hover,
+.color-disabled10-on-active.is-active,
+.color-disabled10-on-active.is-active:hover {
+  color: var(--disabled10) !important;
+}
+
+.color-disabled25-on-hover:hover,
+.color-disabled25-on-active.is-active,
+.color-disabled25-on-active.is-active:hover {
+  color: var(--disabled25) !important;
+}
+
+.color-disabled75-on-hover:hover,
+.color-disabled75-on-active.is-active,
+.color-disabled75-on-active.is-active:hover {
+  color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -3888,6 +4023,24 @@ input:checked + .switch--dot-transparent::after {
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover {
   border-color: var(--transparent) !important;
+}
+
+.border--disabled10-on-hover:hover,
+.border--disabled10-on-active.is-active,
+.border--disabled10-on-active.is-active:hover {
+  border-color: var(--disabled10) !important;
+}
+
+.border--disabled25-on-hover:hover,
+.border--disabled25-on-active.is-active,
+.border--disabled25-on-active.is-active:hover {
+  border-color: var(--disabled25) !important;
+}
+
+.border--disabled75-on-hover:hover,
+.border--disabled75-on-active.is-active,
+.border--disabled75-on-active.is-active:hover {
+  border-color: var(--disabled75) !important;
 }
 
 /** @endgroup */

--- a/src/color-variants.css
+++ b/src/color-variants.css
@@ -1642,9 +1642,6 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 color-white'>color-white</div>
  *   <div class='col w-1/4 color-black'>color-black</div>
  *   <div class='col w-1/4 color-transparent'>color-transparent</div>
- *   <div class='col w-1/4 color-disabled10'>color-disabled10</div>
- *   <div class='col w-1/4 color-disabled25'>color-disabled25</div>
- *   <div class='col w-1/4 color-disabled75'>color-disabled75</div>
  *   <div class='col w-1/4 color-text'>color-text</div>
  * </div>
  */
@@ -1884,18 +1881,6 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
-.color-disabled10 {
-  color: var(--disabled10) !important;
-}
-
-.color-disabled25 {
-  color: var(--disabled25) !important;
-}
-
-.color-disabled75 {
-  color: var(--disabled75) !important;
-}
-
 .color-text {
   color: var(--gray-deep) !important;
 }
@@ -1975,9 +1960,6 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 bg-white py6 px6'>bg-white</div>
  *   <div class='col w-1/4 bg-black py6 px6'>bg-black</div>
  *   <div class='col w-1/4 bg-transparent py6 px6'>bg-transparent</div>
- *   <div class='col w-1/4 bg-disabled10 py6 px6'>bg-disabled10</div>
- *   <div class='col w-1/4 bg-disabled25 py6 px6'>bg-disabled25</div>
- *   <div class='col w-1/4 bg-disabled75 py6 px6'>bg-disabled75</div>
  * </div>
  */
 .bg-gray-dark {
@@ -2222,18 +2204,6 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-transparent {
   background-color: var(--transparent) !important;
-}
-
-.bg-disabled10 {
-  background-color: var(--disabled10) !important;
-}
-
-.bg-disabled25 {
-  background-color: var(--disabled25) !important;
-}
-
-.bg-disabled75 {
-  background-color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -2626,18 +2596,6 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--transparent) !important;
 }
 
-.border--disabled10 {
-  border-color: var(--disabled10) !important;
-}
-
-.border--disabled25 {
-  border-color: var(--disabled25) !important;
-}
-
-.border--disabled75 {
-  border-color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -2680,18 +2638,6 @@ input:checked + .switch--dot-transparent::after {
   box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
-.shadow-disabled10 {
-  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25 {
-  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75 {
-  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -2732,18 +2678,6 @@ input:checked + .switch--dot-transparent::after {
 
 .shadow-lighten75-bold {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
-}
-
-.shadow-disabled10-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -2844,39 +2778,6 @@ input:checked + .switch--dot-transparent::after {
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
-}
-
-.shadow-disabled10-on-hover:hover,
-.shadow-disabled10-on-active.is-active,
-.shadow-disabled10-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
-}
-.shadow-disabled10-bold-on-hover:hover,
-.shadow-disabled10-bold-on-active.is-active,
-.shadow-disabled10-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25-on-hover:hover,
-.shadow-disabled25-on-active.is-active,
-.shadow-disabled25-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
-}
-.shadow-disabled25-bold-on-hover:hover,
-.shadow-disabled25-bold-on-active.is-active,
-.shadow-disabled25-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75-on-hover:hover,
-.shadow-disabled75-on-active.is-active,
-.shadow-disabled75-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
-}
-.shadow-disabled75-bold-on-hover:hover,
-.shadow-disabled75-bold-on-active.is-active,
-.shadow-disabled75-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -3257,24 +3158,6 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--transparent) !important;
 }
 
-.bg-disabled10-on-hover:hover,
-.bg-disabled10-on-active.is-active,
-.bg-disabled10-on-active.is-active:hover {
-  background-color: var(--disabled10) !important;
-}
-
-.bg-disabled25-on-hover:hover,
-.bg-disabled25-on-active.is-active,
-.bg-disabled25-on-active.is-active:hover {
-  background-color: var(--disabled25) !important;
-}
-
-.bg-disabled75-on-hover:hover,
-.bg-disabled75-on-active.is-active,
-.bg-disabled75-on-active.is-active:hover {
-  background-color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -3641,24 +3524,6 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
-.color-disabled10-on-hover:hover,
-.color-disabled10-on-active.is-active,
-.color-disabled10-on-active.is-active:hover {
-  color: var(--disabled10) !important;
-}
-
-.color-disabled25-on-hover:hover,
-.color-disabled25-on-active.is-active,
-.color-disabled25-on-active.is-active:hover {
-  color: var(--disabled25) !important;
-}
-
-.color-disabled75-on-hover:hover,
-.color-disabled75-on-active.is-active,
-.color-disabled75-on-active.is-active:hover {
-  color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -4023,24 +3888,6 @@ input:checked + .switch--dot-transparent::after {
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover {
   border-color: var(--transparent) !important;
-}
-
-.border--disabled10-on-hover:hover,
-.border--disabled10-on-active.is-active,
-.border--disabled10-on-active.is-active:hover {
-  border-color: var(--disabled10) !important;
-}
-
-.border--disabled25-on-hover:hover,
-.border--disabled25-on-active.is-active,
-.border--disabled25-on-active.is-active:hover {
-  border-color: var(--disabled25) !important;
-}
-
-.border--disabled75-on-hover:hover,
-.border--disabled75-on-active.is-active,
-.border--disabled75-on-active.is-active:hover {
-  border-color: var(--disabled75) !important;
 }
 
 /** @endgroup */

--- a/src/forms.css
+++ b/src/forms.css
@@ -93,7 +93,7 @@
 }
 
 /**
- * Style a textarea. Set the color of the border with a `textarea--border-{color} modifier (`*-dark` colors are not available).
+ * Style a textarea. Set the color of the border with a `textarea--border-{color} modifier (`*-deep` and `*-dark` colors are not available).
  *
  * @memberof Inputs & textareas
  * @example
@@ -217,7 +217,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 /** @endgroup */
 
 .select:hover {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select:focus + .select-arrow {
@@ -227,7 +227,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 /* Some browsers color the option text and background, so reset that */
 .select option {
   background-color: var(--white);
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select option:disabled {
@@ -237,7 +237,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 /* IE overrides */
 .select::-ms-expand { display: none; }
 /* IE actually colors the options, so they can't be white */
-.select option { color: var(--gray-dark); }
+.select option { color: var(--gray-deep); }
 /* Remove purple highlight in HC mode */
 @media all and (-ms-high-contrast: active) {
   .select:focus::-ms-value {

--- a/src/forms.css
+++ b/src/forms.css
@@ -31,7 +31,7 @@
 .input,
 .textarea,
 .select {
-  box-shadow: inset 0 0 0 1px var(--default-form-color-light);
+  box-shadow: inset 0 0 0 1px var(--gray-light);
   padding: 6px 12px;
   border-radius: var(--border-radius);
   transition: background-color var(--transition),
@@ -42,16 +42,16 @@
 
 .input:focus,
 .textarea:focus {
-  box-shadow: inset 0 0 0 1px var(--default-form-color);
+  box-shadow: inset 0 0 0 1px var(--gray);
 }
 
 [data-assembly-focus-control='visible'] .select.select--stroke:focus {
-  box-shadow: inset 0 0 0 1px var(--default-form-color), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--gray), var(--focus-shadow);
 }
 
 .input::placeholder,
 .textarea::placeholder {
-  color: var(--inactive-text-color);
+  color: var(--disabled75);
 }
 
 /* Remove bad padding and unique cancel button from IE and Safari inputs */
@@ -132,8 +132,8 @@
 .select--stroke:disabled {
   pointer-events: none;
   color: var(--darken50);
-  background-color: var(--disabled-interactive-color);
-  box-shadow: inset 0 0 0 1px var(--disabled-interactive-color-dark) !important;
+  background-color: var(--disabled10);
+  box-shadow: inset 0 0 0 1px var(--disabled25) !important;
 }
 
 /* Using the attribute selector instead of the pseudo-class `:read-only`
@@ -148,7 +148,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .input[readonly],
 .textarea[readonly] {
-  background-color: var(--disabled-interactive-color);
+  background-color: var(--disabled10);
 }
 
 /**
@@ -207,7 +207,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   pointer-events: none;
   border-left: 4px solid var(--transparent);
   border-right: 4px solid var(--transparent);
-  border-top: 5px solid var(--default-form-color);
+  border-top: 5px solid var(--gray);
   width: 8px;
   height: 8px;
   margin-top: -1px;
@@ -217,17 +217,17 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 /** @endgroup */
 
 .select:hover {
-  color: var(--default-form-color-dark);
+  color: var(--gray-dark);
 }
 
 .select:focus + .select-arrow {
-  border-top-color: var(--default-form-color);
+  border-top-color: var(--gray);
 }
 
 /* Some browsers color the option text and background, so reset that */
 .select option {
   background-color: var(--white);
-  color: var(--text-color);
+  color: var(--gray-dark);
 }
 
 .select option:disabled {
@@ -237,7 +237,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 /* IE overrides */
 .select::-ms-expand { display: none; }
 /* IE actually colors the options, so they can't be white */
-.select option { color: var(--text-color); }
+.select option { color: var(--gray-dark); }
 /* Remove purple highlight in HC mode */
 @media all and (-ms-high-contrast: active) {
   .select:focus::-ms-value {
@@ -301,8 +301,8 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .select--stroke {
   padding: 6px 30px 6px 12px; /* plus arrow */
-  box-shadow: inset 0 0 0 1px var(--default-form-color-light);
-  color: var(--default-form-color) !important;
+  box-shadow: inset 0 0 0 1px var(--gray-light);
+  color: var(--gray) !important;
 }
 
 .select--stroke .select--s {
@@ -331,7 +331,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .select:disabled {
   pointer-events: none;
-  color: var(--inactive-text-color);
+  color: var(--disabled75);
 }
 
 .select:disabled + .select-arrow {
@@ -549,14 +549,14 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  *   <input disabled type='range' />
  * </div>
  */
-.range > input:disabled::-webkit-slider-runnable-track { background: var(--disabled-interactive-color-dark); }
-.range > input:disabled::-moz-range-track { background: var(--disabled-interactive-color-dark); }
-.range > input:disabled::-ms-fill-upper { background: var(--disabled-interactive-color-dark); }
-.range > input:disabled::-ms-fill-lower { background: var(--disabled-interactive-color-dark); }
+.range > input:disabled::-webkit-slider-runnable-track { background: var(--disabled25); }
+.range > input:disabled::-moz-range-track { background: var(--disabled25); }
+.range > input:disabled::-ms-fill-upper { background: var(--disabled25); }
+.range > input:disabled::-ms-fill-lower { background: var(--disabled25); }
 
-.range > input:disabled::-webkit-slider-thumb { border-color: var(--disabled-interactive-color-dark); background: var(--gray-faint); }
-.range > input:disabled::-ms-thumb { border-color: var(--disabled-interactive-color-dark); background: var(--gray-faint); }
-.range > input:disabled::-moz-range-thumb { border-color: var(--disabled-interactive-color-dark); background: var(--gray-faint); }
+.range > input:disabled::-webkit-slider-thumb { border-color: var(--disabled25); background: var(--gray-faint); }
+.range > input:disabled::-ms-thumb { border-color: var(--disabled25); background: var(--gray-faint); }
+.range > input:disabled::-moz-range-thumb { border-color: var(--disabled25); background: var(--gray-faint); }
 
 /* shared form styles */
 .checkbox-container,
@@ -634,7 +634,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .checkbox {
   color: var(--white);
-  border-color: var(--default-form-color);
+  border-color: var(--gray);
   transition: color var(--transition),
     border var(--transition),
     background-color var(--transition);
@@ -685,7 +685,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
  */
 .radio {
   border-radius: 50%;
-  color: var(--default-form-color);
+  color: var(--gray);
   border-color: currentColor;
 }
 
@@ -738,7 +738,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
   border-width: 1px;
   border-style: solid;
   border-color: currentColor;
-  color: var(--default-form-color);
+  color: var(--gray);
   transition: color var(--transition),
     background-color var(--transition),
     border-color var(--transition);
@@ -825,7 +825,7 @@ because it seems to be more cross-browser consistent with all HTML5 input types 
 .toggle {
   flex-shrink: 0;
   cursor: pointer;
-  color: var(--default-form-color);
+  color: var(--gray);
   font-size: var(--font-size-s);
   padding: 3px 18px;
   border-radius: 15px; /* fully round by default */
@@ -932,19 +932,19 @@ input:checked:disabled + .switch {
 }
 
 input:disabled + .switch {
-  border-color: var(--disabled-interactive-color-dark);
+  border-color: var(--disabled25);
 }
 
 input:disabled + .radio,
 input:disabled + .checkbox {
-  background-color: var(--disabled-interactive-color-dark);
+  background-color: var(--disabled25);
   border-color: var(--transparent);
 }
 
 input:checked:disabled + .checkbox,
 input:checked:disabled + .radio,
 input:checked:disabled + .switch {
-  background-color: var(--disabled-interactive-color-dark);
+  background-color: var(--disabled25);
 }
 
 input:disabled + .switch::after,
@@ -959,12 +959,12 @@ input:checked + .radio::before {
 }
 
 input:checked + .radio {
-  color: var(--default-form-color);
+  color: var(--gray);
 }
 
 input:checked + .checkbox {
   border: 1px solid var(--transparent);
-  background-color: var(--default-form-color);
+  background-color: var(--gray);
 }
 
 /* state management for switches */
@@ -975,12 +975,12 @@ input:checked + .switch::after {
 
 input:checked + .switch {
   border-color: var(--transparent);
-  background-color: var(--default-form-color);
+  background-color: var(--gray);
 }
 
 /* state management for toggles */
 input:checked + .toggle {
-  background: var(--default-form-color);
+  background: var(--gray);
   color: var(--white);
 }
 
@@ -1007,6 +1007,6 @@ input:disabled + .toggle {
 }
 
 input:checked:disabled + .toggle {
-  background-color: var(--disabled-interactive-color-dark);
+  background-color: var(--disabled25);
   color: var(--darken25);
 }

--- a/src/links.css
+++ b/src/links.css
@@ -18,7 +18,7 @@
  */
 .link {
   cursor: pointer;
-  color: var(--default-button-color);
+  color: var(--blue);
   transition: color var(--transition);
 }
 
@@ -33,7 +33,7 @@
  */
 .link:hover,
 .link.is-active {
-  color: var(--default-button-color-dark);
+  color: var(--blue-dark);
 }
 
 /**
@@ -48,5 +48,5 @@
 .link:disabled {
   pointer-events: none;
   cursor: default;
-  color: var(--inactive-text-color);
+  color: var(--disabled75);
 }

--- a/src/typography.css
+++ b/src/typography.css
@@ -11,7 +11,7 @@
 body,
 input,
 textarea {
-  color: var(--text-color);
+  color: var(--gray-dark);
   font-size: var(--font-size-m);
   line-height: var(--line-height-m);
   font-family: var(--font-stack-base);
@@ -590,7 +590,7 @@ textarea {
  *
  * @memberof Prose
  * @example
- * <div class="prose prose--dark bg-gray">
+ * <div class="prose prose--dark bg-gray-deep">
  *   <h1>Tortor Porta</h1>
  *   <small>Aenean lacinia bibendum nulla sed consectetur. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam quis risus eget urna mollis ornare vel eu leo.</small>
  *   <hr/>
@@ -656,7 +656,7 @@ textarea {
 }
 
 .prose a:not(.unprose) {
-  color: var(--default-button-color);
+  color: var(--blue);
   text-decoration: underline;
 }
 
@@ -665,7 +665,7 @@ textarea {
 }
 
 .prose a:not(.unprose):hover {
-  color: var(--default-button-color-dark);
+  color: var(--blue-dark);
 }
 
 .prose--dark a:not(.unprose):hover {

--- a/src/variables.json
+++ b/src/variables.json
@@ -1,5 +1,5 @@
 {
-  "gray-dark": "#2C3031",
+  "gray-dark": "#1a2224",
   "gray-deep": "#4D5255",
   "gray": "#757D82",
   "gray-light": "#C7CACC",
@@ -55,11 +55,11 @@
   "purple-lighter": "#E7E0F1",
   "purple-faint": "#F3F1F6",
 
-  "darken5": "rgba(0, 0, 0, 0.05)",
-  "darken10": "rgba(0, 0, 0, 0.1)",
-  "darken25": "rgba(0, 0, 0, 0.25)",
-  "darken50": "rgba(0, 0, 0, 0.5)",
-  "darken75": "rgba(0, 0, 0, 0.75)",
+  "darken5": "rgba(26, 34, 36, 0.05)",
+  "darken10": "rgba(26, 34, 36, 0.1)",
+  "darken25": "rgba(26, 34, 36, 0.25)",
+  "darken50": "rgba(26, 34, 36, 0.5)",
+  "darken75": "rgba(26, 34, 36, 0.75)",
 
   "lighten5": "rgba(255, 255, 255, 0.05)",
   "lighten10": "rgba(255, 255, 255, 0.1)",
@@ -71,19 +71,9 @@
   "white": "#fff",
   "transparent": "transparent",
 
-  "disabled-interactive-color": "rgba(127, 127, 127, 0.1)",
-  "disabled-interactive-color-dark": "rgba(127, 127, 127, 0.25)",
-
-  "inactive-text-color": "rgba(64, 64, 64, 0.45)",
-
-  "text-color": "rgba(0, 0, 0, 0.75)",
-
-  "default-button-color": "#448ee4",
-  "default-button-color-dark": "#346db0",
-
-  "default-form-color-light": "#ccc",
-  "default-form-color": "#666",
-  "default-form-color-dark": "#2d2d2d",
+  "disabled10": "rgba(158, 163, 167, 0.1)",
+  "disabled25": "rgba(158, 163, 167, 0.25)",
+  "disabled75": "rgba(158, 163, 167, 0.75)",
 
   "border-radius": "4px",
   "border-radius-bold": "8px",

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -1645,6 +1645,9 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 color-white'>color-white</div>
  *   <div class='col w-1/4 color-black'>color-black</div>
  *   <div class='col w-1/4 color-transparent'>color-transparent</div>
+ *   <div class='col w-1/4 color-disabled10'>color-disabled10</div>
+ *   <div class='col w-1/4 color-disabled25'>color-disabled25</div>
+ *   <div class='col w-1/4 color-disabled75'>color-disabled75</div>
  *   <div class='col w-1/4 color-text'>color-text</div>
  * </div>
  */
@@ -1884,8 +1887,20 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
+.color-disabled10 {
+  color: var(--disabled10) !important;
+}
+
+.color-disabled25 {
+  color: var(--disabled25) !important;
+}
+
+.color-disabled75 {
+  color: var(--disabled75) !important;
+}
+
 .color-text {
-  color: var(--text-color) !important;
+  color: var(--gray-dark) !important;
 }
 
 /** @endgroup */
@@ -1963,6 +1978,9 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 bg-white py6 px6'>bg-white</div>
  *   <div class='col w-1/4 bg-black py6 px6'>bg-black</div>
  *   <div class='col w-1/4 bg-transparent py6 px6'>bg-transparent</div>
+ *   <div class='col w-1/4 bg-disabled10 py6 px6'>bg-disabled10</div>
+ *   <div class='col w-1/4 bg-disabled25 py6 px6'>bg-disabled25</div>
+ *   <div class='col w-1/4 bg-disabled75 py6 px6'>bg-disabled75</div>
  * </div>
  */
 .bg-gray-dark {
@@ -2207,6 +2225,18 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-transparent {
   background-color: var(--transparent) !important;
+}
+
+.bg-disabled10 {
+  background-color: var(--disabled10) !important;
+}
+
+.bg-disabled25 {
+  background-color: var(--disabled25) !important;
+}
+
+.bg-disabled75 {
+  background-color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -2599,6 +2629,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--transparent) !important;
 }
 
+.border--disabled10 {
+  border-color: var(--disabled10) !important;
+}
+
+.border--disabled25 {
+  border-color: var(--disabled25) !important;
+}
+
+.border--disabled75 {
+  border-color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -2641,6 +2683,18 @@ input:checked + .switch--dot-transparent::after {
   box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
+.shadow-disabled10 {
+  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25 {
+  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75 {
+  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -2681,6 +2735,18 @@ input:checked + .switch--dot-transparent::after {
 
 .shadow-lighten75-bold {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
+}
+
+.shadow-disabled10-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -2781,6 +2847,39 @@ input:checked + .switch--dot-transparent::after {
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
+}
+
+.shadow-disabled10-on-hover:hover,
+.shadow-disabled10-on-active.is-active,
+.shadow-disabled10-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
+}
+.shadow-disabled10-bold-on-hover:hover,
+.shadow-disabled10-bold-on-active.is-active,
+.shadow-disabled10-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25-on-hover:hover,
+.shadow-disabled25-on-active.is-active,
+.shadow-disabled25-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
+}
+.shadow-disabled25-bold-on-hover:hover,
+.shadow-disabled25-bold-on-active.is-active,
+.shadow-disabled25-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75-on-hover:hover,
+.shadow-disabled75-on-active.is-active,
+.shadow-disabled75-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
+}
+.shadow-disabled75-bold-on-hover:hover,
+.shadow-disabled75-bold-on-active.is-active,
+.shadow-disabled75-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -3161,6 +3260,24 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--transparent) !important;
 }
 
+.bg-disabled10-on-hover:hover,
+.bg-disabled10-on-active.is-active,
+.bg-disabled10-on-active.is-active:hover {
+  background-color: var(--disabled10) !important;
+}
+
+.bg-disabled25-on-hover:hover,
+.bg-disabled25-on-active.is-active,
+.bg-disabled25-on-active.is-active:hover {
+  background-color: var(--disabled25) !important;
+}
+
+.bg-disabled75-on-hover:hover,
+.bg-disabled75-on-active.is-active,
+.bg-disabled75-on-active.is-active:hover {
+  background-color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -3527,6 +3644,24 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
+.color-disabled10-on-hover:hover,
+.color-disabled10-on-active.is-active,
+.color-disabled10-on-active.is-active:hover {
+  color: var(--disabled10) !important;
+}
+
+.color-disabled25-on-hover:hover,
+.color-disabled25-on-active.is-active,
+.color-disabled25-on-active.is-active:hover {
+  color: var(--disabled25) !important;
+}
+
+.color-disabled75-on-hover:hover,
+.color-disabled75-on-active.is-active,
+.color-disabled75-on-active.is-active:hover {
+  color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -3891,6 +4026,24 @@ input:checked + .switch--dot-transparent::after {
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover {
   border-color: var(--transparent) !important;
+}
+
+.border--disabled10-on-hover:hover,
+.border--disabled10-on-active.is-active,
+.border--disabled10-on-active.is-active:hover {
+  border-color: var(--disabled10) !important;
+}
+
+.border--disabled25-on-hover:hover,
+.border--disabled25-on-active.is-active,
+.border--disabled25-on-active.is-active:hover {
+  border-color: var(--disabled25) !important;
+}
+
+.border--disabled75-on-hover:hover,
+.border--disabled75-on-active.is-active,
+.border--disabled75-on-active.is-active:hover {
+  border-color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -5542,6 +5695,9 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 color-white'>color-white</div>
  *   <div class='col w-1/4 color-black'>color-black</div>
  *   <div class='col w-1/4 color-transparent'>color-transparent</div>
+ *   <div class='col w-1/4 color-disabled10'>color-disabled10</div>
+ *   <div class='col w-1/4 color-disabled25'>color-disabled25</div>
+ *   <div class='col w-1/4 color-disabled75'>color-disabled75</div>
  *   <div class='col w-1/4 color-text'>color-text</div>
  * </div>
  */
@@ -5781,8 +5937,20 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
+.color-disabled10 {
+  color: var(--disabled10) !important;
+}
+
+.color-disabled25 {
+  color: var(--disabled25) !important;
+}
+
+.color-disabled75 {
+  color: var(--disabled75) !important;
+}
+
 .color-text {
-  color: var(--text-color) !important;
+  color: var(--gray-dark) !important;
 }
 
 /** @endgroup */
@@ -5860,6 +6028,9 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 bg-white py6 px6'>bg-white</div>
  *   <div class='col w-1/4 bg-black py6 px6'>bg-black</div>
  *   <div class='col w-1/4 bg-transparent py6 px6'>bg-transparent</div>
+ *   <div class='col w-1/4 bg-disabled10 py6 px6'>bg-disabled10</div>
+ *   <div class='col w-1/4 bg-disabled25 py6 px6'>bg-disabled25</div>
+ *   <div class='col w-1/4 bg-disabled75 py6 px6'>bg-disabled75</div>
  * </div>
  */
 .bg-gray-dark {
@@ -6104,6 +6275,18 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-transparent {
   background-color: var(--transparent) !important;
+}
+
+.bg-disabled10 {
+  background-color: var(--disabled10) !important;
+}
+
+.bg-disabled25 {
+  background-color: var(--disabled25) !important;
+}
+
+.bg-disabled75 {
+  background-color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -6496,6 +6679,18 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--transparent) !important;
 }
 
+.border--disabled10 {
+  border-color: var(--disabled10) !important;
+}
+
+.border--disabled25 {
+  border-color: var(--disabled25) !important;
+}
+
+.border--disabled75 {
+  border-color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -6538,6 +6733,18 @@ input:checked + .switch--dot-transparent::after {
   box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
+.shadow-disabled10 {
+  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25 {
+  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75 {
+  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -6578,6 +6785,18 @@ input:checked + .switch--dot-transparent::after {
 
 .shadow-lighten75-bold {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
+}
+
+.shadow-disabled10-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75-bold {
+  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -6678,6 +6897,39 @@ input:checked + .switch--dot-transparent::after {
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
+}
+
+.shadow-disabled10-on-hover:hover,
+.shadow-disabled10-on-active.is-active,
+.shadow-disabled10-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
+}
+.shadow-disabled10-bold-on-hover:hover,
+.shadow-disabled10-bold-on-active.is-active,
+.shadow-disabled10-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
+}
+
+.shadow-disabled25-on-hover:hover,
+.shadow-disabled25-on-active.is-active,
+.shadow-disabled25-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
+}
+.shadow-disabled25-bold-on-hover:hover,
+.shadow-disabled25-bold-on-active.is-active,
+.shadow-disabled25-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
+}
+
+.shadow-disabled75-on-hover:hover,
+.shadow-disabled75-on-active.is-active,
+.shadow-disabled75-on-active.is-active:hover {
+  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
+}
+.shadow-disabled75-bold-on-hover:hover,
+.shadow-disabled75-bold-on-active.is-active,
+.shadow-disabled75-bold-on-active.is-active:hover {
+  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -7058,6 +7310,24 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--transparent) !important;
 }
 
+.bg-disabled10-on-hover:hover,
+.bg-disabled10-on-active.is-active,
+.bg-disabled10-on-active.is-active:hover {
+  background-color: var(--disabled10) !important;
+}
+
+.bg-disabled25-on-hover:hover,
+.bg-disabled25-on-active.is-active,
+.bg-disabled25-on-active.is-active:hover {
+  background-color: var(--disabled25) !important;
+}
+
+.bg-disabled75-on-hover:hover,
+.bg-disabled75-on-active.is-active,
+.bg-disabled75-on-active.is-active:hover {
+  background-color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 
 /**
@@ -7422,6 +7692,24 @@ input:checked + .switch--dot-transparent::after {
 .color-transparent-on-active.is-active,
 .color-transparent-on-active.is-active:hover {
   color: var(--transparent) !important;
+}
+
+.color-disabled10-on-hover:hover,
+.color-disabled10-on-active.is-active,
+.color-disabled10-on-active.is-active:hover {
+  color: var(--disabled10) !important;
+}
+
+.color-disabled25-on-hover:hover,
+.color-disabled25-on-active.is-active,
+.color-disabled25-on-active.is-active:hover {
+  color: var(--disabled25) !important;
+}
+
+.color-disabled75-on-hover:hover,
+.color-disabled75-on-active.is-active,
+.color-disabled75-on-active.is-active:hover {
+  color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -7790,6 +8078,24 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--transparent) !important;
 }
 
+.border--disabled10-on-hover:hover,
+.border--disabled10-on-active.is-active,
+.border--disabled10-on-active.is-active:hover {
+  border-color: var(--disabled10) !important;
+}
+
+.border--disabled25-on-hover:hover,
+.border--disabled25-on-active.is-active,
+.border--disabled25-on-active.is-active:hover {
+  border-color: var(--disabled25) !important;
+}
+
+.border--disabled75-on-hover:hover,
+.border--disabled75-on-active.is-active,
+.border--disabled75-on-active.is-active:hover {
+  border-color: var(--disabled75) !important;
+}
+
 /** @endgroup */
 "
 `;
@@ -8035,7 +8341,7 @@ input:checked + .switch--dot-teal::after {
 }
 
 .color-text {
-  color: var(--text-color) !important;
+  color: var(--gray-dark) !important;
 }
 
 /** @endgroup */
@@ -8530,7 +8836,7 @@ input:checked + .toggle--active-gray {
 }
 
 .color-text {
-  color: var(--text-color) !important;
+  color: var(--gray-dark) !important;
 }
 
 /** @endgroup */

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -14,7 +14,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--gray:hover,
 .btn--gray.is-active {
-  background-color: var(--gray-dark);
+  background-color: var(--gray-deep);
 }
 
 .btn--gray-light {
@@ -32,7 +32,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--pink:hover,
 .btn--pink.is-active {
-  background-color: var(--pink-dark);
+  background-color: var(--pink-deep);
 }
 
 .btn--pink-light {
@@ -50,7 +50,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--red:hover,
 .btn--red.is-active {
-  background-color: var(--red-dark);
+  background-color: var(--red-deep);
 }
 
 .btn--red-light {
@@ -68,7 +68,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--orange:hover,
 .btn--orange.is-active {
-  background-color: var(--orange-dark);
+  background-color: var(--orange-deep);
 }
 
 .btn--orange-light {
@@ -86,7 +86,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--yellow:hover,
 .btn--yellow.is-active {
-  background-color: var(--yellow-dark);
+  background-color: var(--yellow-deep);
 }
 
 .btn--yellow-light {
@@ -104,7 +104,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--green:hover,
 .btn--green.is-active {
-  background-color: var(--green-dark);
+  background-color: var(--green-deep);
 }
 
 .btn--green-light {
@@ -122,7 +122,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--blue:hover,
 .btn--blue.is-active {
-  background-color: var(--blue-dark);
+  background-color: var(--blue-deep);
 }
 
 .btn--blue-light {
@@ -140,7 +140,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--purple:hover,
 .btn--purple.is-active {
-  background-color: var(--purple-dark);
+  background-color: var(--purple-deep);
 }
 
 .btn--purple-light {
@@ -248,7 +248,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--gray:hover,
 .btn--stroke.btn--gray.is-active {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .btn--stroke.btn--pink {
@@ -257,7 +257,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--pink:hover,
 .btn--stroke.btn--pink.is-active {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .btn--stroke.btn--red {
@@ -266,7 +266,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--red:hover,
 .btn--stroke.btn--red.is-active {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .btn--stroke.btn--orange {
@@ -275,7 +275,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--orange:hover,
 .btn--stroke.btn--orange.is-active {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .btn--stroke.btn--yellow {
@@ -284,7 +284,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--yellow:hover,
 .btn--stroke.btn--yellow.is-active {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .btn--stroke.btn--green {
@@ -293,7 +293,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--green:hover,
 .btn--stroke.btn--green.is-active {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .btn--stroke.btn--blue {
@@ -302,7 +302,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--blue:hover,
 .btn--stroke.btn--blue.is-active {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .btn--stroke.btn--purple {
@@ -311,7 +311,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--purple:hover,
 .btn--stroke.btn--purple.is-active {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .btn--stroke.btn--darken25 {
@@ -395,11 +395,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select--gray:hover {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select--gray + .select-arrow {
@@ -407,7 +407,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus + .select-arrow {
-  border-top-color: var(--gray-dark);
+  border-top-color: var(--gray-deep);
 }
 
 .select--pink {
@@ -415,11 +415,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .select--pink:hover {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .select--pink + .select-arrow {
@@ -427,7 +427,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus + .select-arrow {
-  border-top-color: var(--pink-dark);
+  border-top-color: var(--pink-deep);
 }
 
 .select--red {
@@ -435,11 +435,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--red:focus {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .select--red:hover {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .select--red + .select-arrow {
@@ -447,7 +447,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--red:focus + .select-arrow {
-  border-top-color: var(--red-dark);
+  border-top-color: var(--red-deep);
 }
 
 .select--orange {
@@ -455,11 +455,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .select--orange:hover {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .select--orange + .select-arrow {
@@ -467,7 +467,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus + .select-arrow {
-  border-top-color: var(--orange-dark);
+  border-top-color: var(--orange-deep);
 }
 
 .select--yellow {
@@ -475,11 +475,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--yellow:focus {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .select--yellow:hover {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .select--yellow + .select-arrow {
@@ -487,7 +487,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--yellow:focus + .select-arrow {
-  border-top-color: var(--yellow-dark);
+  border-top-color: var(--yellow-deep);
 }
 
 .select--green {
@@ -495,11 +495,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .select--green:hover {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .select--green + .select-arrow {
@@ -507,7 +507,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus + .select-arrow {
-  border-top-color: var(--green-dark);
+  border-top-color: var(--green-deep);
 }
 
 .select--blue {
@@ -515,11 +515,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--blue:focus {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .select--blue:hover {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .select--blue + .select-arrow {
@@ -527,7 +527,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--blue:focus + .select-arrow {
-  border-top-color: var(--blue-dark);
+  border-top-color: var(--blue-deep);
 }
 
 .select--purple {
@@ -535,11 +535,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .select--purple:hover {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .select--purple + .select-arrow {
@@ -547,7 +547,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus + .select-arrow {
-  border-top-color: var(--purple-dark);
+  border-top-color: var(--purple-deep);
 }
 
 .select--darken25 {
@@ -718,11 +718,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-gray:focus,
 .input--border-gray:focus {
-  box-shadow: inset 0 0 0 1px var(--gray-dark);
+  box-shadow: inset 0 0 0 1px var(--gray-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--gray:focus {
-  box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--gray-deep), var(--focus-shadow);
 }
 
 .textarea--border-pink,
@@ -733,11 +733,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-pink:focus,
 .input--border-pink:focus {
-  box-shadow: inset 0 0 0 1px var(--pink-dark);
+  box-shadow: inset 0 0 0 1px var(--pink-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--pink:focus {
-  box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--pink-deep), var(--focus-shadow);
 }
 
 .textarea--border-red,
@@ -748,11 +748,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-red:focus,
 .input--border-red:focus {
-  box-shadow: inset 0 0 0 1px var(--red-dark);
+  box-shadow: inset 0 0 0 1px var(--red-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--red:focus {
-  box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--red-deep), var(--focus-shadow);
 }
 
 .textarea--border-orange,
@@ -763,11 +763,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-orange:focus,
 .input--border-orange:focus {
-  box-shadow: inset 0 0 0 1px var(--orange-dark);
+  box-shadow: inset 0 0 0 1px var(--orange-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--orange:focus {
-  box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--orange-deep), var(--focus-shadow);
 }
 
 .textarea--border-yellow,
@@ -778,11 +778,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus {
-  box-shadow: inset 0 0 0 1px var(--yellow-dark);
+  box-shadow: inset 0 0 0 1px var(--yellow-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus {
-  box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--yellow-deep), var(--focus-shadow);
 }
 
 .textarea--border-green,
@@ -793,11 +793,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-green:focus,
 .input--border-green:focus {
-  box-shadow: inset 0 0 0 1px var(--green-dark);
+  box-shadow: inset 0 0 0 1px var(--green-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--green:focus {
-  box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--green-deep), var(--focus-shadow);
 }
 
 .textarea--border-blue,
@@ -808,11 +808,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-blue:focus,
 .input--border-blue:focus {
-  box-shadow: inset 0 0 0 1px var(--blue-dark);
+  box-shadow: inset 0 0 0 1px var(--blue-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--blue:focus {
-  box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--blue-deep), var(--focus-shadow);
 }
 
 .textarea--border-purple,
@@ -823,11 +823,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-purple:focus,
 .input--border-purple:focus {
-  box-shadow: inset 0 0 0 1px var(--purple-dark);
+  box-shadow: inset 0 0 0 1px var(--purple-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--purple:focus {
-  box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--purple-deep), var(--focus-shadow);
 }
 
 .textarea--border-darken25,
@@ -1900,7 +1900,7 @@ input:checked + .switch--dot-transparent::after {
 }
 
 .color-text {
-  color: var(--gray-dark) !important;
+  color: var(--gray-deep) !important;
 }
 
 /** @endgroup */
@@ -2247,7 +2247,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--gray:hover,
 .link--gray.is-active {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .link--pink {
@@ -2256,7 +2256,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--pink:hover,
 .link--pink.is-active {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .link--red {
@@ -2265,7 +2265,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--red:hover,
 .link--red.is-active {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .link--orange {
@@ -2274,7 +2274,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--orange:hover,
 .link--orange.is-active {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .link--yellow {
@@ -2283,7 +2283,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--yellow:hover,
 .link--yellow.is-active {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .link--green {
@@ -2292,7 +2292,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--green:hover,
 .link--green.is-active {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .link--blue {
@@ -2301,7 +2301,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--blue:hover,
 .link--blue.is-active {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .link--purple {
@@ -2310,7 +2310,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--purple:hover,
 .link--purple.is-active {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .link--darken25 {
@@ -4064,7 +4064,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--gray:hover,
 .btn--gray.is-active {
-  background-color: var(--gray-dark);
+  background-color: var(--gray-deep);
 }
 
 .btn--gray-light {
@@ -4082,7 +4082,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--pink:hover,
 .btn--pink.is-active {
-  background-color: var(--pink-dark);
+  background-color: var(--pink-deep);
 }
 
 .btn--pink-light {
@@ -4100,7 +4100,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--red:hover,
 .btn--red.is-active {
-  background-color: var(--red-dark);
+  background-color: var(--red-deep);
 }
 
 .btn--red-light {
@@ -4118,7 +4118,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--orange:hover,
 .btn--orange.is-active {
-  background-color: var(--orange-dark);
+  background-color: var(--orange-deep);
 }
 
 .btn--orange-light {
@@ -4136,7 +4136,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--yellow:hover,
 .btn--yellow.is-active {
-  background-color: var(--yellow-dark);
+  background-color: var(--yellow-deep);
 }
 
 .btn--yellow-light {
@@ -4154,7 +4154,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--green:hover,
 .btn--green.is-active {
-  background-color: var(--green-dark);
+  background-color: var(--green-deep);
 }
 
 .btn--green-light {
@@ -4172,7 +4172,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--blue:hover,
 .btn--blue.is-active {
-  background-color: var(--blue-dark);
+  background-color: var(--blue-deep);
 }
 
 .btn--blue-light {
@@ -4190,7 +4190,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--purple:hover,
 .btn--purple.is-active {
-  background-color: var(--purple-dark);
+  background-color: var(--purple-deep);
 }
 
 .btn--purple-light {
@@ -4298,7 +4298,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--gray:hover,
 .btn--stroke.btn--gray.is-active {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .btn--stroke.btn--pink {
@@ -4307,7 +4307,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--pink:hover,
 .btn--stroke.btn--pink.is-active {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .btn--stroke.btn--red {
@@ -4316,7 +4316,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--red:hover,
 .btn--stroke.btn--red.is-active {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .btn--stroke.btn--orange {
@@ -4325,7 +4325,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--orange:hover,
 .btn--stroke.btn--orange.is-active {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .btn--stroke.btn--yellow {
@@ -4334,7 +4334,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--yellow:hover,
 .btn--stroke.btn--yellow.is-active {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .btn--stroke.btn--green {
@@ -4343,7 +4343,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--green:hover,
 .btn--stroke.btn--green.is-active {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .btn--stroke.btn--blue {
@@ -4352,7 +4352,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--blue:hover,
 .btn--stroke.btn--blue.is-active {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .btn--stroke.btn--purple {
@@ -4361,7 +4361,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--purple:hover,
 .btn--stroke.btn--purple.is-active {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .btn--stroke.btn--darken25 {
@@ -4445,11 +4445,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select--gray:hover {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select--gray + .select-arrow {
@@ -4457,7 +4457,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus + .select-arrow {
-  border-top-color: var(--gray-dark);
+  border-top-color: var(--gray-deep);
 }
 
 .select--pink {
@@ -4465,11 +4465,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .select--pink:hover {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .select--pink + .select-arrow {
@@ -4477,7 +4477,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--pink:focus + .select-arrow {
-  border-top-color: var(--pink-dark);
+  border-top-color: var(--pink-deep);
 }
 
 .select--red {
@@ -4485,11 +4485,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--red:focus {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .select--red:hover {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .select--red + .select-arrow {
@@ -4497,7 +4497,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--red:focus + .select-arrow {
-  border-top-color: var(--red-dark);
+  border-top-color: var(--red-deep);
 }
 
 .select--orange {
@@ -4505,11 +4505,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .select--orange:hover {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .select--orange + .select-arrow {
@@ -4517,7 +4517,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--orange:focus + .select-arrow {
-  border-top-color: var(--orange-dark);
+  border-top-color: var(--orange-deep);
 }
 
 .select--yellow {
@@ -4525,11 +4525,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--yellow:focus {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .select--yellow:hover {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .select--yellow + .select-arrow {
@@ -4537,7 +4537,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--yellow:focus + .select-arrow {
-  border-top-color: var(--yellow-dark);
+  border-top-color: var(--yellow-deep);
 }
 
 .select--green {
@@ -4545,11 +4545,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .select--green:hover {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .select--green + .select-arrow {
@@ -4557,7 +4557,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--green:focus + .select-arrow {
-  border-top-color: var(--green-dark);
+  border-top-color: var(--green-deep);
 }
 
 .select--blue {
@@ -4565,11 +4565,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--blue:focus {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .select--blue:hover {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .select--blue + .select-arrow {
@@ -4577,7 +4577,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--blue:focus + .select-arrow {
-  border-top-color: var(--blue-dark);
+  border-top-color: var(--blue-deep);
 }
 
 .select--purple {
@@ -4585,11 +4585,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .select--purple:hover {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .select--purple + .select-arrow {
@@ -4597,7 +4597,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--purple:focus + .select-arrow {
-  border-top-color: var(--purple-dark);
+  border-top-color: var(--purple-deep);
 }
 
 .select--darken25 {
@@ -4768,11 +4768,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-gray:focus,
 .input--border-gray:focus {
-  box-shadow: inset 0 0 0 1px var(--gray-dark);
+  box-shadow: inset 0 0 0 1px var(--gray-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--gray:focus {
-  box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--gray-deep), var(--focus-shadow);
 }
 
 .textarea--border-pink,
@@ -4783,11 +4783,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-pink:focus,
 .input--border-pink:focus {
-  box-shadow: inset 0 0 0 1px var(--pink-dark);
+  box-shadow: inset 0 0 0 1px var(--pink-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--pink:focus {
-  box-shadow: inset 0 0 0 1px var(--pink-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--pink-deep), var(--focus-shadow);
 }
 
 .textarea--border-red,
@@ -4798,11 +4798,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-red:focus,
 .input--border-red:focus {
-  box-shadow: inset 0 0 0 1px var(--red-dark);
+  box-shadow: inset 0 0 0 1px var(--red-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--red:focus {
-  box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--red-deep), var(--focus-shadow);
 }
 
 .textarea--border-orange,
@@ -4813,11 +4813,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-orange:focus,
 .input--border-orange:focus {
-  box-shadow: inset 0 0 0 1px var(--orange-dark);
+  box-shadow: inset 0 0 0 1px var(--orange-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--orange:focus {
-  box-shadow: inset 0 0 0 1px var(--orange-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--orange-deep), var(--focus-shadow);
 }
 
 .textarea--border-yellow,
@@ -4828,11 +4828,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus {
-  box-shadow: inset 0 0 0 1px var(--yellow-dark);
+  box-shadow: inset 0 0 0 1px var(--yellow-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus {
-  box-shadow: inset 0 0 0 1px var(--yellow-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--yellow-deep), var(--focus-shadow);
 }
 
 .textarea--border-green,
@@ -4843,11 +4843,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-green:focus,
 .input--border-green:focus {
-  box-shadow: inset 0 0 0 1px var(--green-dark);
+  box-shadow: inset 0 0 0 1px var(--green-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--green:focus {
-  box-shadow: inset 0 0 0 1px var(--green-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--green-deep), var(--focus-shadow);
 }
 
 .textarea--border-blue,
@@ -4858,11 +4858,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-blue:focus,
 .input--border-blue:focus {
-  box-shadow: inset 0 0 0 1px var(--blue-dark);
+  box-shadow: inset 0 0 0 1px var(--blue-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--blue:focus {
-  box-shadow: inset 0 0 0 1px var(--blue-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--blue-deep), var(--focus-shadow);
 }
 
 .textarea--border-purple,
@@ -4873,11 +4873,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-purple:focus,
 .input--border-purple:focus {
-  box-shadow: inset 0 0 0 1px var(--purple-dark);
+  box-shadow: inset 0 0 0 1px var(--purple-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--purple:focus {
-  box-shadow: inset 0 0 0 1px var(--purple-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--purple-deep), var(--focus-shadow);
 }
 
 .textarea--border-darken25,
@@ -5950,7 +5950,7 @@ input:checked + .switch--dot-transparent::after {
 }
 
 .color-text {
-  color: var(--gray-dark) !important;
+  color: var(--gray-deep) !important;
 }
 
 /** @endgroup */
@@ -6297,7 +6297,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--gray:hover,
 .link--gray.is-active {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .link--pink {
@@ -6306,7 +6306,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--pink:hover,
 .link--pink.is-active {
-  color: var(--pink-dark);
+  color: var(--pink-deep);
 }
 
 .link--red {
@@ -6315,7 +6315,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--red:hover,
 .link--red.is-active {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .link--orange {
@@ -6324,7 +6324,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--orange:hover,
 .link--orange.is-active {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 .link--yellow {
@@ -6333,7 +6333,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--yellow:hover,
 .link--yellow.is-active {
-  color: var(--yellow-dark);
+  color: var(--yellow-deep);
 }
 
 .link--green {
@@ -6342,7 +6342,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--green:hover,
 .link--green.is-active {
-  color: var(--green-dark);
+  color: var(--green-deep);
 }
 
 .link--blue {
@@ -6351,7 +6351,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--blue:hover,
 .link--blue.is-active {
-  color: var(--blue-dark);
+  color: var(--blue-deep);
 }
 
 .link--purple {
@@ -6360,7 +6360,7 @@ input:checked + .switch--dot-transparent::after {
 
 .link--purple:hover,
 .link--purple.is-active {
-  color: var(--purple-dark);
+  color: var(--purple-deep);
 }
 
 .link--darken25 {
@@ -8114,7 +8114,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--red:hover,
 .btn--red.is-active {
-  background-color: var(--red-dark);
+  background-color: var(--red-deep);
 }
 
 .btn--teal {
@@ -8123,7 +8123,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--teal:hover,
 .btn--teal.is-active {
-  background-color: var(--teal-dark);
+  background-color: var(--teal-deep);
 }
 
 .btn--green-light {
@@ -8141,7 +8141,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--red:hover,
 .btn--stroke.btn--red.is-active {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .btn--stroke.btn--teal {
@@ -8150,7 +8150,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--teal:hover,
 .btn--stroke.btn--teal.is-active {
-  color: var(--teal-dark);
+  color: var(--teal-deep);
 }
 
 .btn.btn--stroke {
@@ -8162,11 +8162,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--red:focus {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .select--red:hover {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .select--red + .select-arrow {
@@ -8174,7 +8174,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--red:focus + .select-arrow {
-  border-top-color: var(--red-dark);
+  border-top-color: var(--red-deep);
 }
 
 .select--teal {
@@ -8182,11 +8182,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--teal:focus {
-  color: var(--teal-dark);
+  color: var(--teal-deep);
 }
 
 .select--teal:hover {
-  color: var(--teal-dark);
+  color: var(--teal-deep);
 }
 
 .select--teal + .select-arrow {
@@ -8194,7 +8194,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--teal:focus + .select-arrow {
-  border-top-color: var(--teal-dark);
+  border-top-color: var(--teal-deep);
 }
 
 .textarea--border-red,
@@ -8205,11 +8205,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-red:focus,
 .input--border-red:focus {
-  box-shadow: inset 0 0 0 1px var(--red-dark);
+  box-shadow: inset 0 0 0 1px var(--red-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--red:focus {
-  box-shadow: inset 0 0 0 1px var(--red-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--red-deep), var(--focus-shadow);
 }
 
 .textarea--border-teal,
@@ -8220,11 +8220,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-teal:focus,
 .input--border-teal:focus {
-  box-shadow: inset 0 0 0 1px var(--teal-dark);
+  box-shadow: inset 0 0 0 1px var(--teal-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--teal:focus {
-  box-shadow: inset 0 0 0 1px var(--teal-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--teal-deep), var(--focus-shadow);
 }
 
 .checkbox--red {
@@ -8341,7 +8341,7 @@ input:checked + .switch--dot-teal::after {
 }
 
 .color-text {
-  color: var(--gray-dark) !important;
+  color: var(--gray-deep) !important;
 }
 
 /** @endgroup */
@@ -8388,7 +8388,7 @@ input:checked + .switch--dot-teal::after {
 
 .link--red:hover,
 .link--red.is-active {
-  color: var(--red-dark);
+  color: var(--red-deep);
 }
 
 .link--teal {
@@ -8397,7 +8397,7 @@ input:checked + .switch--dot-teal::after {
 
 .link--teal:hover,
 .link--teal.is-active {
-  color: var(--teal-dark);
+  color: var(--teal-deep);
 }
 
 /**
@@ -8582,7 +8582,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--green:hover,
 .btn--green.is-active {
-  background-color: var(--green-dark);
+  background-color: var(--green-deep);
 }
 
 .btn--purple {
@@ -8591,7 +8591,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--purple:hover,
 .btn--purple.is-active {
-  background-color: var(--purple-dark);
+  background-color: var(--purple-deep);
 }
 
 .btn--stroke.btn--lighten50 {
@@ -8618,7 +8618,7 @@ scripts/build-color-variants.js to produce the output you want */
 
 .btn--stroke.btn--gray:hover,
 .btn--stroke.btn--gray.is-active {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .btn.btn--stroke {
@@ -8670,11 +8670,11 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select--gray:hover {
-  color: var(--gray-dark);
+  color: var(--gray-deep);
 }
 
 .select--gray + .select-arrow {
@@ -8682,7 +8682,7 @@ scripts/build-color-variants.js to produce the output you want */
 }
 
 .select--gray:focus + .select-arrow {
-  border-top-color: var(--gray-dark);
+  border-top-color: var(--gray-deep);
 }
 
 .textarea--border-lighten50,
@@ -8723,11 +8723,11 @@ scripts/build-color-variants.js to produce the output you want */
 
 .textarea--border-gray:focus,
 .input--border-gray:focus {
-  box-shadow: inset 0 0 0 1px var(--gray-dark);
+  box-shadow: inset 0 0 0 1px var(--gray-deep);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--gray:focus {
-  box-shadow: inset 0 0 0 1px var(--gray-dark), var(--focus-shadow);
+  box-shadow: inset 0 0 0 1px var(--gray-deep), var(--focus-shadow);
 }
 
 .checkbox--lighten50 {
@@ -8836,7 +8836,7 @@ input:checked + .toggle--active-gray {
 }
 
 .color-text {
-  color: var(--gray-dark) !important;
+  color: var(--gray-deep) !important;
 }
 
 /** @endgroup */
@@ -8878,7 +8878,7 @@ input:checked + .toggle--active-gray {
 
 .link--orange:hover,
 .link--orange.is-active {
-  color: var(--orange-dark);
+  color: var(--orange-deep);
 }
 
 /**

--- a/test/__snapshots__/build-color-variants.jest.js.snap
+++ b/test/__snapshots__/build-color-variants.jest.js.snap
@@ -1645,9 +1645,6 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 color-white'>color-white</div>
  *   <div class='col w-1/4 color-black'>color-black</div>
  *   <div class='col w-1/4 color-transparent'>color-transparent</div>
- *   <div class='col w-1/4 color-disabled10'>color-disabled10</div>
- *   <div class='col w-1/4 color-disabled25'>color-disabled25</div>
- *   <div class='col w-1/4 color-disabled75'>color-disabled75</div>
  *   <div class='col w-1/4 color-text'>color-text</div>
  * </div>
  */
@@ -1887,18 +1884,6 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
-.color-disabled10 {
-  color: var(--disabled10) !important;
-}
-
-.color-disabled25 {
-  color: var(--disabled25) !important;
-}
-
-.color-disabled75 {
-  color: var(--disabled75) !important;
-}
-
 .color-text {
   color: var(--gray-deep) !important;
 }
@@ -1978,9 +1963,6 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 bg-white py6 px6'>bg-white</div>
  *   <div class='col w-1/4 bg-black py6 px6'>bg-black</div>
  *   <div class='col w-1/4 bg-transparent py6 px6'>bg-transparent</div>
- *   <div class='col w-1/4 bg-disabled10 py6 px6'>bg-disabled10</div>
- *   <div class='col w-1/4 bg-disabled25 py6 px6'>bg-disabled25</div>
- *   <div class='col w-1/4 bg-disabled75 py6 px6'>bg-disabled75</div>
  * </div>
  */
 .bg-gray-dark {
@@ -2225,18 +2207,6 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-transparent {
   background-color: var(--transparent) !important;
-}
-
-.bg-disabled10 {
-  background-color: var(--disabled10) !important;
-}
-
-.bg-disabled25 {
-  background-color: var(--disabled25) !important;
-}
-
-.bg-disabled75 {
-  background-color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -2629,18 +2599,6 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--transparent) !important;
 }
 
-.border--disabled10 {
-  border-color: var(--disabled10) !important;
-}
-
-.border--disabled25 {
-  border-color: var(--disabled25) !important;
-}
-
-.border--disabled75 {
-  border-color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -2683,18 +2641,6 @@ input:checked + .switch--dot-transparent::after {
   box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
-.shadow-disabled10 {
-  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25 {
-  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75 {
-  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -2735,18 +2681,6 @@ input:checked + .switch--dot-transparent::after {
 
 .shadow-lighten75-bold {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
-}
-
-.shadow-disabled10-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -2847,39 +2781,6 @@ input:checked + .switch--dot-transparent::after {
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
-}
-
-.shadow-disabled10-on-hover:hover,
-.shadow-disabled10-on-active.is-active,
-.shadow-disabled10-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
-}
-.shadow-disabled10-bold-on-hover:hover,
-.shadow-disabled10-bold-on-active.is-active,
-.shadow-disabled10-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25-on-hover:hover,
-.shadow-disabled25-on-active.is-active,
-.shadow-disabled25-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
-}
-.shadow-disabled25-bold-on-hover:hover,
-.shadow-disabled25-bold-on-active.is-active,
-.shadow-disabled25-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75-on-hover:hover,
-.shadow-disabled75-on-active.is-active,
-.shadow-disabled75-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
-}
-.shadow-disabled75-bold-on-hover:hover,
-.shadow-disabled75-bold-on-active.is-active,
-.shadow-disabled75-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -3260,24 +3161,6 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--transparent) !important;
 }
 
-.bg-disabled10-on-hover:hover,
-.bg-disabled10-on-active.is-active,
-.bg-disabled10-on-active.is-active:hover {
-  background-color: var(--disabled10) !important;
-}
-
-.bg-disabled25-on-hover:hover,
-.bg-disabled25-on-active.is-active,
-.bg-disabled25-on-active.is-active:hover {
-  background-color: var(--disabled25) !important;
-}
-
-.bg-disabled75-on-hover:hover,
-.bg-disabled75-on-active.is-active,
-.bg-disabled75-on-active.is-active:hover {
-  background-color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -3644,24 +3527,6 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
-.color-disabled10-on-hover:hover,
-.color-disabled10-on-active.is-active,
-.color-disabled10-on-active.is-active:hover {
-  color: var(--disabled10) !important;
-}
-
-.color-disabled25-on-hover:hover,
-.color-disabled25-on-active.is-active,
-.color-disabled25-on-active.is-active:hover {
-  color: var(--disabled25) !important;
-}
-
-.color-disabled75-on-hover:hover,
-.color-disabled75-on-active.is-active,
-.color-disabled75-on-active.is-active:hover {
-  color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -4026,24 +3891,6 @@ input:checked + .switch--dot-transparent::after {
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover {
   border-color: var(--transparent) !important;
-}
-
-.border--disabled10-on-hover:hover,
-.border--disabled10-on-active.is-active,
-.border--disabled10-on-active.is-active:hover {
-  border-color: var(--disabled10) !important;
-}
-
-.border--disabled25-on-hover:hover,
-.border--disabled25-on-active.is-active,
-.border--disabled25-on-active.is-active:hover {
-  border-color: var(--disabled25) !important;
-}
-
-.border--disabled75-on-hover:hover,
-.border--disabled75-on-active.is-active,
-.border--disabled75-on-active.is-active:hover {
-  border-color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -5695,9 +5542,6 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 color-white'>color-white</div>
  *   <div class='col w-1/4 color-black'>color-black</div>
  *   <div class='col w-1/4 color-transparent'>color-transparent</div>
- *   <div class='col w-1/4 color-disabled10'>color-disabled10</div>
- *   <div class='col w-1/4 color-disabled25'>color-disabled25</div>
- *   <div class='col w-1/4 color-disabled75'>color-disabled75</div>
  *   <div class='col w-1/4 color-text'>color-text</div>
  * </div>
  */
@@ -5937,18 +5781,6 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
-.color-disabled10 {
-  color: var(--disabled10) !important;
-}
-
-.color-disabled25 {
-  color: var(--disabled25) !important;
-}
-
-.color-disabled75 {
-  color: var(--disabled75) !important;
-}
-
 .color-text {
   color: var(--gray-deep) !important;
 }
@@ -6028,9 +5860,6 @@ input:checked + .switch--dot-transparent::after {
  *   <div class='col w-1/4 bg-white py6 px6'>bg-white</div>
  *   <div class='col w-1/4 bg-black py6 px6'>bg-black</div>
  *   <div class='col w-1/4 bg-transparent py6 px6'>bg-transparent</div>
- *   <div class='col w-1/4 bg-disabled10 py6 px6'>bg-disabled10</div>
- *   <div class='col w-1/4 bg-disabled25 py6 px6'>bg-disabled25</div>
- *   <div class='col w-1/4 bg-disabled75 py6 px6'>bg-disabled75</div>
  * </div>
  */
 .bg-gray-dark {
@@ -6275,18 +6104,6 @@ input:checked + .switch--dot-transparent::after {
 
 .bg-transparent {
   background-color: var(--transparent) !important;
-}
-
-.bg-disabled10 {
-  background-color: var(--disabled10) !important;
-}
-
-.bg-disabled25 {
-  background-color: var(--disabled25) !important;
-}
-
-.bg-disabled75 {
-  background-color: var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -6679,18 +6496,6 @@ input:checked + .switch--dot-transparent::after {
   border-color: var(--transparent) !important;
 }
 
-.border--disabled10 {
-  border-color: var(--disabled10) !important;
-}
-
-.border--disabled25 {
-  border-color: var(--disabled25) !important;
-}
-
-.border--disabled75 {
-  border-color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -6733,18 +6538,6 @@ input:checked + .switch--dot-transparent::after {
   box-shadow: 0 2px 10px 0 var(--lighten75) !important;
 }
 
-.shadow-disabled10 {
-  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25 {
-  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75 {
-  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -6785,18 +6578,6 @@ input:checked + .switch--dot-transparent::after {
 
 .shadow-lighten75-bold {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
-}
-
-.shadow-disabled10-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75-bold {
-  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -6897,39 +6678,6 @@ input:checked + .switch--dot-transparent::after {
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover {
   box-shadow: 0 6px 30px 0 var(--lighten75) !important;
-}
-
-.shadow-disabled10-on-hover:hover,
-.shadow-disabled10-on-active.is-active,
-.shadow-disabled10-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled10) !important;
-}
-.shadow-disabled10-bold-on-hover:hover,
-.shadow-disabled10-bold-on-active.is-active,
-.shadow-disabled10-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled10) !important;
-}
-
-.shadow-disabled25-on-hover:hover,
-.shadow-disabled25-on-active.is-active,
-.shadow-disabled25-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled25) !important;
-}
-.shadow-disabled25-bold-on-hover:hover,
-.shadow-disabled25-bold-on-active.is-active,
-.shadow-disabled25-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled25) !important;
-}
-
-.shadow-disabled75-on-hover:hover,
-.shadow-disabled75-on-active.is-active,
-.shadow-disabled75-on-active.is-active:hover {
-  box-shadow: 0 2px 10px 0 var(--disabled75) !important;
-}
-.shadow-disabled75-bold-on-hover:hover,
-.shadow-disabled75-bold-on-active.is-active,
-.shadow-disabled75-bold-on-active.is-active:hover {
-  box-shadow: 0 6px 30px 0 var(--disabled75) !important;
 }
 
 /** @endgroup */
@@ -7310,24 +7058,6 @@ input:checked + .switch--dot-transparent::after {
   background-color: var(--transparent) !important;
 }
 
-.bg-disabled10-on-hover:hover,
-.bg-disabled10-on-active.is-active,
-.bg-disabled10-on-active.is-active:hover {
-  background-color: var(--disabled10) !important;
-}
-
-.bg-disabled25-on-hover:hover,
-.bg-disabled25-on-active.is-active,
-.bg-disabled25-on-active.is-active:hover {
-  background-color: var(--disabled25) !important;
-}
-
-.bg-disabled75-on-hover:hover,
-.bg-disabled75-on-active.is-active,
-.bg-disabled75-on-active.is-active:hover {
-  background-color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -7694,24 +7424,6 @@ input:checked + .switch--dot-transparent::after {
   color: var(--transparent) !important;
 }
 
-.color-disabled10-on-hover:hover,
-.color-disabled10-on-active.is-active,
-.color-disabled10-on-active.is-active:hover {
-  color: var(--disabled10) !important;
-}
-
-.color-disabled25-on-hover:hover,
-.color-disabled25-on-active.is-active,
-.color-disabled25-on-active.is-active:hover {
-  color: var(--disabled25) !important;
-}
-
-.color-disabled75-on-hover:hover,
-.color-disabled75-on-active.is-active,
-.color-disabled75-on-active.is-active:hover {
-  color: var(--disabled75) !important;
-}
-
 /** @endgroup */
 
 /**
@@ -8076,24 +7788,6 @@ input:checked + .switch--dot-transparent::after {
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover {
   border-color: var(--transparent) !important;
-}
-
-.border--disabled10-on-hover:hover,
-.border--disabled10-on-active.is-active,
-.border--disabled10-on-active.is-active:hover {
-  border-color: var(--disabled10) !important;
-}
-
-.border--disabled25-on-hover:hover,
-.border--disabled25-on-active.is-active,
-.border--disabled25-on-active.is-active:hover {
-  border-color: var(--disabled25) !important;
-}
-
-.border--disabled75-on-hover:hover,
-.border--disabled75-on-active.is-active,
-.border--disabled75-on-active.is-active:hover {
-  border-color: var(--disabled75) !important;
 }
 
 /** @endgroup */

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -286,13 +286,13 @@ legend{
 }
 .btn:hover,
 .btn.is-active{
-  background-color:#223B53;
+  background-color:#0B428E;
 }
 
 .btn--stroke:hover,
 .btn--stroke.is-active{
   background-color:transparent;
-  color:#223B53;
+  color:#0B428E;
 }
 .btn:disabled{
   pointer-events:none;
@@ -503,7 +503,7 @@ legend{
 }
 
 .select:hover{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .select:focus + .select-arrow{
@@ -511,14 +511,14 @@ legend{
 }
 .select option{
   background-color:#fff;
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .select option:disabled{
   color:rgba(26, 34, 36, 0.25);
 }
 .select::-ms-expand{ display:none; }
-.select option{ color:#1a2224; }
+.select option{ color:#4D5255; }
 @media all and (-ms-high-contrast: active){
   .select:focus::-ms-value{
     background-color:transparent;
@@ -9192,7 +9192,7 @@ textarea{
 
 .btn--gray:hover,
 .btn--gray.is-active{
-  background-color:#1a2224;
+  background-color:#4D5255;
 }
 
 .btn--gray-light{
@@ -9210,7 +9210,7 @@ textarea{
 
 .btn--pink:hover,
 .btn--pink.is-active{
-  background-color:#800C3C;
+  background-color:#BA1258;
 }
 
 .btn--pink-light{
@@ -9228,7 +9228,7 @@ textarea{
 
 .btn--red:hover,
 .btn--red.is-active{
-  background-color:#741806;
+  background-color:#B6290D;
 }
 
 .btn--red-light{
@@ -9246,7 +9246,7 @@ textarea{
 
 .btn--orange:hover,
 .btn--orange.is-active{
-  background-color:#773503;
+  background-color:#AE4B04;
 }
 
 .btn--orange-light{
@@ -9264,7 +9264,7 @@ textarea{
 
 .btn--yellow:hover,
 .btn--yellow.is-active{
-  background-color:#625204;
+  background-color:#8E740B;
 }
 
 .btn--yellow-light{
@@ -9282,7 +9282,7 @@ textarea{
 
 .btn--green:hover,
 .btn--green.is-active{
-  background-color:#13582F;
+  background-color:#1F7A43;
 }
 
 .btn--green-light{
@@ -9300,7 +9300,7 @@ textarea{
 
 .btn--blue:hover,
 .btn--blue.is-active{
-  background-color:#223B53;
+  background-color:#0B428E;
 }
 
 .btn--blue-light{
@@ -9318,7 +9318,7 @@ textarea{
 
 .btn--purple:hover,
 .btn--purple.is-active{
-  background-color:#512392;
+  background-color:#6E2FC6;
 }
 
 .btn--purple-light{
@@ -9426,7 +9426,7 @@ textarea{
 
 .btn--stroke.btn--gray:hover,
 .btn--stroke.btn--gray.is-active{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .btn--stroke.btn--pink{
@@ -9435,7 +9435,7 @@ textarea{
 
 .btn--stroke.btn--pink:hover,
 .btn--stroke.btn--pink.is-active{
-  color:#800C3C;
+  color:#BA1258;
 }
 
 .btn--stroke.btn--red{
@@ -9444,7 +9444,7 @@ textarea{
 
 .btn--stroke.btn--red:hover,
 .btn--stroke.btn--red.is-active{
-  color:#741806;
+  color:#B6290D;
 }
 
 .btn--stroke.btn--orange{
@@ -9453,7 +9453,7 @@ textarea{
 
 .btn--stroke.btn--orange:hover,
 .btn--stroke.btn--orange.is-active{
-  color:#773503;
+  color:#AE4B04;
 }
 
 .btn--stroke.btn--yellow{
@@ -9462,7 +9462,7 @@ textarea{
 
 .btn--stroke.btn--yellow:hover,
 .btn--stroke.btn--yellow.is-active{
-  color:#625204;
+  color:#8E740B;
 }
 
 .btn--stroke.btn--green{
@@ -9471,7 +9471,7 @@ textarea{
 
 .btn--stroke.btn--green:hover,
 .btn--stroke.btn--green.is-active{
-  color:#13582F;
+  color:#1F7A43;
 }
 
 .btn--stroke.btn--blue{
@@ -9480,7 +9480,7 @@ textarea{
 
 .btn--stroke.btn--blue:hover,
 .btn--stroke.btn--blue.is-active{
-  color:#223B53;
+  color:#0B428E;
 }
 
 .btn--stroke.btn--purple{
@@ -9489,7 +9489,7 @@ textarea{
 
 .btn--stroke.btn--purple:hover,
 .btn--stroke.btn--purple.is-active{
-  color:#512392;
+  color:#6E2FC6;
 }
 
 .btn--stroke.btn--darken25{
@@ -9573,11 +9573,11 @@ textarea{
 }
 
 .select--gray:focus{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .select--gray:hover{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .select--gray + .select-arrow{
@@ -9585,7 +9585,7 @@ textarea{
 }
 
 .select--gray:focus + .select-arrow{
-  border-top-color:#1a2224;
+  border-top-color:#4D5255;
 }
 
 .select--pink{
@@ -9593,11 +9593,11 @@ textarea{
 }
 
 .select--pink:focus{
-  color:#800C3C;
+  color:#BA1258;
 }
 
 .select--pink:hover{
-  color:#800C3C;
+  color:#BA1258;
 }
 
 .select--pink + .select-arrow{
@@ -9605,7 +9605,7 @@ textarea{
 }
 
 .select--pink:focus + .select-arrow{
-  border-top-color:#800C3C;
+  border-top-color:#BA1258;
 }
 
 .select--red{
@@ -9613,11 +9613,11 @@ textarea{
 }
 
 .select--red:focus{
-  color:#741806;
+  color:#B6290D;
 }
 
 .select--red:hover{
-  color:#741806;
+  color:#B6290D;
 }
 
 .select--red + .select-arrow{
@@ -9625,7 +9625,7 @@ textarea{
 }
 
 .select--red:focus + .select-arrow{
-  border-top-color:#741806;
+  border-top-color:#B6290D;
 }
 
 .select--orange{
@@ -9633,11 +9633,11 @@ textarea{
 }
 
 .select--orange:focus{
-  color:#773503;
+  color:#AE4B04;
 }
 
 .select--orange:hover{
-  color:#773503;
+  color:#AE4B04;
 }
 
 .select--orange + .select-arrow{
@@ -9645,7 +9645,7 @@ textarea{
 }
 
 .select--orange:focus + .select-arrow{
-  border-top-color:#773503;
+  border-top-color:#AE4B04;
 }
 
 .select--yellow{
@@ -9653,11 +9653,11 @@ textarea{
 }
 
 .select--yellow:focus{
-  color:#625204;
+  color:#8E740B;
 }
 
 .select--yellow:hover{
-  color:#625204;
+  color:#8E740B;
 }
 
 .select--yellow + .select-arrow{
@@ -9665,7 +9665,7 @@ textarea{
 }
 
 .select--yellow:focus + .select-arrow{
-  border-top-color:#625204;
+  border-top-color:#8E740B;
 }
 
 .select--green{
@@ -9673,11 +9673,11 @@ textarea{
 }
 
 .select--green:focus{
-  color:#13582F;
+  color:#1F7A43;
 }
 
 .select--green:hover{
-  color:#13582F;
+  color:#1F7A43;
 }
 
 .select--green + .select-arrow{
@@ -9685,7 +9685,7 @@ textarea{
 }
 
 .select--green:focus + .select-arrow{
-  border-top-color:#13582F;
+  border-top-color:#1F7A43;
 }
 
 .select--blue{
@@ -9693,11 +9693,11 @@ textarea{
 }
 
 .select--blue:focus{
-  color:#223B53;
+  color:#0B428E;
 }
 
 .select--blue:hover{
-  color:#223B53;
+  color:#0B428E;
 }
 
 .select--blue + .select-arrow{
@@ -9705,7 +9705,7 @@ textarea{
 }
 
 .select--blue:focus + .select-arrow{
-  border-top-color:#223B53;
+  border-top-color:#0B428E;
 }
 
 .select--purple{
@@ -9713,11 +9713,11 @@ textarea{
 }
 
 .select--purple:focus{
-  color:#512392;
+  color:#6E2FC6;
 }
 
 .select--purple:hover{
-  color:#512392;
+  color:#6E2FC6;
 }
 
 .select--purple + .select-arrow{
@@ -9725,7 +9725,7 @@ textarea{
 }
 
 .select--purple:focus + .select-arrow{
-  border-top-color:#512392;
+  border-top-color:#6E2FC6;
 }
 
 .select--darken25{
@@ -9896,11 +9896,11 @@ textarea{
 
 .textarea--border-gray:focus,
 .input--border-gray:focus{
-  box-shadow:inset 0 0 0 1px #1a2224;
+  box-shadow:inset 0 0 0 1px #4D5255;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--gray:focus{
-  box-shadow:inset 0 0 0 1px #1a2224, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #4D5255, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-pink,
@@ -9911,11 +9911,11 @@ textarea{
 
 .textarea--border-pink:focus,
 .input--border-pink:focus{
-  box-shadow:inset 0 0 0 1px #800C3C;
+  box-shadow:inset 0 0 0 1px #BA1258;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--pink:focus{
-  box-shadow:inset 0 0 0 1px #800C3C, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #BA1258, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-red,
@@ -9926,11 +9926,11 @@ textarea{
 
 .textarea--border-red:focus,
 .input--border-red:focus{
-  box-shadow:inset 0 0 0 1px #741806;
+  box-shadow:inset 0 0 0 1px #B6290D;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--red:focus{
-  box-shadow:inset 0 0 0 1px #741806, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #B6290D, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-orange,
@@ -9941,11 +9941,11 @@ textarea{
 
 .textarea--border-orange:focus,
 .input--border-orange:focus{
-  box-shadow:inset 0 0 0 1px #773503;
+  box-shadow:inset 0 0 0 1px #AE4B04;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--orange:focus{
-  box-shadow:inset 0 0 0 1px #773503, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #AE4B04, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-yellow,
@@ -9956,11 +9956,11 @@ textarea{
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus{
-  box-shadow:inset 0 0 0 1px #625204;
+  box-shadow:inset 0 0 0 1px #8E740B;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus{
-  box-shadow:inset 0 0 0 1px #625204, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #8E740B, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-green,
@@ -9971,11 +9971,11 @@ textarea{
 
 .textarea--border-green:focus,
 .input--border-green:focus{
-  box-shadow:inset 0 0 0 1px #13582F;
+  box-shadow:inset 0 0 0 1px #1F7A43;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--green:focus{
-  box-shadow:inset 0 0 0 1px #13582F, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #1F7A43, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-blue,
@@ -9986,11 +9986,11 @@ textarea{
 
 .textarea--border-blue:focus,
 .input--border-blue:focus{
-  box-shadow:inset 0 0 0 1px #223B53;
+  box-shadow:inset 0 0 0 1px #0B428E;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--blue:focus{
-  box-shadow:inset 0 0 0 1px #223B53, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #0B428E, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-purple,
@@ -10001,11 +10001,11 @@ textarea{
 
 .textarea--border-purple:focus,
 .input--border-purple:focus{
-  box-shadow:inset 0 0 0 1px #512392;
+  box-shadow:inset 0 0 0 1px #6E2FC6;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--purple:focus{
-  box-shadow:inset 0 0 0 1px #512392, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #6E2FC6, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken25,
@@ -10968,7 +10968,7 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .color-text{
-  color:#1a2224 !important;
+  color:#4D5255 !important;
 }
 .bg-gray-dark{
   background-color:#1a2224 !important;
@@ -11232,7 +11232,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--gray:hover,
 .link--gray.is-active{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .link--pink{
@@ -11241,7 +11241,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--pink:hover,
 .link--pink.is-active{
-  color:#800C3C;
+  color:#BA1258;
 }
 
 .link--red{
@@ -11250,7 +11250,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--red:hover,
 .link--red.is-active{
-  color:#741806;
+  color:#B6290D;
 }
 
 .link--orange{
@@ -11259,7 +11259,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--orange:hover,
 .link--orange.is-active{
-  color:#773503;
+  color:#AE4B04;
 }
 
 .link--yellow{
@@ -11268,7 +11268,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--yellow:hover,
 .link--yellow.is-active{
-  color:#625204;
+  color:#8E740B;
 }
 
 .link--green{
@@ -11277,7 +11277,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--green:hover,
 .link--green.is-active{
-  color:#13582F;
+  color:#1F7A43;
 }
 
 .link--blue{
@@ -11286,7 +11286,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--blue:hover,
 .link--blue.is-active{
-  color:#223B53;
+  color:#0B428E;
 }
 
 .link--purple{
@@ -11295,7 +11295,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--purple:hover,
 .link--purple.is-active{
-  color:#512392;
+  color:#6E2FC6;
 }
 
 .link--darken25{
@@ -13817,13 +13817,13 @@ legend{
 }
 .btn:hover,
 .btn.is-active{
-  background-color:#072E64;
+  background-color:#0B428E;
 }
 
 .btn--stroke:hover,
 .btn--stroke.is-active{
   background-color:transparent;
-  color:#072E64;
+  color:#0B428E;
 }
 .btn:disabled{
   pointer-events:none;
@@ -14034,7 +14034,7 @@ legend{
 }
 
 .select:hover{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .select:focus + .select-arrow{
@@ -14042,14 +14042,14 @@ legend{
 }
 .select option{
   background-color:#fff;
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .select option:disabled{
   color:rgba(26, 34, 36, 0.25);
 }
 .select::-ms-expand{ display:none; }
-.select option{ color:#1a2224; }
+.select option{ color:#4D5255; }
 @media all and (-ms-high-contrast: active){
   .select:focus::-ms-value{
     background-color:transparent;
@@ -22709,7 +22709,7 @@ textarea{
 
 .btn--gray:hover,
 .btn--gray.is-active{
-  background-color:#1a2224;
+  background-color:#4D5255;
 }
 
 .btn--gray-light{
@@ -22727,7 +22727,7 @@ textarea{
 
 .btn--pink:hover,
 .btn--pink.is-active{
-  background-color:#800C3C;
+  background-color:#BA1258;
 }
 
 .btn--pink-light{
@@ -22745,7 +22745,7 @@ textarea{
 
 .btn--red:hover,
 .btn--red.is-active{
-  background-color:#741806;
+  background-color:#B6290D;
 }
 
 .btn--red-light{
@@ -22763,7 +22763,7 @@ textarea{
 
 .btn--orange:hover,
 .btn--orange.is-active{
-  background-color:#773503;
+  background-color:#AE4B04;
 }
 
 .btn--orange-light{
@@ -22781,7 +22781,7 @@ textarea{
 
 .btn--yellow:hover,
 .btn--yellow.is-active{
-  background-color:#625204;
+  background-color:#8E740B;
 }
 
 .btn--yellow-light{
@@ -22799,7 +22799,7 @@ textarea{
 
 .btn--green:hover,
 .btn--green.is-active{
-  background-color:#13582F;
+  background-color:#1F7A43;
 }
 
 .btn--green-light{
@@ -22817,7 +22817,7 @@ textarea{
 
 .btn--blue:hover,
 .btn--blue.is-active{
-  background-color:#072E64;
+  background-color:#0B428E;
 }
 
 .btn--blue-light{
@@ -22835,7 +22835,7 @@ textarea{
 
 .btn--purple:hover,
 .btn--purple.is-active{
-  background-color:#512392;
+  background-color:#6E2FC6;
 }
 
 .btn--purple-light{
@@ -22943,7 +22943,7 @@ textarea{
 
 .btn--stroke.btn--gray:hover,
 .btn--stroke.btn--gray.is-active{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .btn--stroke.btn--pink{
@@ -22952,7 +22952,7 @@ textarea{
 
 .btn--stroke.btn--pink:hover,
 .btn--stroke.btn--pink.is-active{
-  color:#800C3C;
+  color:#BA1258;
 }
 
 .btn--stroke.btn--red{
@@ -22961,7 +22961,7 @@ textarea{
 
 .btn--stroke.btn--red:hover,
 .btn--stroke.btn--red.is-active{
-  color:#741806;
+  color:#B6290D;
 }
 
 .btn--stroke.btn--orange{
@@ -22970,7 +22970,7 @@ textarea{
 
 .btn--stroke.btn--orange:hover,
 .btn--stroke.btn--orange.is-active{
-  color:#773503;
+  color:#AE4B04;
 }
 
 .btn--stroke.btn--yellow{
@@ -22979,7 +22979,7 @@ textarea{
 
 .btn--stroke.btn--yellow:hover,
 .btn--stroke.btn--yellow.is-active{
-  color:#625204;
+  color:#8E740B;
 }
 
 .btn--stroke.btn--green{
@@ -22988,7 +22988,7 @@ textarea{
 
 .btn--stroke.btn--green:hover,
 .btn--stroke.btn--green.is-active{
-  color:#13582F;
+  color:#1F7A43;
 }
 
 .btn--stroke.btn--blue{
@@ -22997,7 +22997,7 @@ textarea{
 
 .btn--stroke.btn--blue:hover,
 .btn--stroke.btn--blue.is-active{
-  color:#072E64;
+  color:#0B428E;
 }
 
 .btn--stroke.btn--purple{
@@ -23006,7 +23006,7 @@ textarea{
 
 .btn--stroke.btn--purple:hover,
 .btn--stroke.btn--purple.is-active{
-  color:#512392;
+  color:#6E2FC6;
 }
 
 .btn--stroke.btn--darken25{
@@ -23090,11 +23090,11 @@ textarea{
 }
 
 .select--gray:focus{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .select--gray:hover{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .select--gray + .select-arrow{
@@ -23102,7 +23102,7 @@ textarea{
 }
 
 .select--gray:focus + .select-arrow{
-  border-top-color:#1a2224;
+  border-top-color:#4D5255;
 }
 
 .select--pink{
@@ -23110,11 +23110,11 @@ textarea{
 }
 
 .select--pink:focus{
-  color:#800C3C;
+  color:#BA1258;
 }
 
 .select--pink:hover{
-  color:#800C3C;
+  color:#BA1258;
 }
 
 .select--pink + .select-arrow{
@@ -23122,7 +23122,7 @@ textarea{
 }
 
 .select--pink:focus + .select-arrow{
-  border-top-color:#800C3C;
+  border-top-color:#BA1258;
 }
 
 .select--red{
@@ -23130,11 +23130,11 @@ textarea{
 }
 
 .select--red:focus{
-  color:#741806;
+  color:#B6290D;
 }
 
 .select--red:hover{
-  color:#741806;
+  color:#B6290D;
 }
 
 .select--red + .select-arrow{
@@ -23142,7 +23142,7 @@ textarea{
 }
 
 .select--red:focus + .select-arrow{
-  border-top-color:#741806;
+  border-top-color:#B6290D;
 }
 
 .select--orange{
@@ -23150,11 +23150,11 @@ textarea{
 }
 
 .select--orange:focus{
-  color:#773503;
+  color:#AE4B04;
 }
 
 .select--orange:hover{
-  color:#773503;
+  color:#AE4B04;
 }
 
 .select--orange + .select-arrow{
@@ -23162,7 +23162,7 @@ textarea{
 }
 
 .select--orange:focus + .select-arrow{
-  border-top-color:#773503;
+  border-top-color:#AE4B04;
 }
 
 .select--yellow{
@@ -23170,11 +23170,11 @@ textarea{
 }
 
 .select--yellow:focus{
-  color:#625204;
+  color:#8E740B;
 }
 
 .select--yellow:hover{
-  color:#625204;
+  color:#8E740B;
 }
 
 .select--yellow + .select-arrow{
@@ -23182,7 +23182,7 @@ textarea{
 }
 
 .select--yellow:focus + .select-arrow{
-  border-top-color:#625204;
+  border-top-color:#8E740B;
 }
 
 .select--green{
@@ -23190,11 +23190,11 @@ textarea{
 }
 
 .select--green:focus{
-  color:#13582F;
+  color:#1F7A43;
 }
 
 .select--green:hover{
-  color:#13582F;
+  color:#1F7A43;
 }
 
 .select--green + .select-arrow{
@@ -23202,7 +23202,7 @@ textarea{
 }
 
 .select--green:focus + .select-arrow{
-  border-top-color:#13582F;
+  border-top-color:#1F7A43;
 }
 
 .select--blue{
@@ -23210,11 +23210,11 @@ textarea{
 }
 
 .select--blue:focus{
-  color:#072E64;
+  color:#0B428E;
 }
 
 .select--blue:hover{
-  color:#072E64;
+  color:#0B428E;
 }
 
 .select--blue + .select-arrow{
@@ -23222,7 +23222,7 @@ textarea{
 }
 
 .select--blue:focus + .select-arrow{
-  border-top-color:#072E64;
+  border-top-color:#0B428E;
 }
 
 .select--purple{
@@ -23230,11 +23230,11 @@ textarea{
 }
 
 .select--purple:focus{
-  color:#512392;
+  color:#6E2FC6;
 }
 
 .select--purple:hover{
-  color:#512392;
+  color:#6E2FC6;
 }
 
 .select--purple + .select-arrow{
@@ -23242,7 +23242,7 @@ textarea{
 }
 
 .select--purple:focus + .select-arrow{
-  border-top-color:#512392;
+  border-top-color:#6E2FC6;
 }
 
 .select--darken25{
@@ -23413,11 +23413,11 @@ textarea{
 
 .textarea--border-gray:focus,
 .input--border-gray:focus{
-  box-shadow:inset 0 0 0 1px #1a2224;
+  box-shadow:inset 0 0 0 1px #4D5255;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--gray:focus{
-  box-shadow:inset 0 0 0 1px #1a2224, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #4D5255, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-pink,
@@ -23428,11 +23428,11 @@ textarea{
 
 .textarea--border-pink:focus,
 .input--border-pink:focus{
-  box-shadow:inset 0 0 0 1px #800C3C;
+  box-shadow:inset 0 0 0 1px #BA1258;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--pink:focus{
-  box-shadow:inset 0 0 0 1px #800C3C, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #BA1258, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-red,
@@ -23443,11 +23443,11 @@ textarea{
 
 .textarea--border-red:focus,
 .input--border-red:focus{
-  box-shadow:inset 0 0 0 1px #741806;
+  box-shadow:inset 0 0 0 1px #B6290D;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--red:focus{
-  box-shadow:inset 0 0 0 1px #741806, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #B6290D, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-orange,
@@ -23458,11 +23458,11 @@ textarea{
 
 .textarea--border-orange:focus,
 .input--border-orange:focus{
-  box-shadow:inset 0 0 0 1px #773503;
+  box-shadow:inset 0 0 0 1px #AE4B04;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--orange:focus{
-  box-shadow:inset 0 0 0 1px #773503, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #AE4B04, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-yellow,
@@ -23473,11 +23473,11 @@ textarea{
 
 .textarea--border-yellow:focus,
 .input--border-yellow:focus{
-  box-shadow:inset 0 0 0 1px #625204;
+  box-shadow:inset 0 0 0 1px #8E740B;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--yellow:focus{
-  box-shadow:inset 0 0 0 1px #625204, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #8E740B, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-green,
@@ -23488,11 +23488,11 @@ textarea{
 
 .textarea--border-green:focus,
 .input--border-green:focus{
-  box-shadow:inset 0 0 0 1px #13582F;
+  box-shadow:inset 0 0 0 1px #1F7A43;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--green:focus{
-  box-shadow:inset 0 0 0 1px #13582F, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #1F7A43, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-blue,
@@ -23503,11 +23503,11 @@ textarea{
 
 .textarea--border-blue:focus,
 .input--border-blue:focus{
-  box-shadow:inset 0 0 0 1px #072E64;
+  box-shadow:inset 0 0 0 1px #0B428E;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--blue:focus{
-  box-shadow:inset 0 0 0 1px #072E64, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #0B428E, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-purple,
@@ -23518,11 +23518,11 @@ textarea{
 
 .textarea--border-purple:focus,
 .input--border-purple:focus{
-  box-shadow:inset 0 0 0 1px #512392;
+  box-shadow:inset 0 0 0 1px #6E2FC6;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--purple:focus{
-  box-shadow:inset 0 0 0 1px #512392, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #6E2FC6, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken25,
@@ -24517,7 +24517,7 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .color-text{
-  color:#1a2224 !important;
+  color:#4D5255 !important;
 }
 .bg-gray-dark{
   background-color:#1a2224 !important;
@@ -24781,7 +24781,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--gray:hover,
 .link--gray.is-active{
-  color:#1a2224;
+  color:#4D5255;
 }
 
 .link--pink{
@@ -24790,7 +24790,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--pink:hover,
 .link--pink.is-active{
-  color:#800C3C;
+  color:#BA1258;
 }
 
 .link--red{
@@ -24799,7 +24799,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--red:hover,
 .link--red.is-active{
-  color:#741806;
+  color:#B6290D;
 }
 
 .link--orange{
@@ -24808,7 +24808,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--orange:hover,
 .link--orange.is-active{
-  color:#773503;
+  color:#AE4B04;
 }
 
 .link--yellow{
@@ -24817,7 +24817,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--yellow:hover,
 .link--yellow.is-active{
-  color:#625204;
+  color:#8E740B;
 }
 
 .link--green{
@@ -24826,7 +24826,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--green:hover,
 .link--green.is-active{
-  color:#13582F;
+  color:#1F7A43;
 }
 
 .link--blue{
@@ -24835,7 +24835,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--blue:hover,
 .link--blue.is-active{
-  color:#072E64;
+  color:#0B428E;
 }
 
 .link--purple{
@@ -24844,7 +24844,7 @@ input:checked + .switch--dot-transparent::after{
 
 .link--purple:hover,
 .link--purple.is-active{
-  color:#512392;
+  color:#6E2FC6;
 }
 
 .link--darken25{

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -263,7 +263,7 @@ legend{
 .btn{
   display:inline-block;
   font-weight:bold;
-  background-color:#448ee4;
+  background-color:#3887BE;
   font-size:12px;
   color:#fff;
   border-radius:18px;
@@ -276,7 +276,7 @@ legend{
 .btn--stroke{
   background-color:transparent;
   box-shadow:inset 0 0 0 1px currentColor;
-  color:#448ee4;
+  color:#3887BE;
 }
 .btn--s{
   font-size:10px;
@@ -286,26 +286,26 @@ legend{
 }
 .btn:hover,
 .btn.is-active{
-  background-color:#346db0;
+  background-color:#223B53;
 }
 
 .btn--stroke:hover,
 .btn--stroke.is-active{
   background-color:transparent;
-  color:#346db0;
+  color:#223B53;
 }
 .btn:disabled{
   pointer-events:none;
-  color:rgba(64, 64, 64, 0.45);
-  background-color:rgba(127, 127, 127, 0.25);
+  color:rgba(158, 163, 167, 0.75);
+  background-color:rgba(158, 163, 167, 0.25);
   box-shadow:none;
 }
 
 .btn.btn--stroke:disabled{
   pointer-events:none;
   background-color:transparent;
-  box-shadow:inset 0 0 0 1px rgba(64, 64, 64, 0.45);
-  color:rgba(64, 64, 64, 0.45);
+  box-shadow:inset 0 0 0 1px rgba(158, 163, 167, 0.75);
+  color:rgba(158, 163, 167, 0.75);
 }
 .btn--pill-stroke{
   position:relative;
@@ -378,17 +378,17 @@ legend{
 }
 .link{
   cursor:pointer;
-  color:#448ee4;
+  color:#3887BE;
   transition:color 0.125s;
 }
 .link:hover,
 .link.is-active{
-  color:#346db0;
+  color:#223B53;
 }
 .link:disabled{
   pointer-events:none;
   cursor:default;
-  color:rgba(64, 64, 64, 0.45);
+  color:rgba(158, 163, 167, 0.75);
 }
 
 .fieldset,
@@ -407,7 +407,7 @@ legend{
 .input,
 .textarea,
 .select{
-  box-shadow:inset 0 0 0 1px #ccc;
+  box-shadow:inset 0 0 0 1px #C7CACC;
   padding:6px 12px;
   border-radius:4px;
   transition:background-color 0.125s,
@@ -418,16 +418,16 @@ legend{
 
 .input:focus,
 .textarea:focus{
-  box-shadow:inset 0 0 0 1px #666;
+  box-shadow:inset 0 0 0 1px #757D82;
 }
 
 [data-assembly-focus-control='visible'] .select.select--stroke:focus{
-  box-shadow:inset 0 0 0 1px #666, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #757D82, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .input::placeholder,
 .textarea::placeholder{
-  color:rgba(64, 64, 64, 0.45);
+  color:rgba(158, 163, 167, 0.75);
 }
 .input::-ms-clear,
 .input::-ms-reveal{
@@ -462,13 +462,13 @@ legend{
 .textarea:disabled,
 .select--stroke:disabled{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.5);
-  background-color:rgba(127, 127, 127, 0.1);
-  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25) !important;
+  color:rgba(26, 34, 36, 0.5);
+  background-color:rgba(158, 163, 167, 0.1);
+  box-shadow:inset 0 0 0 1px rgba(158, 163, 167, 0.25) !important;
 }
 .input[readonly],
 .textarea[readonly]{
-  background-color:rgba(127, 127, 127, 0.1);
+  background-color:rgba(158, 163, 167, 0.1);
 }
 .select-container{
   display:inline-flex;
@@ -495,7 +495,7 @@ legend{
   pointer-events:none;
   border-left:4px solid transparent;
   border-right:4px solid transparent;
-  border-top:5px solid #666;
+  border-top:5px solid #757D82;
   width:8px;
   height:8px;
   margin-top:-1px;
@@ -503,22 +503,22 @@ legend{
 }
 
 .select:hover{
-  color:#2d2d2d;
+  color:#1a2224;
 }
 
 .select:focus + .select-arrow{
-  border-top-color:#666;
+  border-top-color:#757D82;
 }
 .select option{
   background-color:#fff;
-  color:rgba(0, 0, 0, 0.75);
+  color:#1a2224;
 }
 
 .select option:disabled{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 .select::-ms-expand{ display:none; }
-.select option{ color:rgba(0, 0, 0, 0.75); }
+.select option{ color:#1a2224; }
 @media all and (-ms-high-contrast: active){
   .select:focus::-ms-value{
     background-color:transparent;
@@ -542,8 +542,8 @@ legend{
 }
 .select--stroke{
   padding:6px 30px 6px 12px;
-  box-shadow:inset 0 0 0 1px #ccc;
-  color:#666 !important;
+  box-shadow:inset 0 0 0 1px #C7CACC;
+  color:#757D82 !important;
 }
 
 .select--stroke .select--s{
@@ -551,11 +551,11 @@ legend{
 }
 .select:disabled{
   pointer-events:none;
-  color:rgba(64, 64, 64, 0.45);
+  color:rgba(158, 163, 167, 0.75);
 }
 
 .select:disabled + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.25);
+  border-top-color:rgba(26, 34, 36, 0.25);
 }
 .range{
   display:flex;
@@ -715,14 +715,14 @@ legend{
   height:12px;
   margin-top:0;
 }
-.range > input:disabled::-webkit-slider-runnable-track{ background:rgba(127, 127, 127, 0.25); }
-.range > input:disabled::-moz-range-track{ background:rgba(127, 127, 127, 0.25); }
-.range > input:disabled::-ms-fill-upper{ background:rgba(127, 127, 127, 0.25); }
-.range > input:disabled::-ms-fill-lower{ background:rgba(127, 127, 127, 0.25); }
+.range > input:disabled::-webkit-slider-runnable-track{ background:rgba(158, 163, 167, 0.25); }
+.range > input:disabled::-moz-range-track{ background:rgba(158, 163, 167, 0.25); }
+.range > input:disabled::-ms-fill-upper{ background:rgba(158, 163, 167, 0.25); }
+.range > input:disabled::-ms-fill-lower{ background:rgba(158, 163, 167, 0.25); }
 
-.range > input:disabled::-webkit-slider-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#F7F8F8; }
-.range > input:disabled::-ms-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#F7F8F8; }
-.range > input:disabled::-moz-range-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#F7F8F8; }
+.range > input:disabled::-webkit-slider-thumb{ border-color:rgba(158, 163, 167, 0.25); background:#F7F8F8; }
+.range > input:disabled::-ms-thumb{ border-color:rgba(158, 163, 167, 0.25); background:#F7F8F8; }
+.range > input:disabled::-moz-range-thumb{ border-color:rgba(158, 163, 167, 0.25); background:#F7F8F8; }
 .checkbox-container,
 .switch-container,
 .radio-container{
@@ -763,7 +763,7 @@ legend{
 }
 .checkbox{
   color:#fff;
-  border-color:#666;
+  border-color:#757D82;
   transition:color 0.125s,
     border 0.125s,
     background-color 0.125s;
@@ -782,7 +782,7 @@ legend{
 }
 .radio{
   border-radius:50%;
-  color:#666;
+  color:#757D82;
   border-color:currentColor;
 }
 
@@ -805,7 +805,7 @@ legend{
   border-width:1px;
   border-style:solid;
   border-color:currentColor;
-  color:#666;
+  color:#757D82;
   transition:color 0.125s,
     background-color 0.125s,
     border-color 0.125s;
@@ -848,7 +848,7 @@ legend{
 .toggle{
   flex-shrink:0;
   cursor:pointer;
-  color:#666;
+  color:#757D82;
   font-size:12px;
   padding:3px 18px;
   border-radius:15px;
@@ -878,28 +878,28 @@ input:checked:disabled + .checkbox,
 input:checked:disabled + .radio,
 input:checked:disabled + .switch{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 input:disabled + .switch{
-  border-color:rgba(127, 127, 127, 0.25);
+  border-color:rgba(158, 163, 167, 0.25);
 }
 
 input:disabled + .radio,
 input:disabled + .checkbox{
-  background-color:rgba(127, 127, 127, 0.25);
+  background-color:rgba(158, 163, 167, 0.25);
   border-color:transparent;
 }
 
 input:checked:disabled + .checkbox,
 input:checked:disabled + .radio,
 input:checked:disabled + .switch{
-  background-color:rgba(127, 127, 127, 0.25);
+  background-color:rgba(158, 163, 167, 0.25);
 }
 
 input:disabled + .switch::after,
 input:checked:disabled + .switch::after{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 input:checked + .checkbox > .icon,
 input:checked + .radio::before{
@@ -907,12 +907,12 @@ input:checked + .radio::before{
 }
 
 input:checked + .radio{
-  color:#666;
+  color:#757D82;
 }
 
 input:checked + .checkbox{
   border:1px solid transparent;
-  background-color:#666;
+  background-color:#757D82;
 }
 input:checked + .switch::after{
   left:50%;
@@ -921,27 +921,27 @@ input:checked + .switch::after{
 
 input:checked + .switch{
   border-color:transparent;
-  background-color:#666;
+  background-color:#757D82;
 }
 input:checked + .toggle{
-  background:#666;
+  background:#757D82;
   color:#fff;
 }
 input:disabled + .toggle{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
   border-color:transparent;
 }
 
 input:checked:disabled + .toggle{
-  background-color:rgba(127, 127, 127, 0.25);
-  color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(158, 163, 167, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 body,
 input,
 textarea{
-  color:rgba(0, 0, 0, 0.75);
+  color:#1a2224;
   font-size:16px;
   line-height:24px;
   font-family:'Open Sans', sans-serif;
@@ -951,11 +951,11 @@ textarea{
 .txt-kbd,
 .prose:not(.unprose) kbd{
   font-family:'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace;
-  border:1px solid rgba(0, 0, 0, 0.25);
+  border:1px solid rgba(26, 34, 36, 0.25);
   line-height:18px;
   border-radius:3px;
   padding:2px 3px;
-  box-shadow:0 1px 0 0 rgba(0, 0, 0, 0.1);
+  box-shadow:0 1px 0 0 rgba(26, 34, 36, 0.1);
   font-size:90%;
   font-weight:normal;
 }
@@ -978,7 +978,7 @@ textarea{
   white-space:pre-wrap;
   font-size:90%;
   line-height:1.5em;
-  background:rgba(0, 0, 0, 0.05);
+  background:rgba(26, 34, 36, 0.05);
   border-radius:3px;
 }
 
@@ -1076,7 +1076,7 @@ textarea{
   margin:17px 0;
   border:0;
   height:1px;
-  background:rgba(0, 0, 0, 0.1);
+  background:rgba(26, 34, 36, 0.1);
 }
 
 .txt-hr--dark,
@@ -1174,9 +1174,9 @@ textarea{
 .txt-spacing05{ letter-spacing:0.05em !important; }
 .txt-spacing1{ letter-spacing:0.1em !important; }
 .txt-spacing2{ letter-spacing:0.2em !important; }
-.txt-shadow-darken10{ text-shadow:1px 1px 1px rgba(0, 0, 0, 0.1); }
-.txt-shadow-darken25{ text-shadow:1px 1px 1px rgba(0, 0, 0, 0.25); }
-.txt-shadow-darken50{ text-shadow:1px 1px 1px rgba(0, 0, 0, 0.5); }
+.txt-shadow-darken10{ text-shadow:1px 1px 1px rgba(26, 34, 36, 0.1); }
+.txt-shadow-darken25{ text-shadow:1px 1px 1px rgba(26, 34, 36, 0.25); }
+.txt-shadow-darken50{ text-shadow:1px 1px 1px rgba(26, 34, 36, 0.5); }
 
 .txt-shadow-lighten10{ text-shadow:1px 1px 1px rgba(255, 255, 255, 0.1); }
 .txt-shadow-lighten25{ text-shadow:1px 1px 1px rgba(255, 255, 255, 0.25); }
@@ -1236,7 +1236,7 @@ textarea{
 }
 
 .prose a:not(.unprose){
-  color:#448ee4;
+  color:#3887BE;
   text-decoration:underline;
 }
 
@@ -1245,7 +1245,7 @@ textarea{
 }
 
 .prose a:not(.unprose):hover{
-  color:#346db0;
+  color:#223B53;
 }
 
 .prose--dark a:not(.unprose):hover{
@@ -9045,7 +9045,7 @@ textarea{
   height:36px;
   width:36px;
   border-radius:50%;
-  border:3px solid rgba(0, 0, 0, 0.25);
+  border:3px solid rgba(26, 34, 36, 0.25);
   border-top-color:currentColor;
   animation:assembly-loading 0.8s infinite cubic-bezier(0.45, 0.05, 0.55, 0.95);
 }
@@ -9192,7 +9192,7 @@ textarea{
 
 .btn--gray:hover,
 .btn--gray.is-active{
-  background-color:#2C3031;
+  background-color:#1a2224;
 }
 
 .btn--gray-light{
@@ -9331,34 +9331,34 @@ textarea{
 }
 
 .btn--darken10{
-  background-color:rgba(0, 0, 0, 0.1);
+  background-color:rgba(26, 34, 36, 0.1);
 }
 
 .btn--darken10:hover,
 .btn--darken10.is-active{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 .btn--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 .btn--darken25:hover,
 .btn--darken25.is-active{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 .btn--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 .btn--darken50:hover,
 .btn--darken50.is-active{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 .btn--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 .btn--darken75:hover,
@@ -9417,7 +9417,7 @@ textarea{
 
 .btn--transparent:hover,
 .btn--transparent.is-active{
-  background-color:rgba(0, 0, 0, 0.1);
+  background-color:rgba(26, 34, 36, 0.1);
 }
 
 .btn--stroke.btn--gray{
@@ -9426,7 +9426,7 @@ textarea{
 
 .btn--stroke.btn--gray:hover,
 .btn--stroke.btn--gray.is-active{
-  color:#2C3031;
+  color:#1a2224;
 }
 
 .btn--stroke.btn--pink{
@@ -9493,25 +9493,25 @@ textarea{
 }
 
 .btn--stroke.btn--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 .btn--stroke.btn--darken25:hover,
 .btn--stroke.btn--darken25.is-active{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .btn--stroke.btn--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .btn--stroke.btn--darken50:hover,
 .btn--stroke.btn--darken50.is-active{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .btn--stroke.btn--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .btn--stroke.btn--darken75:hover,
@@ -9561,7 +9561,7 @@ textarea{
 
 .btn--stroke.btn--transparent:hover,
 .btn--stroke.btn--transparent.is-active{
-  color:rgba(0, 0, 0, 0.1);
+  color:rgba(26, 34, 36, 0.1);
 }
 
 .btn.btn--stroke{
@@ -9573,11 +9573,11 @@ textarea{
 }
 
 .select--gray:focus{
-  color:#2C3031;
+  color:#1a2224;
 }
 
 .select--gray:hover{
-  color:#2C3031;
+  color:#1a2224;
 }
 
 .select--gray + .select-arrow{
@@ -9585,7 +9585,7 @@ textarea{
 }
 
 .select--gray:focus + .select-arrow{
-  border-top-color:#2C3031;
+  border-top-color:#1a2224;
 }
 
 .select--pink{
@@ -9729,47 +9729,47 @@ textarea{
 }
 
 .select--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 .select--darken25:focus{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken25:hover{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken25 + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.25);
+  border-top-color:rgba(26, 34, 36, 0.25);
 }
 
 .select--darken25:focus + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.5);
+  border-top-color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken50:focus{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken50:hover{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken50 + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.5);
+  border-top-color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken50:focus + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.75);
+  border-top-color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken75:focus{
@@ -9781,7 +9781,7 @@ textarea{
 }
 
 .select--darken75 + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.75);
+  border-top-color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken75:focus + .select-arrow{
@@ -9873,11 +9873,11 @@ textarea{
 }
 
 .select--transparent:focus{
-  color:rgba(0, 0, 0, 0.1);
+  color:rgba(26, 34, 36, 0.1);
 }
 
 .select--transparent:hover{
-  color:rgba(0, 0, 0, 0.1);
+  color:rgba(26, 34, 36, 0.1);
 }
 
 .select--transparent + .select-arrow{
@@ -9885,7 +9885,7 @@ textarea{
 }
 
 .select--transparent:focus + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.1);
+  border-top-color:rgba(26, 34, 36, 0.1);
 }
 
 .textarea--border-gray,
@@ -9896,11 +9896,11 @@ textarea{
 
 .textarea--border-gray:focus,
 .input--border-gray:focus{
-  box-shadow:inset 0 0 0 1px #2C3031;
+  box-shadow:inset 0 0 0 1px #1a2224;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--gray:focus{
-  box-shadow:inset 0 0 0 1px #2C3031, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #1a2224, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-pink,
@@ -10011,37 +10011,37 @@ textarea{
 .textarea--border-darken25,
 .input--border-darken25,
 .select--stroke.select--darken25{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.5);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--darken25:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken50,
 .input--border-darken50,
 .select--stroke.select--darken50{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.5);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.75);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--darken50:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken75,
 .input--border-darken75,
 .select--stroke.select--darken75{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.75);
 }
 
 .textarea--border-darken75:focus,
@@ -10121,11 +10121,11 @@ textarea{
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.1);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--transparent:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.1), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .checkbox--gray{
@@ -10193,27 +10193,27 @@ input:checked + .checkbox--purple{
 }
 
 .checkbox--darken25{
-  border-color:rgba(0, 0, 0, 0.25);
+  border-color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .checkbox--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 .checkbox--darken50{
-  border-color:rgba(0, 0, 0, 0.5);
+  border-color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .checkbox--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 .checkbox--darken75{
-  border-color:rgba(0, 0, 0, 0.75);
+  border-color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .checkbox--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 .checkbox--lighten25{
@@ -10298,17 +10298,17 @@ input:checked + .radio--purple{
 
 .radio--darken25,
 input:checked + .radio--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 .radio--darken50,
 input:checked + .radio--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .radio--darken75,
 input:checked + .radio--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .radio--lighten25,
@@ -10401,27 +10401,27 @@ input:checked + .toggle--purple{
 }
 
 .toggle--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .toggle--darken25{
-  background:rgba(0, 0, 0, 0.25);
+  background:rgba(26, 34, 36, 0.25);
 }
 
 .toggle--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .toggle--darken50{
-  background:rgba(0, 0, 0, 0.5);
+  background:rgba(26, 34, 36, 0.5);
 }
 
 .toggle--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .toggle--darken75{
-  background:rgba(0, 0, 0, 0.75);
+  background:rgba(26, 34, 36, 0.75);
 }
 
 .toggle--lighten25{
@@ -10497,15 +10497,15 @@ input:checked + .toggle--active-purple{
 }
 
 input:checked + .toggle--active-darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .toggle--active-darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .toggle--active-darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .toggle--active-lighten25{
@@ -10625,39 +10625,39 @@ input:checked + .switch--dot-purple::after{
 }
 
 .switch--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .switch--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .switch--dot-darken25::after{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 .switch--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .switch--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .switch--dot-darken50::after{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 .switch--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .switch--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .switch--dot-darken75::after{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 .switch--lighten25{
@@ -10720,7 +10720,7 @@ input:checked + .switch--dot-transparent::after{
   background-color:transparent;
 }
 .color-gray-dark{
-  color:#2C3031 !important;
+  color:#1a2224 !important;
 }
 
 .color-gray-deep{
@@ -10912,19 +10912,19 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .color-darken10{
-  color:rgba(0, 0, 0, 0.1) !important;
+  color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .color-darken25{
-  color:rgba(0, 0, 0, 0.25) !important;
+  color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .color-darken50{
-  color:rgba(0, 0, 0, 0.5) !important;
+  color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .color-darken75{
-  color:rgba(0, 0, 0, 0.75) !important;
+  color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .color-lighten10{
@@ -10955,11 +10955,23 @@ input:checked + .switch--dot-transparent::after{
   color:transparent !important;
 }
 
+.color-disabled10{
+  color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.color-disabled25{
+  color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.color-disabled75{
+  color:rgba(158, 163, 167, 0.75) !important;
+}
+
 .color-text{
-  color:rgba(0, 0, 0, 0.75) !important;
+  color:#1a2224 !important;
 }
 .bg-gray-dark{
-  background-color:#2C3031 !important;
+  background-color:#1a2224 !important;
 }
 
 .bg-gray-deep{
@@ -11151,23 +11163,23 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .bg-darken5{
-  background-color:rgba(0, 0, 0, 0.05) !important;
+  background-color:rgba(26, 34, 36, 0.05) !important;
 }
 
 .bg-darken10{
-  background-color:rgba(0, 0, 0, 0.1) !important;
+  background-color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .bg-darken25{
-  background-color:rgba(0, 0, 0, 0.25) !important;
+  background-color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .bg-darken50{
-  background-color:rgba(0, 0, 0, 0.5) !important;
+  background-color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .bg-darken75{
-  background-color:rgba(0, 0, 0, 0.75) !important;
+  background-color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .bg-lighten5{
@@ -11202,13 +11214,25 @@ input:checked + .switch--dot-transparent::after{
   background-color:transparent !important;
 }
 
+.bg-disabled10{
+  background-color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.bg-disabled25{
+  background-color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.bg-disabled75{
+  background-color:rgba(158, 163, 167, 0.75) !important;
+}
+
 .link--gray{
   color:#757D82;
 }
 
 .link--gray:hover,
 .link--gray.is-active{
-  color:#2C3031;
+  color:#1a2224;
 }
 
 .link--pink{
@@ -11275,25 +11299,25 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .link--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 .link--darken25:hover,
 .link--darken25.is-active{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .link--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .link--darken50:hover,
 .link--darken50.is-active{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .link--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .link--darken75:hover,
@@ -11343,10 +11367,10 @@ input:checked + .switch--dot-transparent::after{
 
 .link--transparent:hover,
 .link--transparent.is-active{
-  color:rgba(0, 0, 0, 0.1);
+  color:rgba(26, 34, 36, 0.1);
 }
 .border--gray-dark{
-  border-color:#2C3031 !important;
+  border-color:#1a2224 !important;
 }
 
 .border--gray-deep{
@@ -11538,19 +11562,19 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .border--darken10{
-  border-color:rgba(0, 0, 0, 0.1) !important;
+  border-color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .border--darken25{
-  border-color:rgba(0, 0, 0, 0.25) !important;
+  border-color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .border--darken50{
-  border-color:rgba(0, 0, 0, 0.5) !important;
+  border-color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .border--darken75{
-  border-color:rgba(0, 0, 0, 0.75) !important;
+  border-color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .border--lighten10{
@@ -11580,20 +11604,32 @@ input:checked + .switch--dot-transparent::after{
 .border--transparent{
   border-color:transparent !important;
 }
+
+.border--disabled10{
+  border-color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.border--disabled25{
+  border-color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.border--disabled75{
+  border-color:rgba(158, 163, 167, 0.75) !important;
+}
 .shadow-darken10{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.1) !important;
 }
 
 .shadow-darken25{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.25) !important;
 }
 
 .shadow-darken50{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.5) !important;
 }
 
 .shadow-darken75{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.75) !important;
 }
 
 .shadow-lighten10{
@@ -11611,20 +11647,32 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75{
   box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.75) !important;
 }
+
+.shadow-disabled10{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.1) !important;
+}
+
+.shadow-disabled25{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.25) !important;
+}
+
+.shadow-disabled75{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.75) !important;
+}
 .shadow-darken10-bold{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.1) !important;
 }
 
 .shadow-darken25-bold{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.25) !important;
 }
 
 .shadow-darken50-bold{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.5) !important;
 }
 
 .shadow-darken75-bold{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.75) !important;
 }
 
 .shadow-lighten10-bold{
@@ -11642,48 +11690,60 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75-bold{
   box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
 }
+
+.shadow-disabled10-bold{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.1) !important;
+}
+
+.shadow-disabled25-bold{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.25) !important;
+}
+
+.shadow-disabled75-bold{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.75) !important;
+}
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
 .shadow-darken10-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.1) !important;
 }
 .shadow-darken10-bold-on-hover:hover,
 .shadow-darken10-bold-on-active.is-active,
 .shadow-darken10-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.1) !important;
 }
 
 .shadow-darken25-on-hover:hover,
 .shadow-darken25-on-active.is-active,
 .shadow-darken25-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.25) !important;
 }
 .shadow-darken25-bold-on-hover:hover,
 .shadow-darken25-bold-on-active.is-active,
 .shadow-darken25-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.25) !important;
 }
 
 .shadow-darken50-on-hover:hover,
 .shadow-darken50-on-active.is-active,
 .shadow-darken50-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.5) !important;
 }
 .shadow-darken50-bold-on-hover:hover,
 .shadow-darken50-bold-on-active.is-active,
 .shadow-darken50-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.5) !important;
 }
 
 .shadow-darken75-on-hover:hover,
 .shadow-darken75-on-active.is-active,
 .shadow-darken75-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.75) !important;
 }
 .shadow-darken75-bold-on-hover:hover,
 .shadow-darken75-bold-on-active.is-active,
 .shadow-darken75-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.75) !important;
 }
 
 .shadow-lighten10-on-hover:hover,
@@ -11729,10 +11789,43 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75-bold-on-active.is-active:hover{
   box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
 }
+
+.shadow-disabled10-on-hover:hover,
+.shadow-disabled10-on-active.is-active,
+.shadow-disabled10-on-active.is-active:hover{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.1) !important;
+}
+.shadow-disabled10-bold-on-hover:hover,
+.shadow-disabled10-bold-on-active.is-active,
+.shadow-disabled10-bold-on-active.is-active:hover{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.1) !important;
+}
+
+.shadow-disabled25-on-hover:hover,
+.shadow-disabled25-on-active.is-active,
+.shadow-disabled25-on-active.is-active:hover{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.25) !important;
+}
+.shadow-disabled25-bold-on-hover:hover,
+.shadow-disabled25-bold-on-active.is-active,
+.shadow-disabled25-bold-on-active.is-active:hover{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.25) !important;
+}
+
+.shadow-disabled75-on-hover:hover,
+.shadow-disabled75-on-active.is-active,
+.shadow-disabled75-on-active.is-active:hover{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.75) !important;
+}
+.shadow-disabled75-bold-on-hover:hover,
+.shadow-disabled75-bold-on-active.is-active,
+.shadow-disabled75-bold-on-active.is-active:hover{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.75) !important;
+}
 .bg-gray-dark-on-hover:hover,
 .bg-gray-dark-on-active.is-active,
 .bg-gray-dark-on-active.is-active:hover{
-  background-color:#2C3031 !important;
+  background-color:#1a2224 !important;
 }
 
 .bg-gray-deep-on-hover:hover,
@@ -12020,31 +12113,31 @@ input:checked + .switch--dot-transparent::after{
 .bg-darken5-on-hover:hover,
 .bg-darken5-on-active.is-active,
 .bg-darken5-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.05) !important;
+  background-color:rgba(26, 34, 36, 0.05) !important;
 }
 
 .bg-darken10-on-hover:hover,
 .bg-darken10-on-active.is-active,
 .bg-darken10-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.1) !important;
+  background-color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .bg-darken25-on-hover:hover,
 .bg-darken25-on-active.is-active,
 .bg-darken25-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.25) !important;
+  background-color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .bg-darken50-on-hover:hover,
 .bg-darken50-on-active.is-active,
 .bg-darken50-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.5) !important;
+  background-color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .bg-darken75-on-hover:hover,
 .bg-darken75-on-active.is-active,
 .bg-darken75-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.75) !important;
+  background-color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .bg-lighten5-on-hover:hover,
@@ -12094,10 +12187,28 @@ input:checked + .switch--dot-transparent::after{
 .bg-transparent-on-active.is-active:hover{
   background-color:transparent !important;
 }
+
+.bg-disabled10-on-hover:hover,
+.bg-disabled10-on-active.is-active,
+.bg-disabled10-on-active.is-active:hover{
+  background-color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.bg-disabled25-on-hover:hover,
+.bg-disabled25-on-active.is-active,
+.bg-disabled25-on-active.is-active:hover{
+  background-color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.bg-disabled75-on-hover:hover,
+.bg-disabled75-on-active.is-active,
+.bg-disabled75-on-active.is-active:hover{
+  background-color:rgba(158, 163, 167, 0.75) !important;
+}
 .color-gray-dark-on-hover:hover,
 .color-gray-dark-on-active.is-active,
 .color-gray-dark-on-active.is-active:hover{
-  color:#2C3031 !important;
+  color:#1a2224 !important;
 }
 
 .color-gray-deep-on-hover:hover,
@@ -12385,25 +12496,25 @@ input:checked + .switch--dot-transparent::after{
 .color-darken10-on-hover:hover,
 .color-darken10-on-active.is-active,
 .color-darken10-on-active.is-active:hover{
-  color:rgba(0, 0, 0, 0.1) !important;
+  color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .color-darken25-on-hover:hover,
 .color-darken25-on-active.is-active,
 .color-darken25-on-active.is-active:hover{
-  color:rgba(0, 0, 0, 0.25) !important;
+  color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .color-darken50-on-hover:hover,
 .color-darken50-on-active.is-active,
 .color-darken50-on-active.is-active:hover{
-  color:rgba(0, 0, 0, 0.5) !important;
+  color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .color-darken75-on-hover:hover,
 .color-darken75-on-active.is-active,
 .color-darken75-on-active.is-active:hover{
-  color:rgba(0, 0, 0, 0.75) !important;
+  color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .color-lighten10-on-hover:hover,
@@ -12447,10 +12558,28 @@ input:checked + .switch--dot-transparent::after{
 .color-transparent-on-active.is-active:hover{
   color:transparent !important;
 }
+
+.color-disabled10-on-hover:hover,
+.color-disabled10-on-active.is-active,
+.color-disabled10-on-active.is-active:hover{
+  color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.color-disabled25-on-hover:hover,
+.color-disabled25-on-active.is-active,
+.color-disabled25-on-active.is-active:hover{
+  color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.color-disabled75-on-hover:hover,
+.color-disabled75-on-active.is-active,
+.color-disabled75-on-active.is-active:hover{
+  color:rgba(158, 163, 167, 0.75) !important;
+}
 .border--gray-dark-on-hover:hover,
 .border--gray-dark-on-active.is-active,
 .border--gray-dark-on-active.is-active:hover{
-  border-color:#2C3031 !important;
+  border-color:#1a2224 !important;
 }
 
 .border--gray-deep-on-hover:hover,
@@ -12738,25 +12867,25 @@ input:checked + .switch--dot-transparent::after{
 .border--darken10-on-hover:hover,
 .border--darken10-on-active.is-active,
 .border--darken10-on-active.is-active:hover{
-  border-color:rgba(0, 0, 0, 0.1) !important;
+  border-color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .border--darken25-on-hover:hover,
 .border--darken25-on-active.is-active,
 .border--darken25-on-active.is-active:hover{
-  border-color:rgba(0, 0, 0, 0.25) !important;
+  border-color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .border--darken50-on-hover:hover,
 .border--darken50-on-active.is-active,
 .border--darken50-on-active.is-active:hover{
-  border-color:rgba(0, 0, 0, 0.5) !important;
+  border-color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .border--darken75-on-hover:hover,
 .border--darken75-on-active.is-active,
 .border--darken75-on-active.is-active:hover{
-  border-color:rgba(0, 0, 0, 0.75) !important;
+  border-color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .border--lighten10-on-hover:hover,
@@ -12799,6 +12928,24 @@ input:checked + .switch--dot-transparent::after{
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover{
   border-color:transparent !important;
+}
+
+.border--disabled10-on-hover:hover,
+.border--disabled10-on-active.is-active,
+.border--disabled10-on-active.is-active:hover{
+  border-color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.border--disabled25-on-hover:hover,
+.border--disabled25-on-active.is-active,
+.border--disabled25-on-active.is-active:hover{
+  border-color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.border--disabled75-on-hover:hover,
+.border--disabled75-on-active.is-active,
+.border--disabled75-on-active.is-active:hover{
+  border-color:rgba(158, 163, 167, 0.75) !important;
 }
 
 @media screen and (min-width: 640px){
@@ -13647,7 +13794,7 @@ legend{
 .btn{
   display:inline-block;
   font-weight:bold;
-  background-color:#448ee4;
+  background-color:#0F71FA;
   font-size:12px;
   color:#fff;
   border-radius:18px;
@@ -13660,7 +13807,7 @@ legend{
 .btn--stroke{
   background-color:transparent;
   box-shadow:inset 0 0 0 1px currentColor;
-  color:#448ee4;
+  color:#0F71FA;
 }
 .btn--s{
   font-size:10px;
@@ -13670,26 +13817,26 @@ legend{
 }
 .btn:hover,
 .btn.is-active{
-  background-color:#346db0;
+  background-color:#072E64;
 }
 
 .btn--stroke:hover,
 .btn--stroke.is-active{
   background-color:transparent;
-  color:#346db0;
+  color:#072E64;
 }
 .btn:disabled{
   pointer-events:none;
-  color:rgba(64, 64, 64, 0.45);
-  background-color:rgba(127, 127, 127, 0.25);
+  color:rgba(158, 163, 167, 0.75);
+  background-color:rgba(158, 163, 167, 0.25);
   box-shadow:none;
 }
 
 .btn.btn--stroke:disabled{
   pointer-events:none;
   background-color:transparent;
-  box-shadow:inset 0 0 0 1px rgba(64, 64, 64, 0.45);
-  color:rgba(64, 64, 64, 0.45);
+  box-shadow:inset 0 0 0 1px rgba(158, 163, 167, 0.75);
+  color:rgba(158, 163, 167, 0.75);
 }
 .btn--pill-stroke{
   position:relative;
@@ -13762,17 +13909,17 @@ legend{
 }
 .link{
   cursor:pointer;
-  color:#448ee4;
+  color:#0F71FA;
   transition:color 0.125s;
 }
 .link:hover,
 .link.is-active{
-  color:#346db0;
+  color:#072E64;
 }
 .link:disabled{
   pointer-events:none;
   cursor:default;
-  color:rgba(64, 64, 64, 0.45);
+  color:rgba(158, 163, 167, 0.75);
 }
 
 .fieldset,
@@ -13791,7 +13938,7 @@ legend{
 .input,
 .textarea,
 .select{
-  box-shadow:inset 0 0 0 1px #ccc;
+  box-shadow:inset 0 0 0 1px #C7CACC;
   padding:6px 12px;
   border-radius:4px;
   transition:background-color 0.125s,
@@ -13802,16 +13949,16 @@ legend{
 
 .input:focus,
 .textarea:focus{
-  box-shadow:inset 0 0 0 1px #666;
+  box-shadow:inset 0 0 0 1px #757D82;
 }
 
 [data-assembly-focus-control='visible'] .select.select--stroke:focus{
-  box-shadow:inset 0 0 0 1px #666, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #757D82, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .input::placeholder,
 .textarea::placeholder{
-  color:rgba(64, 64, 64, 0.45);
+  color:rgba(158, 163, 167, 0.75);
 }
 .input::-ms-clear,
 .input::-ms-reveal{
@@ -13846,13 +13993,13 @@ legend{
 .textarea:disabled,
 .select--stroke:disabled{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.5);
-  background-color:rgba(127, 127, 127, 0.1);
-  box-shadow:inset 0 0 0 1px rgba(127, 127, 127, 0.25) !important;
+  color:rgba(26, 34, 36, 0.5);
+  background-color:rgba(158, 163, 167, 0.1);
+  box-shadow:inset 0 0 0 1px rgba(158, 163, 167, 0.25) !important;
 }
 .input[readonly],
 .textarea[readonly]{
-  background-color:rgba(127, 127, 127, 0.1);
+  background-color:rgba(158, 163, 167, 0.1);
 }
 .select-container{
   display:inline-flex;
@@ -13879,7 +14026,7 @@ legend{
   pointer-events:none;
   border-left:4px solid transparent;
   border-right:4px solid transparent;
-  border-top:5px solid #666;
+  border-top:5px solid #757D82;
   width:8px;
   height:8px;
   margin-top:-1px;
@@ -13887,22 +14034,22 @@ legend{
 }
 
 .select:hover{
-  color:#2d2d2d;
+  color:#1a2224;
 }
 
 .select:focus + .select-arrow{
-  border-top-color:#666;
+  border-top-color:#757D82;
 }
 .select option{
   background-color:#fff;
-  color:rgba(0, 0, 0, 0.75);
+  color:#1a2224;
 }
 
 .select option:disabled{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 .select::-ms-expand{ display:none; }
-.select option{ color:rgba(0, 0, 0, 0.75); }
+.select option{ color:#1a2224; }
 @media all and (-ms-high-contrast: active){
   .select:focus::-ms-value{
     background-color:transparent;
@@ -13926,8 +14073,8 @@ legend{
 }
 .select--stroke{
   padding:6px 30px 6px 12px;
-  box-shadow:inset 0 0 0 1px #ccc;
-  color:#666 !important;
+  box-shadow:inset 0 0 0 1px #C7CACC;
+  color:#757D82 !important;
 }
 
 .select--stroke .select--s{
@@ -13935,11 +14082,11 @@ legend{
 }
 .select:disabled{
   pointer-events:none;
-  color:rgba(64, 64, 64, 0.45);
+  color:rgba(158, 163, 167, 0.75);
 }
 
 .select:disabled + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.25);
+  border-top-color:rgba(26, 34, 36, 0.25);
 }
 .range{
   display:flex;
@@ -14099,14 +14246,14 @@ legend{
   height:12px;
   margin-top:0;
 }
-.range > input:disabled::-webkit-slider-runnable-track{ background:rgba(127, 127, 127, 0.25); }
-.range > input:disabled::-moz-range-track{ background:rgba(127, 127, 127, 0.25); }
-.range > input:disabled::-ms-fill-upper{ background:rgba(127, 127, 127, 0.25); }
-.range > input:disabled::-ms-fill-lower{ background:rgba(127, 127, 127, 0.25); }
+.range > input:disabled::-webkit-slider-runnable-track{ background:rgba(158, 163, 167, 0.25); }
+.range > input:disabled::-moz-range-track{ background:rgba(158, 163, 167, 0.25); }
+.range > input:disabled::-ms-fill-upper{ background:rgba(158, 163, 167, 0.25); }
+.range > input:disabled::-ms-fill-lower{ background:rgba(158, 163, 167, 0.25); }
 
-.range > input:disabled::-webkit-slider-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#F7F8F8; }
-.range > input:disabled::-ms-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#F7F8F8; }
-.range > input:disabled::-moz-range-thumb{ border-color:rgba(127, 127, 127, 0.25); background:#F7F8F8; }
+.range > input:disabled::-webkit-slider-thumb{ border-color:rgba(158, 163, 167, 0.25); background:#F7F8F8; }
+.range > input:disabled::-ms-thumb{ border-color:rgba(158, 163, 167, 0.25); background:#F7F8F8; }
+.range > input:disabled::-moz-range-thumb{ border-color:rgba(158, 163, 167, 0.25); background:#F7F8F8; }
 .checkbox-container,
 .switch-container,
 .radio-container{
@@ -14147,7 +14294,7 @@ legend{
 }
 .checkbox{
   color:#fff;
-  border-color:#666;
+  border-color:#757D82;
   transition:color 0.125s,
     border 0.125s,
     background-color 0.125s;
@@ -14166,7 +14313,7 @@ legend{
 }
 .radio{
   border-radius:50%;
-  color:#666;
+  color:#757D82;
   border-color:currentColor;
 }
 
@@ -14189,7 +14336,7 @@ legend{
   border-width:1px;
   border-style:solid;
   border-color:currentColor;
-  color:#666;
+  color:#757D82;
   transition:color 0.125s,
     background-color 0.125s,
     border-color 0.125s;
@@ -14232,7 +14379,7 @@ legend{
 .toggle{
   flex-shrink:0;
   cursor:pointer;
-  color:#666;
+  color:#757D82;
   font-size:12px;
   padding:3px 18px;
   border-radius:15px;
@@ -14262,28 +14409,28 @@ input:checked:disabled + .checkbox,
 input:checked:disabled + .radio,
 input:checked:disabled + .switch{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 input:disabled + .switch{
-  border-color:rgba(127, 127, 127, 0.25);
+  border-color:rgba(158, 163, 167, 0.25);
 }
 
 input:disabled + .radio,
 input:disabled + .checkbox{
-  background-color:rgba(127, 127, 127, 0.25);
+  background-color:rgba(158, 163, 167, 0.25);
   border-color:transparent;
 }
 
 input:checked:disabled + .checkbox,
 input:checked:disabled + .radio,
 input:checked:disabled + .switch{
-  background-color:rgba(127, 127, 127, 0.25);
+  background-color:rgba(158, 163, 167, 0.25);
 }
 
 input:disabled + .switch::after,
 input:checked:disabled + .switch::after{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 input:checked + .checkbox > .icon,
 input:checked + .radio::before{
@@ -14291,12 +14438,12 @@ input:checked + .radio::before{
 }
 
 input:checked + .radio{
-  color:#666;
+  color:#757D82;
 }
 
 input:checked + .checkbox{
   border:1px solid transparent;
-  background-color:#666;
+  background-color:#757D82;
 }
 input:checked + .switch::after{
   left:50%;
@@ -14305,27 +14452,27 @@ input:checked + .switch::after{
 
 input:checked + .switch{
   border-color:transparent;
-  background-color:#666;
+  background-color:#757D82;
 }
 input:checked + .toggle{
-  background:#666;
+  background:#757D82;
   color:#fff;
 }
 input:disabled + .toggle{
   pointer-events:none;
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
   border-color:transparent;
 }
 
 input:checked:disabled + .toggle{
-  background-color:rgba(127, 127, 127, 0.25);
-  color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(158, 163, 167, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 body,
 input,
 textarea{
-  color:rgba(0, 0, 0, 0.75);
+  color:#1a2224;
   font-size:16px;
   line-height:24px;
   font-family:'Open Sans', sans-serif;
@@ -14335,11 +14482,11 @@ textarea{
 .txt-kbd,
 .prose:not(.unprose) kbd{
   font-family:'Menlo', 'Bitstream Vera Sans Mono', 'Monaco', 'Consolas', monospace;
-  border:1px solid rgba(0, 0, 0, 0.25);
+  border:1px solid rgba(26, 34, 36, 0.25);
   line-height:18px;
   border-radius:3px;
   padding:2px 3px;
-  box-shadow:0 1px 0 0 rgba(0, 0, 0, 0.1);
+  box-shadow:0 1px 0 0 rgba(26, 34, 36, 0.1);
   font-size:90%;
   font-weight:normal;
 }
@@ -14362,7 +14509,7 @@ textarea{
   white-space:pre-wrap;
   font-size:90%;
   line-height:1.5em;
-  background:rgba(0, 0, 0, 0.05);
+  background:rgba(26, 34, 36, 0.05);
   border-radius:3px;
 }
 
@@ -14460,7 +14607,7 @@ textarea{
   margin:17px 0;
   border:0;
   height:1px;
-  background:rgba(0, 0, 0, 0.1);
+  background:rgba(26, 34, 36, 0.1);
 }
 
 .txt-hr--dark,
@@ -14558,9 +14705,9 @@ textarea{
 .txt-spacing05{ letter-spacing:0.05em !important; }
 .txt-spacing1{ letter-spacing:0.1em !important; }
 .txt-spacing2{ letter-spacing:0.2em !important; }
-.txt-shadow-darken10{ text-shadow:1px 1px 1px rgba(0, 0, 0, 0.1); }
-.txt-shadow-darken25{ text-shadow:1px 1px 1px rgba(0, 0, 0, 0.25); }
-.txt-shadow-darken50{ text-shadow:1px 1px 1px rgba(0, 0, 0, 0.5); }
+.txt-shadow-darken10{ text-shadow:1px 1px 1px rgba(26, 34, 36, 0.1); }
+.txt-shadow-darken25{ text-shadow:1px 1px 1px rgba(26, 34, 36, 0.25); }
+.txt-shadow-darken50{ text-shadow:1px 1px 1px rgba(26, 34, 36, 0.5); }
 
 .txt-shadow-lighten10{ text-shadow:1px 1px 1px rgba(255, 255, 255, 0.1); }
 .txt-shadow-lighten25{ text-shadow:1px 1px 1px rgba(255, 255, 255, 0.25); }
@@ -14620,7 +14767,7 @@ textarea{
 }
 
 .prose a:not(.unprose){
-  color:#448ee4;
+  color:#0F71FA;
   text-decoration:underline;
 }
 
@@ -14629,7 +14776,7 @@ textarea{
 }
 
 .prose a:not(.unprose):hover{
-  color:#346db0;
+  color:#072E64;
 }
 
 .prose--dark a:not(.unprose):hover{
@@ -22429,7 +22576,7 @@ textarea{
   height:36px;
   width:36px;
   border-radius:50%;
-  border:3px solid rgba(0, 0, 0, 0.25);
+  border:3px solid rgba(26, 34, 36, 0.25);
   border-top-color:currentColor;
   animation:assembly-loading 0.8s infinite cubic-bezier(0.45, 0.05, 0.55, 0.95);
 }
@@ -22562,7 +22709,7 @@ textarea{
 
 .btn--gray:hover,
 .btn--gray.is-active{
-  background-color:#2C3031;
+  background-color:#1a2224;
 }
 
 .btn--gray-light{
@@ -22701,34 +22848,34 @@ textarea{
 }
 
 .btn--darken10{
-  background-color:rgba(0, 0, 0, 0.1);
+  background-color:rgba(26, 34, 36, 0.1);
 }
 
 .btn--darken10:hover,
 .btn--darken10.is-active{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 .btn--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 .btn--darken25:hover,
 .btn--darken25.is-active{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 .btn--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 .btn--darken50:hover,
 .btn--darken50.is-active{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 .btn--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 .btn--darken75:hover,
@@ -22787,7 +22934,7 @@ textarea{
 
 .btn--transparent:hover,
 .btn--transparent.is-active{
-  background-color:rgba(0, 0, 0, 0.1);
+  background-color:rgba(26, 34, 36, 0.1);
 }
 
 .btn--stroke.btn--gray{
@@ -22796,7 +22943,7 @@ textarea{
 
 .btn--stroke.btn--gray:hover,
 .btn--stroke.btn--gray.is-active{
-  color:#2C3031;
+  color:#1a2224;
 }
 
 .btn--stroke.btn--pink{
@@ -22863,25 +23010,25 @@ textarea{
 }
 
 .btn--stroke.btn--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 .btn--stroke.btn--darken25:hover,
 .btn--stroke.btn--darken25.is-active{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .btn--stroke.btn--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .btn--stroke.btn--darken50:hover,
 .btn--stroke.btn--darken50.is-active{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .btn--stroke.btn--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .btn--stroke.btn--darken75:hover,
@@ -22931,7 +23078,7 @@ textarea{
 
 .btn--stroke.btn--transparent:hover,
 .btn--stroke.btn--transparent.is-active{
-  color:rgba(0, 0, 0, 0.1);
+  color:rgba(26, 34, 36, 0.1);
 }
 
 .btn.btn--stroke{
@@ -22943,11 +23090,11 @@ textarea{
 }
 
 .select--gray:focus{
-  color:#2C3031;
+  color:#1a2224;
 }
 
 .select--gray:hover{
-  color:#2C3031;
+  color:#1a2224;
 }
 
 .select--gray + .select-arrow{
@@ -22955,7 +23102,7 @@ textarea{
 }
 
 .select--gray:focus + .select-arrow{
-  border-top-color:#2C3031;
+  border-top-color:#1a2224;
 }
 
 .select--pink{
@@ -23099,47 +23246,47 @@ textarea{
 }
 
 .select--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 .select--darken25:focus{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken25:hover{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken25 + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.25);
+  border-top-color:rgba(26, 34, 36, 0.25);
 }
 
 .select--darken25:focus + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.5);
+  border-top-color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken50:focus{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken50:hover{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken50 + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.5);
+  border-top-color:rgba(26, 34, 36, 0.5);
 }
 
 .select--darken50:focus + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.75);
+  border-top-color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken75:focus{
@@ -23151,7 +23298,7 @@ textarea{
 }
 
 .select--darken75 + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.75);
+  border-top-color:rgba(26, 34, 36, 0.75);
 }
 
 .select--darken75:focus + .select-arrow{
@@ -23243,11 +23390,11 @@ textarea{
 }
 
 .select--transparent:focus{
-  color:rgba(0, 0, 0, 0.1);
+  color:rgba(26, 34, 36, 0.1);
 }
 
 .select--transparent:hover{
-  color:rgba(0, 0, 0, 0.1);
+  color:rgba(26, 34, 36, 0.1);
 }
 
 .select--transparent + .select-arrow{
@@ -23255,7 +23402,7 @@ textarea{
 }
 
 .select--transparent:focus + .select-arrow{
-  border-top-color:rgba(0, 0, 0, 0.1);
+  border-top-color:rgba(26, 34, 36, 0.1);
 }
 
 .textarea--border-gray,
@@ -23266,11 +23413,11 @@ textarea{
 
 .textarea--border-gray:focus,
 .input--border-gray:focus{
-  box-shadow:inset 0 0 0 1px #2C3031;
+  box-shadow:inset 0 0 0 1px #1a2224;
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--gray:focus{
-  box-shadow:inset 0 0 0 1px #2C3031, 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px #1a2224, 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-pink,
@@ -23381,37 +23528,37 @@ textarea{
 .textarea--border-darken25,
 .input--border-darken25,
 .select--stroke.select--darken25{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.25);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.25);
 }
 
 .textarea--border-darken25:focus,
 .input--border-darken25:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.5);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--darken25:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.5), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken50,
 .input--border-darken50,
 .select--stroke.select--darken50{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.5);
 }
 
 .textarea--border-darken50:focus,
 .input--border-darken50:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.75);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--darken50:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.75), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .textarea--border-darken75,
 .input--border-darken75,
 .select--stroke.select--darken75{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.75);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.75);
 }
 
 .textarea--border-darken75:focus,
@@ -23491,11 +23638,11 @@ textarea{
 
 .textarea--border-transparent:focus,
 .input--border-transparent:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.1);
 }
 
 [data-assembly-focus-control='visible'] .select--stroke.select--transparent:focus{
-  box-shadow:inset 0 0 0 1px rgba(0, 0, 0, 0.1), 0 0 0 3px rgba(137, 199, 216, 0.65);
+  box-shadow:inset 0 0 0 1px rgba(26, 34, 36, 0.1), 0 0 0 3px rgba(137, 199, 216, 0.65);
 }
 
 .checkbox--gray{
@@ -23563,27 +23710,27 @@ input:checked + .checkbox--purple{
 }
 
 .checkbox--darken25{
-  border-color:rgba(0, 0, 0, 0.25);
+  border-color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .checkbox--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 .checkbox--darken50{
-  border-color:rgba(0, 0, 0, 0.5);
+  border-color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .checkbox--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 .checkbox--darken75{
-  border-color:rgba(0, 0, 0, 0.75);
+  border-color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .checkbox--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 .checkbox--lighten25{
@@ -23668,17 +23815,17 @@ input:checked + .radio--purple{
 
 .radio--darken25,
 input:checked + .radio--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 .radio--darken50,
 input:checked + .radio--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .radio--darken75,
 input:checked + .radio--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .radio--lighten25,
@@ -23771,27 +23918,27 @@ input:checked + .toggle--purple{
 }
 
 .toggle--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .toggle--darken25{
-  background:rgba(0, 0, 0, 0.25);
+  background:rgba(26, 34, 36, 0.25);
 }
 
 .toggle--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .toggle--darken50{
-  background:rgba(0, 0, 0, 0.5);
+  background:rgba(26, 34, 36, 0.5);
 }
 
 .toggle--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .toggle--darken75{
-  background:rgba(0, 0, 0, 0.75);
+  background:rgba(26, 34, 36, 0.75);
 }
 
 .toggle--lighten25{
@@ -23867,15 +24014,15 @@ input:checked + .toggle--active-purple{
 }
 
 input:checked + .toggle--active-darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .toggle--active-darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .toggle--active-darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .toggle--active-lighten25{
@@ -23995,39 +24142,39 @@ input:checked + .switch--dot-purple::after{
 }
 
 .switch--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .switch--darken25{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 input:checked + .switch--dot-darken25::after{
-  background-color:rgba(0, 0, 0, 0.25);
+  background-color:rgba(26, 34, 36, 0.25);
 }
 
 .switch--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .switch--darken50{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 input:checked + .switch--dot-darken50::after{
-  background-color:rgba(0, 0, 0, 0.5);
+  background-color:rgba(26, 34, 36, 0.5);
 }
 
 .switch--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .switch--darken75{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 input:checked + .switch--dot-darken75::after{
-  background-color:rgba(0, 0, 0, 0.75);
+  background-color:rgba(26, 34, 36, 0.75);
 }
 
 .switch--lighten25{
@@ -24106,11 +24253,11 @@ input:checked + .switch--dot-transparent::after{
 
 .range--purple > input{ color:#9669D5; }
 
-.range--darken25 > input{ color:rgba(0, 0, 0, 0.25); }
+.range--darken25 > input{ color:rgba(26, 34, 36, 0.25); }
 
-.range--darken50 > input{ color:rgba(0, 0, 0, 0.5); }
+.range--darken50 > input{ color:rgba(26, 34, 36, 0.5); }
 
-.range--darken75 > input{ color:rgba(0, 0, 0, 0.75); }
+.range--darken75 > input{ color:rgba(26, 34, 36, 0.75); }
 
 .range--lighten25 > input{ color:rgba(255, 255, 255, 0.25); }
 
@@ -24122,7 +24269,7 @@ input:checked + .switch--dot-transparent::after{
 
 .range--transparent > input{ color:transparent; }
 .color-gray-dark{
-  color:#2C3031 !important;
+  color:#1a2224 !important;
 }
 
 .color-gray-deep{
@@ -24314,19 +24461,19 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .color-darken10{
-  color:rgba(0, 0, 0, 0.1) !important;
+  color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .color-darken25{
-  color:rgba(0, 0, 0, 0.25) !important;
+  color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .color-darken50{
-  color:rgba(0, 0, 0, 0.5) !important;
+  color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .color-darken75{
-  color:rgba(0, 0, 0, 0.75) !important;
+  color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .color-lighten10{
@@ -24357,11 +24504,23 @@ input:checked + .switch--dot-transparent::after{
   color:transparent !important;
 }
 
+.color-disabled10{
+  color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.color-disabled25{
+  color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.color-disabled75{
+  color:rgba(158, 163, 167, 0.75) !important;
+}
+
 .color-text{
-  color:rgba(0, 0, 0, 0.75) !important;
+  color:#1a2224 !important;
 }
 .bg-gray-dark{
-  background-color:#2C3031 !important;
+  background-color:#1a2224 !important;
 }
 
 .bg-gray-deep{
@@ -24553,23 +24712,23 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .bg-darken5{
-  background-color:rgba(0, 0, 0, 0.05) !important;
+  background-color:rgba(26, 34, 36, 0.05) !important;
 }
 
 .bg-darken10{
-  background-color:rgba(0, 0, 0, 0.1) !important;
+  background-color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .bg-darken25{
-  background-color:rgba(0, 0, 0, 0.25) !important;
+  background-color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .bg-darken50{
-  background-color:rgba(0, 0, 0, 0.5) !important;
+  background-color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .bg-darken75{
-  background-color:rgba(0, 0, 0, 0.75) !important;
+  background-color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .bg-lighten5{
@@ -24604,13 +24763,25 @@ input:checked + .switch--dot-transparent::after{
   background-color:transparent !important;
 }
 
+.bg-disabled10{
+  background-color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.bg-disabled25{
+  background-color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.bg-disabled75{
+  background-color:rgba(158, 163, 167, 0.75) !important;
+}
+
 .link--gray{
   color:#757D82;
 }
 
 .link--gray:hover,
 .link--gray.is-active{
-  color:#2C3031;
+  color:#1a2224;
 }
 
 .link--pink{
@@ -24677,25 +24848,25 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .link--darken25{
-  color:rgba(0, 0, 0, 0.25);
+  color:rgba(26, 34, 36, 0.25);
 }
 
 .link--darken25:hover,
 .link--darken25.is-active{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .link--darken50{
-  color:rgba(0, 0, 0, 0.5);
+  color:rgba(26, 34, 36, 0.5);
 }
 
 .link--darken50:hover,
 .link--darken50.is-active{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .link--darken75{
-  color:rgba(0, 0, 0, 0.75);
+  color:rgba(26, 34, 36, 0.75);
 }
 
 .link--darken75:hover,
@@ -24745,10 +24916,10 @@ input:checked + .switch--dot-transparent::after{
 
 .link--transparent:hover,
 .link--transparent.is-active{
-  color:rgba(0, 0, 0, 0.1);
+  color:rgba(26, 34, 36, 0.1);
 }
 .border--gray-dark{
-  border-color:#2C3031 !important;
+  border-color:#1a2224 !important;
 }
 
 .border--gray-deep{
@@ -24940,19 +25111,19 @@ input:checked + .switch--dot-transparent::after{
 }
 
 .border--darken10{
-  border-color:rgba(0, 0, 0, 0.1) !important;
+  border-color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .border--darken25{
-  border-color:rgba(0, 0, 0, 0.25) !important;
+  border-color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .border--darken50{
-  border-color:rgba(0, 0, 0, 0.5) !important;
+  border-color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .border--darken75{
-  border-color:rgba(0, 0, 0, 0.75) !important;
+  border-color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .border--lighten10{
@@ -24982,20 +25153,32 @@ input:checked + .switch--dot-transparent::after{
 .border--transparent{
   border-color:transparent !important;
 }
+
+.border--disabled10{
+  border-color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.border--disabled25{
+  border-color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.border--disabled75{
+  border-color:rgba(158, 163, 167, 0.75) !important;
+}
 .shadow-darken10{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.1) !important;
 }
 
 .shadow-darken25{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.25) !important;
 }
 
 .shadow-darken50{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.5) !important;
 }
 
 .shadow-darken75{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.75) !important;
 }
 
 .shadow-lighten10{
@@ -25013,20 +25196,32 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75{
   box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.75) !important;
 }
+
+.shadow-disabled10{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.1) !important;
+}
+
+.shadow-disabled25{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.25) !important;
+}
+
+.shadow-disabled75{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.75) !important;
+}
 .shadow-darken10-bold{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.1) !important;
 }
 
 .shadow-darken25-bold{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.25) !important;
 }
 
 .shadow-darken50-bold{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.5) !important;
 }
 
 .shadow-darken75-bold{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.75) !important;
 }
 
 .shadow-lighten10-bold{
@@ -25044,48 +25239,60 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75-bold{
   box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
 }
+
+.shadow-disabled10-bold{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.1) !important;
+}
+
+.shadow-disabled25-bold{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.25) !important;
+}
+
+.shadow-disabled75-bold{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.75) !important;
+}
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
 .shadow-darken10-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.1) !important;
 }
 .shadow-darken10-bold-on-hover:hover,
 .shadow-darken10-bold-on-active.is-active,
 .shadow-darken10-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.1) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.1) !important;
 }
 
 .shadow-darken25-on-hover:hover,
 .shadow-darken25-on-active.is-active,
 .shadow-darken25-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.25) !important;
 }
 .shadow-darken25-bold-on-hover:hover,
 .shadow-darken25-bold-on-active.is-active,
 .shadow-darken25-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.25) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.25) !important;
 }
 
 .shadow-darken50-on-hover:hover,
 .shadow-darken50-on-active.is-active,
 .shadow-darken50-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.5) !important;
 }
 .shadow-darken50-bold-on-hover:hover,
 .shadow-darken50-bold-on-active.is-active,
 .shadow-darken50-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.5) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.5) !important;
 }
 
 .shadow-darken75-on-hover:hover,
 .shadow-darken75-on-active.is-active,
 .shadow-darken75-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.75) !important;
 }
 .shadow-darken75-bold-on-hover:hover,
 .shadow-darken75-bold-on-active.is-active,
 .shadow-darken75-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(0, 0, 0, 0.75) !important;
+  box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.75) !important;
 }
 
 .shadow-lighten10-on-hover:hover,
@@ -25131,10 +25338,43 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75-bold-on-active.is-active:hover{
   box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
 }
+
+.shadow-disabled10-on-hover:hover,
+.shadow-disabled10-on-active.is-active,
+.shadow-disabled10-on-active.is-active:hover{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.1) !important;
+}
+.shadow-disabled10-bold-on-hover:hover,
+.shadow-disabled10-bold-on-active.is-active,
+.shadow-disabled10-bold-on-active.is-active:hover{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.1) !important;
+}
+
+.shadow-disabled25-on-hover:hover,
+.shadow-disabled25-on-active.is-active,
+.shadow-disabled25-on-active.is-active:hover{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.25) !important;
+}
+.shadow-disabled25-bold-on-hover:hover,
+.shadow-disabled25-bold-on-active.is-active,
+.shadow-disabled25-bold-on-active.is-active:hover{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.25) !important;
+}
+
+.shadow-disabled75-on-hover:hover,
+.shadow-disabled75-on-active.is-active,
+.shadow-disabled75-on-active.is-active:hover{
+  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.75) !important;
+}
+.shadow-disabled75-bold-on-hover:hover,
+.shadow-disabled75-bold-on-active.is-active,
+.shadow-disabled75-bold-on-active.is-active:hover{
+  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.75) !important;
+}
 .bg-gray-dark-on-hover:hover,
 .bg-gray-dark-on-active.is-active,
 .bg-gray-dark-on-active.is-active:hover{
-  background-color:#2C3031 !important;
+  background-color:#1a2224 !important;
 }
 
 .bg-gray-deep-on-hover:hover,
@@ -25422,31 +25662,31 @@ input:checked + .switch--dot-transparent::after{
 .bg-darken5-on-hover:hover,
 .bg-darken5-on-active.is-active,
 .bg-darken5-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.05) !important;
+  background-color:rgba(26, 34, 36, 0.05) !important;
 }
 
 .bg-darken10-on-hover:hover,
 .bg-darken10-on-active.is-active,
 .bg-darken10-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.1) !important;
+  background-color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .bg-darken25-on-hover:hover,
 .bg-darken25-on-active.is-active,
 .bg-darken25-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.25) !important;
+  background-color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .bg-darken50-on-hover:hover,
 .bg-darken50-on-active.is-active,
 .bg-darken50-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.5) !important;
+  background-color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .bg-darken75-on-hover:hover,
 .bg-darken75-on-active.is-active,
 .bg-darken75-on-active.is-active:hover{
-  background-color:rgba(0, 0, 0, 0.75) !important;
+  background-color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .bg-lighten5-on-hover:hover,
@@ -25496,10 +25736,28 @@ input:checked + .switch--dot-transparent::after{
 .bg-transparent-on-active.is-active:hover{
   background-color:transparent !important;
 }
+
+.bg-disabled10-on-hover:hover,
+.bg-disabled10-on-active.is-active,
+.bg-disabled10-on-active.is-active:hover{
+  background-color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.bg-disabled25-on-hover:hover,
+.bg-disabled25-on-active.is-active,
+.bg-disabled25-on-active.is-active:hover{
+  background-color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.bg-disabled75-on-hover:hover,
+.bg-disabled75-on-active.is-active,
+.bg-disabled75-on-active.is-active:hover{
+  background-color:rgba(158, 163, 167, 0.75) !important;
+}
 .color-gray-dark-on-hover:hover,
 .color-gray-dark-on-active.is-active,
 .color-gray-dark-on-active.is-active:hover{
-  color:#2C3031 !important;
+  color:#1a2224 !important;
 }
 
 .color-gray-deep-on-hover:hover,
@@ -25787,25 +26045,25 @@ input:checked + .switch--dot-transparent::after{
 .color-darken10-on-hover:hover,
 .color-darken10-on-active.is-active,
 .color-darken10-on-active.is-active:hover{
-  color:rgba(0, 0, 0, 0.1) !important;
+  color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .color-darken25-on-hover:hover,
 .color-darken25-on-active.is-active,
 .color-darken25-on-active.is-active:hover{
-  color:rgba(0, 0, 0, 0.25) !important;
+  color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .color-darken50-on-hover:hover,
 .color-darken50-on-active.is-active,
 .color-darken50-on-active.is-active:hover{
-  color:rgba(0, 0, 0, 0.5) !important;
+  color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .color-darken75-on-hover:hover,
 .color-darken75-on-active.is-active,
 .color-darken75-on-active.is-active:hover{
-  color:rgba(0, 0, 0, 0.75) !important;
+  color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .color-lighten10-on-hover:hover,
@@ -25849,10 +26107,28 @@ input:checked + .switch--dot-transparent::after{
 .color-transparent-on-active.is-active:hover{
   color:transparent !important;
 }
+
+.color-disabled10-on-hover:hover,
+.color-disabled10-on-active.is-active,
+.color-disabled10-on-active.is-active:hover{
+  color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.color-disabled25-on-hover:hover,
+.color-disabled25-on-active.is-active,
+.color-disabled25-on-active.is-active:hover{
+  color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.color-disabled75-on-hover:hover,
+.color-disabled75-on-active.is-active,
+.color-disabled75-on-active.is-active:hover{
+  color:rgba(158, 163, 167, 0.75) !important;
+}
 .border--gray-dark-on-hover:hover,
 .border--gray-dark-on-active.is-active,
 .border--gray-dark-on-active.is-active:hover{
-  border-color:#2C3031 !important;
+  border-color:#1a2224 !important;
 }
 
 .border--gray-deep-on-hover:hover,
@@ -26140,25 +26416,25 @@ input:checked + .switch--dot-transparent::after{
 .border--darken10-on-hover:hover,
 .border--darken10-on-active.is-active,
 .border--darken10-on-active.is-active:hover{
-  border-color:rgba(0, 0, 0, 0.1) !important;
+  border-color:rgba(26, 34, 36, 0.1) !important;
 }
 
 .border--darken25-on-hover:hover,
 .border--darken25-on-active.is-active,
 .border--darken25-on-active.is-active:hover{
-  border-color:rgba(0, 0, 0, 0.25) !important;
+  border-color:rgba(26, 34, 36, 0.25) !important;
 }
 
 .border--darken50-on-hover:hover,
 .border--darken50-on-active.is-active,
 .border--darken50-on-active.is-active:hover{
-  border-color:rgba(0, 0, 0, 0.5) !important;
+  border-color:rgba(26, 34, 36, 0.5) !important;
 }
 
 .border--darken75-on-hover:hover,
 .border--darken75-on-active.is-active,
 .border--darken75-on-active.is-active:hover{
-  border-color:rgba(0, 0, 0, 0.75) !important;
+  border-color:rgba(26, 34, 36, 0.75) !important;
 }
 
 .border--lighten10-on-hover:hover,
@@ -26201,6 +26477,24 @@ input:checked + .switch--dot-transparent::after{
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover{
   border-color:transparent !important;
+}
+
+.border--disabled10-on-hover:hover,
+.border--disabled10-on-active.is-active,
+.border--disabled10-on-active.is-active:hover{
+  border-color:rgba(158, 163, 167, 0.1) !important;
+}
+
+.border--disabled25-on-hover:hover,
+.border--disabled25-on-active.is-active,
+.border--disabled25-on-active.is-active:hover{
+  border-color:rgba(158, 163, 167, 0.25) !important;
+}
+
+.border--disabled75-on-hover:hover,
+.border--disabled75-on-active.is-active,
+.border--disabled75-on-active.is-active:hover{
+  border-color:rgba(158, 163, 167, 0.75) !important;
 }
 
 @media screen and (min-width: 640px){

--- a/test/__snapshots__/build-css.jest.js.snap
+++ b/test/__snapshots__/build-css.jest.js.snap
@@ -10955,18 +10955,6 @@ input:checked + .switch--dot-transparent::after{
   color:transparent !important;
 }
 
-.color-disabled10{
-  color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.color-disabled25{
-  color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.color-disabled75{
-  color:rgba(158, 163, 167, 0.75) !important;
-}
-
 .color-text{
   color:#4D5255 !important;
 }
@@ -11212,18 +11200,6 @@ input:checked + .switch--dot-transparent::after{
 
 .bg-transparent{
   background-color:transparent !important;
-}
-
-.bg-disabled10{
-  background-color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.bg-disabled25{
-  background-color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.bg-disabled75{
-  background-color:rgba(158, 163, 167, 0.75) !important;
 }
 
 .link--gray{
@@ -11604,18 +11580,6 @@ input:checked + .switch--dot-transparent::after{
 .border--transparent{
   border-color:transparent !important;
 }
-
-.border--disabled10{
-  border-color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.border--disabled25{
-  border-color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.border--disabled75{
-  border-color:rgba(158, 163, 167, 0.75) !important;
-}
 .shadow-darken10{
   box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.1) !important;
 }
@@ -11647,18 +11611,6 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75{
   box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.75) !important;
 }
-
-.shadow-disabled10{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.1) !important;
-}
-
-.shadow-disabled25{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.25) !important;
-}
-
-.shadow-disabled75{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.75) !important;
-}
 .shadow-darken10-bold{
   box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.1) !important;
 }
@@ -11689,18 +11641,6 @@ input:checked + .switch--dot-transparent::after{
 
 .shadow-lighten75-bold{
   box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
-}
-
-.shadow-disabled10-bold{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.1) !important;
-}
-
-.shadow-disabled25-bold{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.25) !important;
-}
-
-.shadow-disabled75-bold{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.75) !important;
 }
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
@@ -11788,39 +11728,6 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover{
   box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
-}
-
-.shadow-disabled10-on-hover:hover,
-.shadow-disabled10-on-active.is-active,
-.shadow-disabled10-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.1) !important;
-}
-.shadow-disabled10-bold-on-hover:hover,
-.shadow-disabled10-bold-on-active.is-active,
-.shadow-disabled10-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.1) !important;
-}
-
-.shadow-disabled25-on-hover:hover,
-.shadow-disabled25-on-active.is-active,
-.shadow-disabled25-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.25) !important;
-}
-.shadow-disabled25-bold-on-hover:hover,
-.shadow-disabled25-bold-on-active.is-active,
-.shadow-disabled25-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.25) !important;
-}
-
-.shadow-disabled75-on-hover:hover,
-.shadow-disabled75-on-active.is-active,
-.shadow-disabled75-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.75) !important;
-}
-.shadow-disabled75-bold-on-hover:hover,
-.shadow-disabled75-bold-on-active.is-active,
-.shadow-disabled75-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.75) !important;
 }
 .bg-gray-dark-on-hover:hover,
 .bg-gray-dark-on-active.is-active,
@@ -12187,24 +12094,6 @@ input:checked + .switch--dot-transparent::after{
 .bg-transparent-on-active.is-active:hover{
   background-color:transparent !important;
 }
-
-.bg-disabled10-on-hover:hover,
-.bg-disabled10-on-active.is-active,
-.bg-disabled10-on-active.is-active:hover{
-  background-color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.bg-disabled25-on-hover:hover,
-.bg-disabled25-on-active.is-active,
-.bg-disabled25-on-active.is-active:hover{
-  background-color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.bg-disabled75-on-hover:hover,
-.bg-disabled75-on-active.is-active,
-.bg-disabled75-on-active.is-active:hover{
-  background-color:rgba(158, 163, 167, 0.75) !important;
-}
 .color-gray-dark-on-hover:hover,
 .color-gray-dark-on-active.is-active,
 .color-gray-dark-on-active.is-active:hover{
@@ -12558,24 +12447,6 @@ input:checked + .switch--dot-transparent::after{
 .color-transparent-on-active.is-active:hover{
   color:transparent !important;
 }
-
-.color-disabled10-on-hover:hover,
-.color-disabled10-on-active.is-active,
-.color-disabled10-on-active.is-active:hover{
-  color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.color-disabled25-on-hover:hover,
-.color-disabled25-on-active.is-active,
-.color-disabled25-on-active.is-active:hover{
-  color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.color-disabled75-on-hover:hover,
-.color-disabled75-on-active.is-active,
-.color-disabled75-on-active.is-active:hover{
-  color:rgba(158, 163, 167, 0.75) !important;
-}
 .border--gray-dark-on-hover:hover,
 .border--gray-dark-on-active.is-active,
 .border--gray-dark-on-active.is-active:hover{
@@ -12928,24 +12799,6 @@ input:checked + .switch--dot-transparent::after{
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover{
   border-color:transparent !important;
-}
-
-.border--disabled10-on-hover:hover,
-.border--disabled10-on-active.is-active,
-.border--disabled10-on-active.is-active:hover{
-  border-color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.border--disabled25-on-hover:hover,
-.border--disabled25-on-active.is-active,
-.border--disabled25-on-active.is-active:hover{
-  border-color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.border--disabled75-on-hover:hover,
-.border--disabled75-on-active.is-active,
-.border--disabled75-on-active.is-active:hover{
-  border-color:rgba(158, 163, 167, 0.75) !important;
 }
 
 @media screen and (min-width: 640px){
@@ -24504,18 +24357,6 @@ input:checked + .switch--dot-transparent::after{
   color:transparent !important;
 }
 
-.color-disabled10{
-  color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.color-disabled25{
-  color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.color-disabled75{
-  color:rgba(158, 163, 167, 0.75) !important;
-}
-
 .color-text{
   color:#4D5255 !important;
 }
@@ -24761,18 +24602,6 @@ input:checked + .switch--dot-transparent::after{
 
 .bg-transparent{
   background-color:transparent !important;
-}
-
-.bg-disabled10{
-  background-color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.bg-disabled25{
-  background-color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.bg-disabled75{
-  background-color:rgba(158, 163, 167, 0.75) !important;
 }
 
 .link--gray{
@@ -25153,18 +24982,6 @@ input:checked + .switch--dot-transparent::after{
 .border--transparent{
   border-color:transparent !important;
 }
-
-.border--disabled10{
-  border-color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.border--disabled25{
-  border-color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.border--disabled75{
-  border-color:rgba(158, 163, 167, 0.75) !important;
-}
 .shadow-darken10{
   box-shadow:0 2px 10px 0 rgba(26, 34, 36, 0.1) !important;
 }
@@ -25196,18 +25013,6 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75{
   box-shadow:0 2px 10px 0 rgba(255, 255, 255, 0.75) !important;
 }
-
-.shadow-disabled10{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.1) !important;
-}
-
-.shadow-disabled25{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.25) !important;
-}
-
-.shadow-disabled75{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.75) !important;
-}
 .shadow-darken10-bold{
   box-shadow:0 6px 30px 0 rgba(26, 34, 36, 0.1) !important;
 }
@@ -25238,18 +25043,6 @@ input:checked + .switch--dot-transparent::after{
 
 .shadow-lighten75-bold{
   box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
-}
-
-.shadow-disabled10-bold{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.1) !important;
-}
-
-.shadow-disabled25-bold{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.25) !important;
-}
-
-.shadow-disabled75-bold{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.75) !important;
 }
 .shadow-darken10-on-hover:hover,
 .shadow-darken10-on-active.is-active,
@@ -25337,39 +25130,6 @@ input:checked + .switch--dot-transparent::after{
 .shadow-lighten75-bold-on-active.is-active,
 .shadow-lighten75-bold-on-active.is-active:hover{
   box-shadow:0 6px 30px 0 rgba(255, 255, 255, 0.75) !important;
-}
-
-.shadow-disabled10-on-hover:hover,
-.shadow-disabled10-on-active.is-active,
-.shadow-disabled10-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.1) !important;
-}
-.shadow-disabled10-bold-on-hover:hover,
-.shadow-disabled10-bold-on-active.is-active,
-.shadow-disabled10-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.1) !important;
-}
-
-.shadow-disabled25-on-hover:hover,
-.shadow-disabled25-on-active.is-active,
-.shadow-disabled25-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.25) !important;
-}
-.shadow-disabled25-bold-on-hover:hover,
-.shadow-disabled25-bold-on-active.is-active,
-.shadow-disabled25-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.25) !important;
-}
-
-.shadow-disabled75-on-hover:hover,
-.shadow-disabled75-on-active.is-active,
-.shadow-disabled75-on-active.is-active:hover{
-  box-shadow:0 2px 10px 0 rgba(158, 163, 167, 0.75) !important;
-}
-.shadow-disabled75-bold-on-hover:hover,
-.shadow-disabled75-bold-on-active.is-active,
-.shadow-disabled75-bold-on-active.is-active:hover{
-  box-shadow:0 6px 30px 0 rgba(158, 163, 167, 0.75) !important;
 }
 .bg-gray-dark-on-hover:hover,
 .bg-gray-dark-on-active.is-active,
@@ -25736,24 +25496,6 @@ input:checked + .switch--dot-transparent::after{
 .bg-transparent-on-active.is-active:hover{
   background-color:transparent !important;
 }
-
-.bg-disabled10-on-hover:hover,
-.bg-disabled10-on-active.is-active,
-.bg-disabled10-on-active.is-active:hover{
-  background-color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.bg-disabled25-on-hover:hover,
-.bg-disabled25-on-active.is-active,
-.bg-disabled25-on-active.is-active:hover{
-  background-color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.bg-disabled75-on-hover:hover,
-.bg-disabled75-on-active.is-active,
-.bg-disabled75-on-active.is-active:hover{
-  background-color:rgba(158, 163, 167, 0.75) !important;
-}
 .color-gray-dark-on-hover:hover,
 .color-gray-dark-on-active.is-active,
 .color-gray-dark-on-active.is-active:hover{
@@ -26107,24 +25849,6 @@ input:checked + .switch--dot-transparent::after{
 .color-transparent-on-active.is-active:hover{
   color:transparent !important;
 }
-
-.color-disabled10-on-hover:hover,
-.color-disabled10-on-active.is-active,
-.color-disabled10-on-active.is-active:hover{
-  color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.color-disabled25-on-hover:hover,
-.color-disabled25-on-active.is-active,
-.color-disabled25-on-active.is-active:hover{
-  color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.color-disabled75-on-hover:hover,
-.color-disabled75-on-active.is-active,
-.color-disabled75-on-active.is-active:hover{
-  color:rgba(158, 163, 167, 0.75) !important;
-}
 .border--gray-dark-on-hover:hover,
 .border--gray-dark-on-active.is-active,
 .border--gray-dark-on-active.is-active:hover{
@@ -26477,24 +26201,6 @@ input:checked + .switch--dot-transparent::after{
 .border--transparent-on-active.is-active,
 .border--transparent-on-active.is-active:hover{
   border-color:transparent !important;
-}
-
-.border--disabled10-on-hover:hover,
-.border--disabled10-on-active.is-active,
-.border--disabled10-on-active.is-active:hover{
-  border-color:rgba(158, 163, 167, 0.1) !important;
-}
-
-.border--disabled25-on-hover:hover,
-.border--disabled25-on-active.is-active,
-.border--disabled25-on-active.is-active:hover{
-  border-color:rgba(158, 163, 167, 0.25) !important;
-}
-
-.border--disabled75-on-hover:hover,
-.border--disabled75-on-active.is-active,
-.border--disabled75-on-active.is-active:hover{
-  border-color:rgba(158, 163, 167, 0.75) !important;
 }
 
 @media screen and (min-width: 640px){


### PR DESCRIPTION
This PR fixes an upstream issue in Mapbox's build of Assembly but should also generally simplify Assembly for everyone. Not a breaking change but does result in subtle visual differences (generally I'd consider it an improvement - nicer disabled and semitransparent colors). Remove all colors specific to forms, buttons, links, use only generic colors. Add new disabled color variants.

@tristen for review