### PR TITLE
update engines to include npm >=6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@mapbox/assembly",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "autoprefixer": "^10.2.5",
@@ -72,7 +72,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": "^6.0.0"
+        "npm": ">=6"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": "^6.0.0"
+    "npm": ">=6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`@mapbox/assembly` causes `Unsupported Engine` warning when running npm on many of our docs sites, which are all now working on node 18/npm 9.  The package works as expected in node 18/npm 9, so this will silence the warning.