### PR TITLE
Fix artifacts build

### DIFF
--- a/.artifacts.yml
+++ b/.artifacts.yml
@@ -4,6 +4,6 @@ publisher:
   - filter: on-branch
     name: publisher-branches
     config:
-      node_version: 14.x
+      node_version: 18.x
       site_build_dir: _site
       npm_build_script: build


### PR DESCRIPTION
Looks like publisher here is failing because of incompatible lockfile because we updated `nvmrc` but didn't update node in artifacts. This PR fixes that.