### PR TITLE
Add MD4 shim for Webpack4 on Node18+

### DIFF
--- a/batfish.config.js
+++ b/batfish.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('./src/md4-shim');
+
 const path = require('path');
 // eslint-disable-next-line
 const navigationStructure = require('./_tmp_assembly/navigation.json');

--- a/src/md4-shim.js
+++ b/src/md4-shim.js
@@ -1,0 +1,22 @@
+const crypto = require('crypto')
+// MD4 algorithm is not available anymore in NodeJS 17+ (because of lib SSL 3).
+// https://stackoverflow.com/a/72219174/1447466
+// config.output.hashFunction = 'md5'
+// is supposed to disables MD4, but it doesn't work correctly until
+// https://github.com/webpack/webpack/pull/14306
+try {
+    crypto.createHash('md4')
+} catch (e) {
+    let printed = false
+    const print = alg => {
+        if (alg != 'md4') return
+        if (printed) return
+        printed = true
+        console.warn('MD4 is unsupported, replacing it with MD5')
+    }
+    const createHash = crypto.createHash
+    crypto.createHash = (alg, ...params) => {
+        print(alg)
+        return createHash(alg == 'md4' ? 'md5' : alg, ...params)
+    }
+}


### PR DESCRIPTION
Build now fails because Webpack4 doesn't work on Node18+ since it uses obsolete MD4 to build filenames. We can workaround that without upgrading it if we silently replace it with MD5, which is functionally the same.